### PR TITLE
Minor performance improvement - use String concatenation instead of S…

### DIFF
--- a/src/main/java/javaslang/collection/Tree.java
+++ b/src/main/java/javaslang/collection/Tree.java
@@ -219,7 +219,7 @@ public interface Tree<T> extends Functor<T>, Iterable<T> {
                         final String children = tree.getChildren()
                                 .map(Local.this::toString)
                                 .join(" ");
-                        return String.format("(%s %s)", value, children);
+                        return "(" + value + " " + children + ")";
                     }
                 }
             }
@@ -247,7 +247,7 @@ public interface Tree<T> extends Functor<T>, Iterable<T> {
                         final String children = tree.getChildren()
                                 .map(child -> toString(child, depth + 1))
                                 .join();
-                        return String.format("\n%s%s%s", indent, value, children);
+                        return "\n" + indent + value + children;
                     }
                 }
             }

--- a/src/main/java/javaslang/control/Either.java
+++ b/src/main/java/javaslang/control/Either.java
@@ -384,7 +384,7 @@ public interface Either<L, R> {
 
         @Override
         public String toString() {
-            return String.format("LeftProjection(%s)", either);
+            return "LeftProjection("+either+")";
         }
 
         private L asLeft() {
@@ -665,7 +665,7 @@ public interface Either<L, R> {
 
         @Override
         public String toString() {
-            return String.format("RightProjection(%s)", either);
+            return "RightProjection("+either+")";
         }
 
         private L asLeft() {

--- a/src/main/java/javaslang/control/Failure.java
+++ b/src/main/java/javaslang/control/Failure.java
@@ -168,7 +168,7 @@ public final class Failure<T> implements Try<T>, Serializable {
 
     @Override
     public String toString() {
-        return String.format("Failure(%s)", cause.getCause());
+        return "Failure("+cause.getCause()+")";
     }
 
     /**

--- a/src/main/java/javaslang/control/Left.java
+++ b/src/main/java/javaslang/control/Left.java
@@ -80,6 +80,6 @@ public final class Left<L, R> implements Either<L, R>, Serializable {
 
     @Override
     public String toString() {
-        return String.format("Left(%s)", value);
+        return "Left("+value+")";
     }
 }

--- a/src/main/java/javaslang/control/Right.java
+++ b/src/main/java/javaslang/control/Right.java
@@ -80,6 +80,6 @@ public final class Right<L, R> implements Either<L, R>, Serializable {
 
     @Override
     public String toString() {
-        return String.format("Right(%s)", value);
+        return "Right("+value+")";
     }
 }

--- a/src/main/java/javaslang/control/Some.java
+++ b/src/main/java/javaslang/control/Some.java
@@ -79,6 +79,6 @@ public final class Some<T> implements Option<T>, Serializable {
 
     @Override
     public String toString() {
-        return String.format("Some(%s)", value);
+        return "Some("+value+")";
     }
 }

--- a/src/main/java/javaslang/control/Success.java
+++ b/src/main/java/javaslang/control/Success.java
@@ -164,6 +164,6 @@ public final class Success<T> implements Try<T>, Serializable {
 
     @Override
     public String toString() {
-        return String.format("Success(%s)", value);
+        return "Success("+value+")";
     }
 }

--- a/src/main/java/javaslang/test/Errors.java
+++ b/src/main/java/javaslang/test/Errors.java
@@ -43,6 +43,6 @@ interface Errors {
      * @return a new Error instance.
      */
     static Error predicateError(Throwable cause) {
-        return new Error(String.format("Applying predicate: %s", cause.getMessage()), cause);
+        return new Error("Applying predicate: " + cause.getMessage(), cause);
     }
 }


### PR DESCRIPTION
…tring#format()

The improvement is used only when the concatenation representation is still readable. All usages of String#format() used in exception's message, or with formatting or with multiple placeholders are preserved.