### PR TITLE
Revert "Removed algebra package to get flatMap() right and uncluttere…

### DIFF
--- a/generator/Generator.scala
+++ b/generator/Generator.scala
@@ -33,6 +33,8 @@ def generateMainClasses(): Unit = {
 
   genMatch()
   genFunctions()
+  genFunctor()
+  genMonad()
   genPropertyChecks()
   genTuples()
 
@@ -405,6 +407,164 @@ def generateMainClasses(): Unit = {
         }
       """
     })
+
+  /**
+   * Generator of javaslang.algebra.Functor*
+   */
+  def genFunctor(): Unit = {
+
+    genJavaslangFile("javaslang.algebra", "CheckedFunctor")(genFunctor("CheckedFunctor", checked = true))
+    genJavaslangFile("javaslang.algebra", "Functor")(genFunctor("Functor", checked = false))
+
+    def genFunctor(name: String, checked: Boolean)(im: ImportManager, packageName: String, className: String): String = {
+
+      val functionType = if (checked) im.getType("javaslang.control.Try.CheckedFunction") else im.getType("java.util.function.Function")
+
+      xs"""
+        /$javadoc
+         * <p>Defines a $className by generalizing the map.</p>
+         *
+         * All instances of the $className interface should obey the two functor laws:
+         * <ul>
+         *     <li>{@code m.map(a -> a) ≡ m}</li>
+         *     <li>{@code m.map(f.compose(g)) ≡ m.map(g).map(f)}</li>
+         * </ul>
+         * where "f, g ∈ $functionType".
+         *
+         * @param <T> component type of this functor
+         * @see <a href="http://www.haskellforall.com/2012/09/the-functor-design-pattern.html">The functor design pattern</a>
+         * @since 1.1.0
+         */
+        public interface $className<T> {
+
+            /**
+             * Applies a function f to the components of this $name.
+             *
+             * @param <U> type of the component of the resulting $name
+             * @param mapper a ${checked.gen("Checked")}Function which maps the component of this $name
+             * @return a new $className
+             * @throws NullPointerException if {@code f} is null
+             */
+            <U> $className<U> map($functionType<? super T, ? extends U> mapper);
+        }
+      """
+    }
+  }
+
+  /**
+   * Generator of javaslang.algebra.Monad*
+   */
+  def genMonad(): Unit = {
+
+    genJavaslangFile("javaslang.algebra", s"CheckedMonad")(genMonad("CheckedMonad", checked = true))
+    genJavaslangFile("javaslang.algebra", s"Monad")(genMonad("Monad", checked = false))
+
+    def genMonad(name: String, checked: Boolean)(im: ImportManager, packageName: String, className: String): String = {
+
+      val functionType = if (checked) im.getType("javaslang.control.Try.CheckedFunction") else im.getType("java.util.function.Function")
+      val consumerType = if (checked) im.getType("javaslang.control.Try.CheckedConsumer") else im.getType("java.util.function.Consumer")
+      val predicateType = if (checked) im.getType("javaslang.control.Try.CheckedPredicate") else im.getType("java.util.function.Predicate")
+      val kind = im.getType("javaslang.Kind")
+
+      xs"""
+        /$javadoc
+         * Defines a $className by generalizing the flatMap function.
+         * <p>
+         * All instances of the $className interface should obey the three control laws:
+         * <ul>
+         *     <li><strong>Left identity:</strong> {@code unit(a).flatMap(f) ≡ f a}</li>
+         *     <li><strong>Right identity:</strong> {@code m.flatMap(unit) ≡ m}</li>
+         *     <li><strong>Associativity:</strong> {@code m.flatMap(f).flatMap(g) ≡ m.flatMap(x -> f.apply(x).flatMap(g)}</li>
+         * </ul>
+         * given
+         * <ul>
+         * <li>an object {@code m} of type {@code Kind<M, T>}</li>
+         * <li>an object {@code a} of type T</li>
+         * <li>a constructor {@code unit} taking an {@code a} and producing an object of type {@code M}</li>
+         * <li>a function {@code f: T → M}
+         * </ul>
+         *
+         * To read further about monads in Java please refer to
+         * <a href="http://java.dzone.com/articles/whats-wrong-java-8-part-iv">What's Wrong in Java 8, Part IV: Monads</a>.
+         *
+         * @param <M> placeholder for the type that implements this
+         * @param <T> component type of this ${checked.gen("checked ")}monad
+         * @since 1.1.0
+         */
+        public interface $className<M extends $className<M, ?>, T> extends $kind<M, T>, ${checked.gen("Checked")}Functor<T> {
+
+            /**
+             * Returns the result of applying f to M's value of type T and returns a new M with value of type U.
+             *
+             * @param <U> component type of the resulting monad
+             * @param mapper a ${checked.gen("checked ")}function that maps the monad value to a new monad instance
+             * @return a new $className instance of component type U and container type M
+             * @throws NullPointerException if {@code mapper} is null
+             */
+            <U> $className<M, U> flatMap($functionType<? super T, ? extends $kind<M, U>> mapper);
+
+            /**
+             * Flattens a nested, monadic structure using a function.
+             * <p>
+             * A vivid example showing a simple container type:
+             * <pre>
+             * <code>
+             * // given a monad M&lt;T&gt;
+             * [a,[b,c],d].flatten( Match
+             *    .when((M m) -&gt; m)
+             *    .when((T t) -&gt; new M(t))
+             * ) = [a,b,c,d]
+             * </code>
+             * </pre>
+             *
+             * @param <U> component type of the resulting {@code Monad}
+             * @param f a function which maps elements of this monad to monads of the same kind
+             * @return A monadic structure containing flattened elements.
+             * @throws NullPointerException if {@code f} is null
+             */
+            <U> $name<M, U> flatten($functionType<? super T, ? extends $kind<M, U>> f);
+
+            /**
+             * Checks, if an element exists such that the predicate holds.
+             *
+             * @param predicate A Predicate
+             * @return true, if predicate holds for an element of this, false otherwise
+             * @throws NullPointerException if {@code predicate} is null
+             */
+            boolean exists($predicateType<? super T> predicate);
+
+            /**
+             * Checks, if the given predicate holds for all elements of this.
+             *
+             * @param predicate A Predicate
+             * @return true, if the predicate holds for all elements of this, false otherwise
+             * @throws NullPointerException if {@code predicate} is null
+             */
+            boolean forAll($predicateType<? super T> predicate);
+
+            /**
+             * Performs an action on each element of this monad.
+             *
+             * @param action A {@code Consumer}
+             * @throws NullPointerException if {@code action} is null
+             */
+            void forEach(${im.getType("java.util.function.Consumer")}<? super T> action);
+
+            /**
+             * Performs an action on each element of this monad.
+             * @param action A {@code Consumer}
+             * @return An instance of this monad type
+             * @throws NullPointerException if {@code action} is null
+             */
+            $className<M, T> peek($consumerType<? super T> action);
+
+            @Override
+            <U> $className<M, U> map($functionType<? super T, ? extends U> mapper);
+        }
+      """
+    }
+  }
+
 
   /**
    * Generator of javaslang.test.Property

--- a/src-gen/main/java/javaslang/algebra/CheckedFunctor.java
+++ b/src-gen/main/java/javaslang/algebra/CheckedFunctor.java
@@ -1,0 +1,39 @@
+/*     / \____  _    ______   _____ / \____   ____  _____
+ *    /  \__  \/ \  / \__  \ /  __//  \__  \ /    \/ __  \   Javaslang
+ *  _/  // _\  \  \/  / _\  \\_  \/  // _\  \  /\  \__/  /   Copyright 2014-2015 Daniel Dietrich
+ * /___/ \_____/\____/\_____/____/\___\_____/_/  \_/____/    Licensed under the Apache License, Version 2.0
+ */
+package javaslang.algebra;
+
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*\
+   G E N E R A T O R   C R A F T E D
+\*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
+
+import javaslang.control.Try.CheckedFunction;
+
+/**
+ * <p>Defines a CheckedFunctor by generalizing the map.</p>
+ *
+ * All instances of the CheckedFunctor interface should obey the two functor laws:
+ * <ul>
+ *     <li>{@code m.map(a -> a) ≡ m}</li>
+ *     <li>{@code m.map(f.compose(g)) ≡ m.map(g).map(f)}</li>
+ * </ul>
+ * where "f, g ∈ CheckedFunction".
+ *
+ * @param <T> component type of this functor
+ * @see <a href="http://www.haskellforall.com/2012/09/the-functor-design-pattern.html">The functor design pattern</a>
+ * @since 1.1.0
+ */
+public interface CheckedFunctor<T> {
+
+    /**
+     * Applies a function f to the components of this CheckedFunctor.
+     *
+     * @param <U> type of the component of the resulting CheckedFunctor
+     * @param mapper a CheckedFunction which maps the component of this CheckedFunctor
+     * @return a new CheckedFunctor
+     * @throws NullPointerException if {@code f} is null
+     */
+    <U> CheckedFunctor<U> map(CheckedFunction<? super T, ? extends U> mapper);
+}

--- a/src-gen/main/java/javaslang/algebra/CheckedMonad.java
+++ b/src-gen/main/java/javaslang/algebra/CheckedMonad.java
@@ -1,0 +1,111 @@
+/*     / \____  _    ______   _____ / \____   ____  _____
+ *    /  \__  \/ \  / \__  \ /  __//  \__  \ /    \/ __  \   Javaslang
+ *  _/  // _\  \  \/  / _\  \\_  \/  // _\  \  /\  \__/  /   Copyright 2014-2015 Daniel Dietrich
+ * /___/ \_____/\____/\_____/____/\___\_____/_/  \_/____/    Licensed under the Apache License, Version 2.0
+ */
+package javaslang.algebra;
+
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*\
+   G E N E R A T O R   C R A F T E D
+\*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
+
+import java.util.function.Consumer;
+import javaslang.Kind;
+import javaslang.control.Try.CheckedConsumer;
+import javaslang.control.Try.CheckedFunction;
+import javaslang.control.Try.CheckedPredicate;
+
+/**
+ * Defines a CheckedMonad by generalizing the flatMap function.
+ * <p>
+ * All instances of the CheckedMonad interface should obey the three control laws:
+ * <ul>
+ *     <li><strong>Left identity:</strong> {@code unit(a).flatMap(f) ≡ f a}</li>
+ *     <li><strong>Right identity:</strong> {@code m.flatMap(unit) ≡ m}</li>
+ *     <li><strong>Associativity:</strong> {@code m.flatMap(f).flatMap(g) ≡ m.flatMap(x -> f.apply(x).flatMap(g)}</li>
+ * </ul>
+ * given
+ * <ul>
+ * <li>an object {@code m} of type {@code Kind<M, T>}</li>
+ * <li>an object {@code a} of type T</li>
+ * <li>a constructor {@code unit} taking an {@code a} and producing an object of type {@code M}</li>
+ * <li>a function {@code f: T → M}
+ * </ul>
+ *
+ * To read further about monads in Java please refer to
+ * <a href="http://java.dzone.com/articles/whats-wrong-java-8-part-iv">What's Wrong in Java 8, Part IV: Monads</a>.
+ *
+ * @param <M> placeholder for the type that implements this
+ * @param <T> component type of this checked monad
+ * @since 1.1.0
+ */
+public interface CheckedMonad<M extends CheckedMonad<M, ?>, T> extends Kind<M, T>, CheckedFunctor<T> {
+
+    /**
+     * Returns the result of applying f to M's value of type T and returns a new M with value of type U.
+     *
+     * @param <U> component type of the resulting monad
+     * @param mapper a checked function that maps the monad value to a new monad instance
+     * @return a new CheckedMonad instance of component type U and container type M
+     * @throws NullPointerException if {@code mapper} is null
+     */
+    <U> CheckedMonad<M, U> flatMap(CheckedFunction<? super T, ? extends Kind<M, U>> mapper);
+
+    /**
+     * Flattens a nested, monadic structure using a function.
+     * <p>
+     * A vivid example showing a simple container type:
+     * <pre>
+     * <code>
+     * // given a monad M&lt;T&gt;
+     * [a,[b,c],d].flatten( Match
+     *    .when((M m) -&gt; m)
+     *    .when((T t) -&gt; new M(t))
+     * ) = [a,b,c,d]
+     * </code>
+     * </pre>
+     *
+     * @param <U> component type of the resulting {@code Monad}
+     * @param f a function which maps elements of this monad to monads of the same kind
+     * @return A monadic structure containing flattened elements.
+     * @throws NullPointerException if {@code f} is null
+     */
+    <U> CheckedMonad<M, U> flatten(CheckedFunction<? super T, ? extends Kind<M, U>> f);
+
+    /**
+     * Checks, if an element exists such that the predicate holds.
+     *
+     * @param predicate A Predicate
+     * @return true, if predicate holds for an element of this, false otherwise
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    boolean exists(CheckedPredicate<? super T> predicate);
+
+    /**
+     * Checks, if the given predicate holds for all elements of this.
+     *
+     * @param predicate A Predicate
+     * @return true, if the predicate holds for all elements of this, false otherwise
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    boolean forAll(CheckedPredicate<? super T> predicate);
+
+    /**
+     * Performs an action on each element of this monad.
+     *
+     * @param action A {@code Consumer}
+     * @throws NullPointerException if {@code action} is null
+     */
+    void forEach(Consumer<? super T> action);
+
+    /**
+     * Performs an action on each element of this monad.
+     * @param action A {@code Consumer}
+     * @return An instance of this monad type
+     * @throws NullPointerException if {@code action} is null
+     */
+    CheckedMonad<M, T> peek(CheckedConsumer<? super T> action);
+
+    @Override
+    <U> CheckedMonad<M, U> map(CheckedFunction<? super T, ? extends U> mapper);
+}

--- a/src-gen/main/java/javaslang/algebra/Functor.java
+++ b/src-gen/main/java/javaslang/algebra/Functor.java
@@ -1,0 +1,39 @@
+/*     / \____  _    ______   _____ / \____   ____  _____
+ *    /  \__  \/ \  / \__  \ /  __//  \__  \ /    \/ __  \   Javaslang
+ *  _/  // _\  \  \/  / _\  \\_  \/  // _\  \  /\  \__/  /   Copyright 2014-2015 Daniel Dietrich
+ * /___/ \_____/\____/\_____/____/\___\_____/_/  \_/____/    Licensed under the Apache License, Version 2.0
+ */
+package javaslang.algebra;
+
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*\
+   G E N E R A T O R   C R A F T E D
+\*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
+
+import java.util.function.Function;
+
+/**
+ * <p>Defines a Functor by generalizing the map.</p>
+ *
+ * All instances of the Functor interface should obey the two functor laws:
+ * <ul>
+ *     <li>{@code m.map(a -> a) ≡ m}</li>
+ *     <li>{@code m.map(f.compose(g)) ≡ m.map(g).map(f)}</li>
+ * </ul>
+ * where "f, g ∈ Function".
+ *
+ * @param <T> component type of this functor
+ * @see <a href="http://www.haskellforall.com/2012/09/the-functor-design-pattern.html">The functor design pattern</a>
+ * @since 1.1.0
+ */
+public interface Functor<T> {
+
+    /**
+     * Applies a function f to the components of this Functor.
+     *
+     * @param <U> type of the component of the resulting Functor
+     * @param mapper a Function which maps the component of this Functor
+     * @return a new Functor
+     * @throws NullPointerException if {@code f} is null
+     */
+    <U> Functor<U> map(Function<? super T, ? extends U> mapper);
+}

--- a/src-gen/main/java/javaslang/algebra/Monad.java
+++ b/src-gen/main/java/javaslang/algebra/Monad.java
@@ -1,0 +1,110 @@
+/*     / \____  _    ______   _____ / \____   ____  _____
+ *    /  \__  \/ \  / \__  \ /  __//  \__  \ /    \/ __  \   Javaslang
+ *  _/  // _\  \  \/  / _\  \\_  \/  // _\  \  /\  \__/  /   Copyright 2014-2015 Daniel Dietrich
+ * /___/ \_____/\____/\_____/____/\___\_____/_/  \_/____/    Licensed under the Apache License, Version 2.0
+ */
+package javaslang.algebra;
+
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*\
+   G E N E R A T O R   C R A F T E D
+\*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import javaslang.Kind;
+
+/**
+ * Defines a Monad by generalizing the flatMap function.
+ * <p>
+ * All instances of the Monad interface should obey the three control laws:
+ * <ul>
+ *     <li><strong>Left identity:</strong> {@code unit(a).flatMap(f) ≡ f a}</li>
+ *     <li><strong>Right identity:</strong> {@code m.flatMap(unit) ≡ m}</li>
+ *     <li><strong>Associativity:</strong> {@code m.flatMap(f).flatMap(g) ≡ m.flatMap(x -> f.apply(x).flatMap(g)}</li>
+ * </ul>
+ * given
+ * <ul>
+ * <li>an object {@code m} of type {@code Kind<M, T>}</li>
+ * <li>an object {@code a} of type T</li>
+ * <li>a constructor {@code unit} taking an {@code a} and producing an object of type {@code M}</li>
+ * <li>a function {@code f: T → M}
+ * </ul>
+ *
+ * To read further about monads in Java please refer to
+ * <a href="http://java.dzone.com/articles/whats-wrong-java-8-part-iv">What's Wrong in Java 8, Part IV: Monads</a>.
+ *
+ * @param <M> placeholder for the type that implements this
+ * @param <T> component type of this monad
+ * @since 1.1.0
+ */
+public interface Monad<M extends Monad<M, ?>, T> extends Kind<M, T>, Functor<T> {
+
+    /**
+     * Returns the result of applying f to M's value of type T and returns a new M with value of type U.
+     *
+     * @param <U> component type of the resulting monad
+     * @param mapper a function that maps the monad value to a new monad instance
+     * @return a new Monad instance of component type U and container type M
+     * @throws NullPointerException if {@code mapper} is null
+     */
+    <U> Monad<M, U> flatMap(Function<? super T, ? extends Kind<M, U>> mapper);
+
+    /**
+     * Flattens a nested, monadic structure using a function.
+     * <p>
+     * A vivid example showing a simple container type:
+     * <pre>
+     * <code>
+     * // given a monad M&lt;T&gt;
+     * [a,[b,c],d].flatten( Match
+     *    .when((M m) -&gt; m)
+     *    .when((T t) -&gt; new M(t))
+     * ) = [a,b,c,d]
+     * </code>
+     * </pre>
+     *
+     * @param <U> component type of the resulting {@code Monad}
+     * @param f a function which maps elements of this monad to monads of the same kind
+     * @return A monadic structure containing flattened elements.
+     * @throws NullPointerException if {@code f} is null
+     */
+    <U> Monad<M, U> flatten(Function<? super T, ? extends Kind<M, U>> f);
+
+    /**
+     * Checks, if an element exists such that the predicate holds.
+     *
+     * @param predicate A Predicate
+     * @return true, if predicate holds for an element of this, false otherwise
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    boolean exists(Predicate<? super T> predicate);
+
+    /**
+     * Checks, if the given predicate holds for all elements of this.
+     *
+     * @param predicate A Predicate
+     * @return true, if the predicate holds for all elements of this, false otherwise
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    boolean forAll(Predicate<? super T> predicate);
+
+    /**
+     * Performs an action on each element of this monad.
+     *
+     * @param action A {@code Consumer}
+     * @throws NullPointerException if {@code action} is null
+     */
+    void forEach(Consumer<? super T> action);
+
+    /**
+     * Performs an action on each element of this monad.
+     * @param action A {@code Consumer}
+     * @return An instance of this monad type
+     * @throws NullPointerException if {@code action} is null
+     */
+    Monad<M, T> peek(Consumer<? super T> action);
+
+    @Override
+    <U> Monad<M, U> map(Function<? super T, ? extends U> mapper);
+}

--- a/src/main/java/javaslang/Kind.java
+++ b/src/main/java/javaslang/Kind.java
@@ -1,0 +1,67 @@
+/*     / \____  _    ______   _____ / \____   ____  _____
+ *    /  \__  \/ \  / \__  \ /  __//  \__  \ /    \/ __  \   Javaslang
+ *  _/  // _\  \  \/  / _\  \\_  \/  // _\  \  /\  \__/  /   Copyright 2014-2015 Daniel Dietrich
+ * /___/ \_____/\____/\_____/____/\___\_____/_/  \_/____/    Licensed under the Apache License, Version 2.0
+ */
+package javaslang;
+
+/**
+ * A {@code Kind} is the type of a type constructor.
+ * <p>
+ * It is denoted as decomposition of a type constructor, i.e. {@code List<T>} is {@code Kind<List<?>, T>}.
+ * <p>
+ * Higher-kinded/higher-order types cannot be expressed with Java. This is an approximation, it has its limitations.
+ * <p>
+ * <strong>Example:</strong>
+ * <p>
+ * Javaslang uses {@code Kind} to define a function {@code flatMap(Function)} in several related classes. The special
+ * thing about the {@code Function} argument is, that it returns an instance of the type {@code flatMap()} is defined in.
+ * <p>
+ * In particular, {@code flatMap()} is defined in {@code Monad}, {@code Traversable}, {@code Seq} and {@code List},
+ * where {@code List extends Seq, Monad} and {@code Seq extends Traversable}.
+ * <p>
+ * Here is how it looks like:
+ * <pre>
+ * <code>
+ * interface Monad&lt;M extends Monad&lt;M, ?&gt;, T&gt; extends Kind&lt;M, T&gt; {
+ *     &lt;U&gt; Monad&lt;M, U&gt; flatMap(Function&lt;? super T, ? extends Kind&lt;M, U&gt;&gt; mapper);
+ * }
+ *
+ * interface Traversable&lt;M extends Traversable&lt;M, ?&gt;, T&gt; extends Kind&lt;M, T&gt; {
+ *     &lt;U&gt; Traversable&lt;M, U&gt; flatMap(Function&lt;? super T, ? extends Kind&lt;M, U&gt;&gt; mapper);
+ * }
+ *
+ * interface Seq&lt;M extends Seq&lt;M, ?&gt;, T&gt; extends Kind&lt;M, T&gt;, Traversable&lt;M, T&gt; {
+ *     &#64;Override
+ *     &lt;U&gt; Seq&lt;M, U&gt; flatMap(Function&lt;? super T, ? extends Kind&lt;M, U&gt;&gt; mapper);
+ * }
+ *
+ * interface List&lt;T&gt; extends Kind&lt;List&lt;?&gt;, T&gt;, Seq&lt;List&lt;?&gt;, T&gt;, Monad&lt;List&lt;?&gt;, T&gt; {
+ *     &#64;Override
+ *     &lt;U&gt; List&lt;U&gt; flatMap(Function&lt;? super T, ? extends Kind&lt;List&lt;?&gt;, U&gt;&gt; mapper);
+ * }
+ * </code>
+ * </pre>
+ *
+ * <strong>Limitations:</strong>
+ * <ul>
+ * <li>Once a type extends {@code Kind} with a concrete first generic parameter type, like {@code List} does, the
+ * {@code Kind} is fixated. There is no way for subclasses to implement a more specific {@code Kind}.</li>
+ * <li>We can construct illegal relationships, like {@code interface Option<T> extends Monad<List<?>, T>}. The compiler
+ * will detect this, if {@code Kind} is also extended appropriately:
+ * {@code interface Option<T> extends Kind<Option<?>, T>, Monad<Option<?>, T>}.</li>
+ * </ul>
+ * <p>
+ * See also
+ * <ul>
+ * <li><a href="http://adriaanm.github.io/files/higher.pdf">Generics of a Higher Kind</a> (Moors, Piessens, Odersky)</li>
+ * <li><a href="http://en.wikipedia.org/wiki/Kind_(type_theory)">Kind (type theory)</a> (wikipedia)</li>
+ * <li><a href="http://en.wikipedia.org/wiki/Type_constructor">Type constructor</a> (wikipedia)</li>
+ * </ul>
+ *
+ * @param <TYPE> container type
+ * @param <T>    component type
+ * @since 1.1.0
+ */
+public interface Kind<TYPE extends Kind<TYPE, ?>, T> {
+}

--- a/src/main/java/javaslang/algebra/Monoid.java
+++ b/src/main/java/javaslang/algebra/Monoid.java
@@ -1,0 +1,71 @@
+/*     / \____  _    ______   _____ / \____   ____  _____
+ *    /  \__  \/ \  / \__  \ /  __//  \__  \ /    \/ __  \   Javaslang
+ *  _/  // _\  \  \/  / _\  \\_  \/  // _\  \  /\  \__/  /   Copyright 2014-2015 Daniel Dietrich
+ * /___/ \_____/\____/\_____/____/\___\_____/_/  \_/____/    Licensed under the Apache License, Version 2.0
+ */
+package javaslang.algebra;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * <p>A Monoid is a {@linkplain javaslang.algebra.Semigroup} (types with an associative binary operation) that has an
+ * identity element {@code zero}.</p>
+ * <p>Given a type {@code A}, instances of Monoid should satisfy the following laws:</p>
+ * <ul>
+ * <li>Associativity: {@code combine(combine(x,y),z) == combine(x,combine(y,z))} for any {@code x,y,z} of type
+ * {@code A}.</li>
+ * <li>Identity: {@code combine(zero(), x) == x == combine(x, zero())} for any {@code x} of type {@code A}.</li>
+ * </ul>
+ * <p>Example: {@linkplain java.lang.String} is a Monoid with zero {@code ""} (empty String) and String concatenation
+ * {@code +} as combine operation.</p>
+ * <p>Please note that some types can be viewed as a monoid in more than one way, e.g. both addition and multiplication
+ * on numbers.</p>
+ *
+ * @param <A> A type.
+ * @since 1.1.0
+ */
+public interface Monoid<A> extends Semigroup<A> {
+
+    /**
+     * The unique neutral element regarding {@linkplain #combine(Object, Object)}.
+     *
+     * @return The zero element of this Monoid
+     */
+    A zero();
+
+    /**
+     * The monoid of endomorphisms under composition.
+     *
+     * @param <A> Value type
+     * @return The monoid of endomorphisms of type A.
+     */
+    static <A> Monoid<Function<A, A>> endoMonoid() {
+        return Monoid.of(Function.identity(), Function::compose);
+    }
+
+    /**
+     * Factory method for monoids, taking a zero and a Semigroup.
+     *
+     * @param <A>       Value type
+     * @param zero      The zero of the Monoid.
+     * @param semigroup The associative binary operation of the Monoid. Please note that
+     *                  {@linkplain javaslang.algebra.Semigroup} is a {@linkplain java.lang.FunctionalInterface}.
+     * @return a new Monoid on type A
+     * @throws NullPointerException if {@code semigroup} is null
+     */
+    static <A> Monoid<A> of(A zero, Semigroup<A> semigroup) {
+        Objects.requireNonNull(semigroup, "semigroup is null");
+        return new Monoid<A>() {
+            @Override
+            public A combine(A a1, A a2) {
+                return semigroup.combine(a1, a2);
+            }
+
+            @Override
+            public A zero() {
+                return zero;
+            }
+        };
+    }
+}

--- a/src/main/java/javaslang/algebra/Semigroup.java
+++ b/src/main/java/javaslang/algebra/Semigroup.java
@@ -1,0 +1,32 @@
+/*     / \____  _    ______   _____ / \____   ____  _____
+ *    /  \__  \/ \  / \__  \ /  __//  \__  \ /    \/ __  \   Javaslang
+ *  _/  // _\  \  \/  / _\  \\_  \/  // _\  \  /\  \__/  /   Copyright 2014-2015 Daniel Dietrich
+ * /___/ \_____/\____/\_____/____/\___\_____/_/  \_/____/    Licensed under the Apache License, Version 2.0
+ */
+package javaslang.algebra;
+
+/**
+ * <p>A Semigroup is a type with an associative binary operation {@linkplain #combine(Object, Object)}.</p>
+ * <p>Given a type {@code A}, instances of Semigroup should satisfy the following law:</p>
+ * <ul>
+ * <li>Associativity: {@code combine(combine(x,y),z) == combine(x,combine(y,z))} for any {@code x,y,z} of type
+ * {@code A}.</li>
+ * </ul>
+ * <p>Note: Technically a Semigroup is the same as a {@code java.util.function.BiFunction<A,A,A>}. Introducing this new type
+ * clarifies that the operation {@code combine} is associative.</p>
+ *
+ * @param <A> A type.
+ * @since 1.1.0
+ */
+@FunctionalInterface
+public interface Semigroup<A> {
+
+    /**
+     * Combines two elements of the same type, which is also returned.
+     *
+     * @param a1 An element
+     * @param a2 Another element
+     * @return The combination of a1 and a2
+     */
+    A combine(A a1, A a2);
+}

--- a/src/main/java/javaslang/algebra/package-info.java
+++ b/src/main/java/javaslang/algebra/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * <p>Algebraic interfaces used to describe inherent class properties like {@linkplain javaslang.algebra.Monad}.</p>
+ * <p>Interfaces like {@linkplain javaslang.Kind} are needed to enhance API design and are mainly used
+ * internally by Javaslang. An example for {@linkplain javaslang.algebra.Monoid} usage is
+ * {@link javaslang.collection.Traversable#foldMap(javaslang.algebra.Monoid, java.util.function.Function)}.</p>
+ *
+ * @since 1.1.0
+ */
+package javaslang.algebra;

--- a/src/main/java/javaslang/collection/List.java
+++ b/src/main/java/javaslang/collection/List.java
@@ -7,6 +7,8 @@ package javaslang.collection;
 
 import javaslang.Tuple;
 import javaslang.Tuple2;
+import javaslang.Kind;
+import javaslang.algebra.Monad;
 import javaslang.control.None;
 import javaslang.control.Option;
 import javaslang.control.Some;
@@ -44,7 +46,7 @@ import java.util.stream.Collector;
  * @param <T> Component type of the List.
  * @since 1.1.0
  */
-public interface List<T> extends Seq<T> {
+public interface List<T> extends Kind<List<?>, T>, Seq<List<?>, T>, Monad<List<?>, T> {
 
     /**
      * Returns a {@link java.util.stream.Collector} which may be used in conjunction with
@@ -264,7 +266,7 @@ public interface List<T> extends Seq<T> {
 
     @SuppressWarnings("unchecked")
     @Override
-    default <U> List<U> flatMap(Function<? super T, ? extends Iterable<U>> mapper) {
+    default <U> List<U> flatMap(Function<? super T, ? extends Kind<List<?>, U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return isEmpty() ? Nil.instance() : foldRight(nil(), (t, xs) -> xs.prependAll((List<U>) mapper.apply(t)));
     }
@@ -293,7 +295,7 @@ public interface List<T> extends Seq<T> {
      */
     @SuppressWarnings("unchecked")
     @Override
-    default <U> List<U> flatten(Function<? super T, ? extends Iterable<U>> f) {
+    default <U> List<U> flatten(Function<? super T, ? extends Kind<List<?>, U>> f) {
         Objects.requireNonNull(f, "f is null");
         return isEmpty() ? Nil.instance() : foldRight(nil(), (t, xs) -> xs.prependAll((List<U>) f.apply(t)));
     }

--- a/src/main/java/javaslang/collection/Seq.java
+++ b/src/main/java/javaslang/collection/Seq.java
@@ -6,6 +6,7 @@
 package javaslang.collection;
 
 import javaslang.Tuple2;
+import javaslang.Kind;
 import javaslang.control.Option;
 
 import java.util.Comparator;
@@ -47,7 +48,7 @@ import java.util.function.*;
  * @param <T> Component type
  * @since 1.1.0
  */
-public interface Seq<T> extends Traversable<T>, IntFunction<T> {
+public interface Seq<M extends Seq<M, ?>, T> extends Kind<M, T>, Traversable<M, T>, IntFunction<T> {
 
     /**
      * A {@code Seq} is a partial function which returns the element at the specified index by calling
@@ -68,7 +69,7 @@ public interface Seq<T> extends Traversable<T>, IntFunction<T> {
      * @param element An element
      * @return A new Seq containing the given element appended to this elements
      */
-    Seq<T> append(T element);
+    Seq<M, T> append(T element);
 
     /**
      * Appends all given elements to this.
@@ -77,7 +78,7 @@ public interface Seq<T> extends Traversable<T>, IntFunction<T> {
      * @return A new Seq containing the given elements appended to this elements
      * @throws NullPointerException if {@code elements} is null
      */
-    Seq<T> appendAll(Iterable<? extends T> elements);
+    Seq<M, T> appendAll(Iterable<? extends T> elements);
 
     /**
      * Returns the element at the specified index.
@@ -104,7 +105,7 @@ public interface Seq<T> extends Traversable<T>, IntFunction<T> {
      * @return a new Seq, where the given element is inserted into this at the given index
      * @throws IndexOutOfBoundsException if this is empty, index &lt; 0 or index &gt;= length()
      */
-    Seq<T> insert(int index, T element);
+    Seq<M, T> insert(int index, T element);
 
     /**
      * Inserts the given elements at the specified index.
@@ -114,7 +115,7 @@ public interface Seq<T> extends Traversable<T>, IntFunction<T> {
      * @return a new Seq, where the given elements are inserted into this at the given index
      * @throws IndexOutOfBoundsException if this is empty, index &lt; 0 or index &gt;= length()
      */
-    Seq<T> insertAll(int index, Iterable<? extends T> elements);
+    Seq<M, T> insertAll(int index, Iterable<? extends T> elements);
 
     /**
      * Returns an iterator of this elements starting at the given index.
@@ -157,7 +158,7 @@ public interface Seq<T> extends Traversable<T>, IntFunction<T> {
      *
      * @return this unique permutations
      */
-    Seq<? extends Seq<T>> permutations();
+    Seq<M, ? extends Seq<M, T>> permutations();
 
     /**
      * Prepends an element to this.
@@ -165,7 +166,7 @@ public interface Seq<T> extends Traversable<T>, IntFunction<T> {
      * @param element An element
      * @return A new Seq containing the given element prepended to this elements
      */
-    Seq<T> prepend(T element);
+    Seq<M, T> prepend(T element);
 
     /**
      * Prepends all given elements to this.
@@ -173,7 +174,7 @@ public interface Seq<T> extends Traversable<T>, IntFunction<T> {
      * @param elements An Iterable of elements
      * @return A new Seq containing the given elements prepended to this elements
      */
-    Seq<T> prependAll(Iterable<? extends T> elements);
+    Seq<M, T> prependAll(Iterable<? extends T> elements);
 
     /**
      * Sets the given element at the specified index.
@@ -183,7 +184,7 @@ public interface Seq<T> extends Traversable<T>, IntFunction<T> {
      * @return a new Seq consisting of this elements and the given element is set at the given index
      * @throws IndexOutOfBoundsException if this is empty, index &lt; 0 or index &gt;= length()
      */
-    Seq<T> set(int index, T element);
+    Seq<M, T> set(int index, T element);
 
     /**
      * Sorts this elements according to their natural order. If this elements are not
@@ -192,7 +193,7 @@ public interface Seq<T> extends Traversable<T>, IntFunction<T> {
      * @return A sorted version of this
      * @throws ClassCastException if this elements are not {@code Comparable}
      */
-    Seq<T> sort();
+    Seq<M, T> sort();
 
     /**
      * Sorts this elements according to the provided {@code Comparator}. If this elements are not
@@ -201,7 +202,7 @@ public interface Seq<T> extends Traversable<T>, IntFunction<T> {
      * @param comparator A comparator
      * @return a sorted version of this
      */
-    Seq<T> sort(Comparator<? super T> comparator);
+    Seq<M, T> sort(Comparator<? super T> comparator);
 
     /**
      * Splits a Seq at the specified index. The result of {@code splitAt(n)} is equivalent to
@@ -210,7 +211,7 @@ public interface Seq<T> extends Traversable<T>, IntFunction<T> {
      * @param n An index.
      * @return A Tuple containing the first n and the remaining elements.
      */
-    Tuple2<? extends Seq<T>, ? extends Seq<T>> splitAt(int n);
+    Tuple2<? extends Seq<M, T>, ? extends Seq<M, T>> splitAt(int n);
 
     /**
      * <p>Returns a Seq that is a subsequence of this. The subsequence begins with the element at the specified index
@@ -229,7 +230,7 @@ public interface Seq<T> extends Traversable<T>, IntFunction<T> {
      * @throws IndexOutOfBoundsException if {@code beginIndex} is negative or larger than the length of this
      *                                   {@code String} object.
      */
-    Seq<T> subsequence(int beginIndex);
+    Seq<M, T> subsequence(int beginIndex);
 
     /**
      * <p>Returns a Seq that is a subsequence of this. The subsequence begins with the element at the specified index
@@ -253,124 +254,124 @@ public interface Seq<T> extends Traversable<T>, IntFunction<T> {
      *                                   {@code beginIndex} is larger than
      *                                   {@code endIndex}.
      */
-    Seq<T> subsequence(int beginIndex, int endIndex);
+    Seq<M, T> subsequence(int beginIndex, int endIndex);
 
     // -- Adjusted return types of Traversable methods
 
     @Override
-    Seq<T> clear();
+    Seq<M, T> clear();
 
     @Override
-    Seq<? extends Seq<T>> combinations();
+    Seq<M, ? extends Seq<M, T>> combinations();
 
     @Override
-    Seq<? extends Seq<T>> combinations(int k);
+    Seq<M, ? extends Seq<M, T>> combinations(int k);
 
     @Override
-    Seq<T> distinct();
+    Seq<M, T> distinct();
 
     @Override
-    <U> Seq<T> distinct(Function<? super T, ? extends U> keyExtractor);
+    <U> Seq<M, T> distinct(Function<? super T, ? extends U> keyExtractor);
 
     @Override
-    Seq<T> drop(int n);
+    Seq<M, T> drop(int n);
 
     @Override
-    Seq<T> dropRight(int n);
+    Seq<M, T> dropRight(int n);
 
     @Override
-    Seq<T> dropWhile(Predicate<? super T> predicate);
+    Seq<M, T> dropWhile(Predicate<? super T> predicate);
 
     @Override
-    Seq<T> filter(Predicate<? super T> predicate);
+    Seq<M, T> filter(Predicate<? super T> predicate);
 
     @Override
-    Seq<T> findAll(Predicate<? super T> predicate);
+    Seq<M, T> findAll(Predicate<? super T> predicate);
 
     @Override
-    <U> Seq<U> flatMap(Function<? super T, ? extends Iterable<U>> mapper);
+    <U> Seq<M, U> flatMap(Function<? super T, ? extends Kind<M, U>> mapper);
 
     @Override
-    <U> Seq<U> flatten(Function<? super T, ? extends Iterable<U>> f);
+    <U> Seq<M, U> flatten(Function<? super T, ? extends Kind<M, U>> f);
 
     @Override
-    Seq<? extends Seq<T>> grouped(int size);
+    Seq<M, ? extends Seq<M, T>> grouped(int size);
 
     @Override
-    Seq<T> init();
+    Seq<M, T> init();
 
     @Override
-    Option<? extends Seq<T>> initOption();
+    Option<? extends Seq<M, T>> initOption();
 
     @Override
-    Seq<T> intersperse(T element);
+    Seq<M, T> intersperse(T element);
 
     @Override
-    <U> Seq<U> map(Function<? super T, ? extends U> mapper);
+    <U> Seq<M, U> map(Function<? super T, ? extends U> mapper);
 
     @Override
-    Tuple2<? extends Seq<T>, ? extends Seq<T>> partition(Predicate<? super T> predicate);
+    Tuple2<? extends Seq<M, T>, ? extends Seq<M, T>> partition(Predicate<? super T> predicate);
 
     @Override
-    Seq<T> peek(Consumer<? super T> action);
+    Seq<M, T> peek(Consumer<? super T> action);
 
     @Override
-    Seq<T> remove(T element);
+    Seq<M, T> remove(T element);
 
     @Override
-    Seq<T> removeAll(T element);
+    Seq<M, T> removeAll(T element);
 
     @Override
-    Seq<T> removeAll(Iterable<? extends T> elements);
+    Seq<M, T> removeAll(Iterable<? extends T> elements);
 
     @Override
-    Seq<T> replace(T currentElement, T newElement);
+    Seq<M, T> replace(T currentElement, T newElement);
 
     @Override
-    Seq<T> replaceAll(T currentElement, T newElement);
+    Seq<M, T> replaceAll(T currentElement, T newElement);
 
     @Override
-    Seq<T> replaceAll(UnaryOperator<T> operator);
+    Seq<M, T> replaceAll(UnaryOperator<T> operator);
 
     @Override
-    Seq<T> retainAll(Iterable<? extends T> elements);
+    Seq<M, T> retainAll(Iterable<? extends T> elements);
 
     @Override
-    Seq<T> reverse();
+    Seq<M, T> reverse();
 
     @Override
-    Seq<? extends Seq<T>> sliding(int size);
+    Seq<M, ? extends Seq<M, T>> sliding(int size);
 
     @Override
-    Seq<? extends Seq<T>> sliding(int size, int step);
+    Seq<M, ? extends Seq<M, T>> sliding(int size, int step);
 
     @Override
-    Tuple2<? extends Seq<T>, ? extends Seq<T>> span(Predicate<? super T> predicate);
+    Tuple2<? extends Seq<M, T>, ? extends Seq<M, T>> span(Predicate<? super T> predicate);
 
     @Override
-    Seq<T> tail();
+    Seq<M, T> tail();
 
     @Override
-    Option<? extends Seq<T>> tailOption();
+    Option<? extends Seq<M, T>> tailOption();
 
     @Override
-    Seq<T> take(int n);
+    Seq<M, T> take(int n);
 
     @Override
-    Seq<T> takeRight(int n);
+    Seq<M, T> takeRight(int n);
 
     @Override
-    Seq<T> takeWhile(Predicate<? super T> predicate);
+    Seq<M, T> takeWhile(Predicate<? super T> predicate);
 
     @Override
-    <T1, T2> Tuple2<? extends Seq<T1>, ? extends Seq<T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper);
+    <T1, T2> Tuple2<? extends Seq<M, T1>, ? extends Seq<M, T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper);
 
     @Override
-    <U> Seq<Tuple2<T, U>> zip(Iterable<U> that);
+    <U> Seq<M, Tuple2<T, U>> zip(Iterable<U> that);
 
     @Override
-    <U> Seq<Tuple2<T, U>> zipAll(Iterable<U> that, T thisElem, U thatElem);
+    <U> Seq<M, Tuple2<T, U>> zipAll(Iterable<U> that, T thisElem, U thatElem);
 
     @Override
-    Seq<Tuple2<T, Integer>> zipWithIndex();
+    Seq<M, Tuple2<T, Integer>> zipWithIndex();
 }

--- a/src/main/java/javaslang/collection/Tree.java
+++ b/src/main/java/javaslang/collection/Tree.java
@@ -5,6 +5,7 @@
  */
 package javaslang.collection;
 
+import javaslang.algebra.Functor;
 import javaslang.control.Match;
 
 import java.util.*;
@@ -16,7 +17,7 @@ import java.util.function.Function;
  * @param <T> component type of this Tree
  * @since 1.1.0
  */
-public interface Tree<T> extends Iterable<T> {
+public interface Tree<T> extends Functor<T>, Iterable<T> {
 
     /**
      * Gets the value of this tree.
@@ -197,6 +198,7 @@ public interface Tree<T> extends Iterable<T> {
         }
     }
 
+    @Override
     <U> Tree<U> map(Function<? super T, ? extends U> mapper);
 
     /**

--- a/src/main/java/javaslang/control/Failure.java
+++ b/src/main/java/javaslang/control/Failure.java
@@ -5,6 +5,8 @@
  */
 package javaslang.control;
 
+import javaslang.Kind;
+
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.Optional;
@@ -141,7 +143,8 @@ public final class Failure<T> implements Try<T>, Serializable {
     }
 
     @SuppressWarnings("unchecked")
-    public <U> Failure<U> flatMap(CheckedFunction<? super T, ? extends Try<U>> mapper) {
+    @Override
+    public <U> Failure<U> flatMap(CheckedFunction<? super T, ? extends Kind<Try<?>, U>> mapper) {
         return (Failure<U>) this;
     }
 

--- a/src/main/java/javaslang/control/None.java
+++ b/src/main/java/javaslang/control/None.java
@@ -74,6 +74,11 @@ public final class None<T> implements Option<T>, Serializable {
     }
 
     @Override
+    public None<T> toOption() {
+        return this;
+    }
+
+    @Override
     public Optional<T> toJavaOptional() {
         return Optional.empty();
     }

--- a/src/main/java/javaslang/control/Some.java
+++ b/src/main/java/javaslang/control/Some.java
@@ -58,6 +58,11 @@ public final class Some<T> implements Option<T>, Serializable {
     }
 
     @Override
+    public Some<T> toOption() {
+        return this;
+    }
+
+    @Override
     public Optional<T> toJavaOptional() {
         return Optional.ofNullable(value);
     }

--- a/src/main/java/javaslang/control/Success.java
+++ b/src/main/java/javaslang/control/Success.java
@@ -5,6 +5,8 @@
  */
 package javaslang.control;
 
+import javaslang.Kind;
+
 import java.io.Serializable;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -142,7 +144,7 @@ public final class Success<T> implements Try<T>, Serializable {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <U> Try<U> flatMap(CheckedFunction<? super T, ? extends Try<U>> mapper) {
+    public <U> Try<U> flatMap(CheckedFunction<? super T, ? extends Kind<Try<?>, U>> mapper) {
         try {
             return (Try<U>) mapper.apply(value);
         } catch (Throwable t) {

--- a/src/main/java/javaslang/control/Valences.java
+++ b/src/main/java/javaslang/control/Valences.java
@@ -1,0 +1,63 @@
+/*     / \____  _    ______   _____ / \____   ____  _____
+ *    /  \__  \/ \  / \__  \ /  __//  \__  \ /    \/ __  \   Javaslang
+ *  _/  // _\  \  \/  / _\  \\_  \/  // _\  \  /\  \__/  /   Copyright 2014-2015 Daniel Dietrich
+ * /___/ \_____/\____/\_____/____/\___\_____/_/  \_/____/    Licensed under the Apache License, Version 2.0
+ */
+package javaslang.control;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * This class is not intended to be extended nor it is intended to be public API.
+ *
+ * @since 1.1.0
+ */
+final class Valences {
+
+    /**
+     * This class is not intended to be instantiated.
+     */
+    private Valences() {
+        throw new AssertionError(Valences.class.getName() + " is not intended to be instantiated.");
+    }
+
+    // has one (primary) value
+    interface Univalent<T> {
+
+        T get();
+
+        T orElse(T other);
+
+        T orElseGet(Supplier<? extends T> other);
+
+        <X extends Throwable> T orElseThrow(Supplier<X> exceptionSupplier) throws X;
+
+        Option<T> toOption();
+
+        Optional<T> toJavaOptional();
+    }
+
+    // has two values (, one is primary)
+    interface Bivalent<T, U> {
+
+        T get();
+
+        T orElse(T other);
+
+        T orElseGet(Function<? super U, ? extends T> other);
+
+        void orElseRun(Consumer<? super U> action);
+
+        <X extends Throwable> T orElseThrow(Function<? super U, X> exceptionProvider) throws X;
+
+        Option<T> toOption();
+
+        // order of generic parameters may vary (see Either.LeftProjection, Either.RightProjection)
+        Either<?, ?> toEither();
+
+        Optional<T> toJavaOptional();
+    }
+}

--- a/src/test/java/javaslang/TypeConsistencyTest.java
+++ b/src/test/java/javaslang/TypeConsistencyTest.java
@@ -32,6 +32,7 @@ public class TypeConsistencyTest {
             "javaslang.control.Failure//public abstract javaslang.control.Try javaslang.control.Try.recover(javaslang.control.Try$CheckedFunction)",
             "javaslang.control.Failure//public abstract javaslang.control.Try javaslang.control.Try.recoverWith(javaslang.control.Try$CheckedFunction)",
             "javaslang.control.Failure//public abstract javaslang.control.Try javaslang.control.Try.failed()",
+            "javaslang.control.Failure//public default javaslang.control.Try javaslang.control.Try.flatten()",
             "javaslang.control.Failure//public default javaslang.control.Try javaslang.control.Try.flatten(javaslang.control.Try$CheckedFunction)",
             "javaslang.control.Failure//public abstract javaslang.control.Try javaslang.control.Try.map(javaslang.control.Try$CheckedFunction)",
             "javaslang.control.Failure//public default javaslang.control.Try javaslang.control.Try.andThen(javaslang.control.Try$CheckedRunnable)",
@@ -40,6 +41,7 @@ public class TypeConsistencyTest {
             "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.failed()",
             "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.filter(javaslang.control.Try$CheckedPredicate)",
             "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.flatMap(javaslang.control.Try$CheckedFunction)",
+            "javaslang.control.Success//public default javaslang.control.Try javaslang.control.Try.flatten()",
             "javaslang.control.Success//public default javaslang.control.Try javaslang.control.Try.flatten(javaslang.control.Try$CheckedFunction)",
             "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.map(javaslang.control.Try$CheckedFunction)",
             "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.peek(javaslang.control.Try$CheckedConsumer)",
@@ -48,11 +50,13 @@ public class TypeConsistencyTest {
             // control.None
             "javaslang.control.None//public default javaslang.control.Option javaslang.control.Option.filter(java.util.function.Predicate)",
             "javaslang.control.None//public default javaslang.control.Option javaslang.control.Option.flatMap(java.util.function.Function)",
+            "javaslang.control.None//public default javaslang.control.Option javaslang.control.Option.flatten()",
             "javaslang.control.None//public default javaslang.control.Option javaslang.control.Option.flatten(java.util.function.Function)",
 
             // control.Some
             "javaslang.control.Some//public default javaslang.control.Option javaslang.control.Option.filter(java.util.function.Predicate)",
             "javaslang.control.Some//public default javaslang.control.Option javaslang.control.Option.flatMap(java.util.function.Function)",
+            "javaslang.control.Some//public default javaslang.control.Option javaslang.control.Option.flatten()",
             "javaslang.control.Some//public default javaslang.control.Option javaslang.control.Option.flatten(java.util.function.Function)",
 
             // control.Left

--- a/src/test/java/javaslang/algebra/AlgebraTest.java
+++ b/src/test/java/javaslang/algebra/AlgebraTest.java
@@ -1,0 +1,23 @@
+/*     / \____  _    ______   _____ / \____   ____  _____
+ *    /  \__  \/ \  / \__  \ /  __//  \__  \ /    \/ __  \   Javaslang
+ *  _/  // _\  \  \/  / _\  \\_  \/  // _\  \  /\  \__/  /   Copyright 2014-2015 Daniel Dietrich
+ * /___/ \_____/\____/\_____/____/\___\_____/_/  \_/____/    Licensed under the Apache License, Version 2.0
+ */
+package javaslang.algebra;
+
+import org.junit.Test;
+
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AlgebraTest {
+
+    @Test
+    public void shouldCombineMonoids() {
+        final Monoid<Function<Integer, Integer>> endo = Monoid.endoMonoid();
+        final Function<Integer, Integer> after = i -> i + 1;
+        final Function<Integer, Integer> before = i -> i * 2;
+        assertThat(endo.combine(after, before).apply(2)).isEqualTo(5);
+    }
+}

--- a/src/test/java/javaslang/algebra/CheckedFunctorLaws.java
+++ b/src/test/java/javaslang/algebra/CheckedFunctorLaws.java
@@ -1,0 +1,36 @@
+/*     / \____  _    ______   _____ / \____   ____  _____
+ *    /  \__  \/ \  / \__  \ /  __//  \__  \ /    \/ __  \   Javaslang
+ *  _/  // _\  \  \/  / _\  \\_  \/  // _\  \  /\  \__/  /   Copyright 2014-2015 Daniel Dietrich
+ * /___/ \_____/\____/\_____/____/\___\_____/_/  \_/____/    Licensed under the Apache License, Version 2.0
+ */
+package javaslang.algebra;
+
+import javaslang.control.Try;
+import javaslang.test.Arbitrary;
+import javaslang.test.CheckResult;
+import javaslang.test.Property;
+
+public interface CheckedFunctorLaws {
+
+    void shouldSatisfyCheckedFunctorIdentity();
+
+    void shouldSatisfyCheckedFunctorComposition();
+
+    // m.map(id) ≡ id
+    default <T> CheckResult checkCheckedFunctorIdentity(Arbitrary<? extends CheckedFunctor<T>> functors) {
+        return new Property("checkedFunctor.identity")
+                .forAll(functors)
+                .suchThat(functor -> functor.map(t -> t).equals(functor))
+                .check();
+    }
+
+    // m.map(f).map(g) ≡ m.map(x -> g.apply(f.apply(x)))
+    default <T, U, V> CheckResult checkCheckedFunctorComposition(Arbitrary<? extends CheckedFunctor<T>> functors,
+                                                          Arbitrary<Try.CheckedFunction<? super T, ? extends U>> fs,
+                                                          Arbitrary<Try.CheckedFunction<? super U, ? extends V>> gs) {
+        return new Property("checkedFunctor.composition")
+                .forAll(functors, fs, gs)
+                .suchThat((functor, f, g) -> functor.map(f).map(g).equals(functor.map(t -> g.apply(f.apply(t)))))
+                .check();
+    }
+}

--- a/src/test/java/javaslang/algebra/CheckedMonadLaws.java
+++ b/src/test/java/javaslang/algebra/CheckedMonadLaws.java
@@ -1,0 +1,61 @@
+/*     / \____  _    ______   _____ / \____   ____  _____
+ *    /  \__  \/ \  / \__  \ /  __//  \__  \ /    \/ __  \   Javaslang
+ *  _/  // _\  \  \/  / _\  \\_  \/  // _\  \  /\  \__/  /   Copyright 2014-2015 Daniel Dietrich
+ * /___/ \_____/\____/\_____/____/\___\_____/_/  \_/____/    Licensed under the Apache License, Version 2.0
+ */
+package javaslang.algebra;
+
+import javaslang.control.Try;
+import javaslang.test.Arbitrary;
+import javaslang.test.CheckResult;
+import javaslang.test.Property;
+
+@SuppressWarnings("Convert2MethodRef")
+public interface CheckedMonadLaws<M extends CheckedMonad<M, ?>> extends CheckedFunctorLaws {
+
+    void shouldSatisfyCheckedMonadLeftIdentity();
+
+    void shouldSatisfyCheckedMonadRightIdentity();
+
+    void shouldSatisfyCheckedMonadAssociativity();
+
+    // unit(a).flatMap(f) ≡ f.apply(a)
+    default <T, U> CheckResult checkCheckedMonadLeftIdentity(Try.CheckedFunction<? super T, ? extends CheckedMonad<M, T>> unit,
+                                                      Arbitrary<T> ts,
+                                                      Arbitrary<Try.CheckedFunction<? super T, ? extends CheckedMonad<M, U>>> fs) {
+        return new Property("checkedMonad.left_identity")
+                .forAll(ts, fs)
+                .suchThat((t, f) -> {
+                    final CheckedMonad<M, U> term1 = unit.apply(t).flatMap((T tt) -> f.apply(tt));
+                    final CheckedMonad<M, U> term2 = f.apply(t);
+                    return term1.equals(term2);
+                })
+                .check();
+    }
+
+    // m.flatMap(unit) ≡ m
+    default <T> CheckResult checkCheckedMonadRightIdentity(Try.CheckedFunction<? super T, ? extends CheckedMonad<M, T>> unit,
+                                                    Arbitrary<? extends CheckedMonad<M, T>> ms) {
+        return new Property("checkedMonad.right_identity")
+                .forAll(ms)
+                .suchThat(m -> {
+                    final CheckedMonad<M, T> term = m.flatMap((T t) -> unit.apply(t));
+                    return term.equals(m);
+                })
+                .check();
+    }
+
+    // m.flatMap(f).flatMap(g) ≡ m.flatMap(x -> f.apply(x).flatMap(g))
+    default <T, U, V> CheckResult checkCheckedMonadAssociativity(Arbitrary<? extends CheckedMonad<M, T>> ms,
+                                                          Arbitrary<Try.CheckedFunction<? super T, ? extends CheckedMonad<M, U>>> fs,
+                                                          Arbitrary<Try.CheckedFunction<? super U, ? extends CheckedMonad<M, V>>> gs) {
+        return new Property("checkedMonad.associativity")
+                .forAll(ms, fs, gs)
+                .suchThat((m, f, g) -> {
+                    final CheckedMonad<M, V> term1 = m.flatMap((T t) -> f.apply(t)).flatMap((U u) -> g.apply(u));
+                    final CheckedMonad<M, V> term2 = m.flatMap((T t) -> f.apply(t).flatMap((U u) -> g.apply(u)));
+                    return term1.equals(term2);
+                })
+                .check();
+    }
+}

--- a/src/test/java/javaslang/algebra/FunctorLaws.java
+++ b/src/test/java/javaslang/algebra/FunctorLaws.java
@@ -1,0 +1,37 @@
+/*     / \____  _    ______   _____ / \____   ____  _____
+ *    /  \__  \/ \  / \__  \ /  __//  \__  \ /    \/ __  \   Javaslang
+ *  _/  // _\  \  \/  / _\  \\_  \/  // _\  \  /\  \__/  /   Copyright 2014-2015 Daniel Dietrich
+ * /___/ \_____/\____/\_____/____/\___\_____/_/  \_/____/    Licensed under the Apache License, Version 2.0
+ */
+package javaslang.algebra;
+
+import javaslang.test.Arbitrary;
+import javaslang.test.CheckResult;
+import javaslang.test.Property;
+
+import java.util.function.Function;
+
+public interface FunctorLaws {
+
+    void shouldSatisfyFunctorIdentity();
+
+    void shouldSatisfyFunctorComposition();
+
+    // m.map(id) ≡ id
+    default <T> CheckResult checkFunctorIdentity(Arbitrary<? extends Functor<T>> functors) {
+        return new Property("functor.identity")
+                .forAll(functors)
+                .suchThat(functor -> functor.map(t -> t).equals(functor))
+                .check();
+    }
+
+    // m.map(f).map(g) ≡ m.map(x -> g.apply(f.apply(x)))
+    default <T, U, V> CheckResult checkFunctorComposition(Arbitrary<? extends Functor<T>> functors,
+                                                          Arbitrary<Function<? super T, ? extends U>> fs,
+                                                          Arbitrary<Function<? super U, ? extends V>> gs) {
+        return new Property("functor.composition")
+                .forAll(functors, fs, gs)
+                .suchThat((functor, f, g) -> functor.map(f).map(g).equals(functor.map(t -> g.apply(f.apply(t)))))
+                .check();
+    }
+}

--- a/src/test/java/javaslang/algebra/MonadLaws.java
+++ b/src/test/java/javaslang/algebra/MonadLaws.java
@@ -1,0 +1,62 @@
+/*     / \____  _    ______   _____ / \____   ____  _____
+ *    /  \__  \/ \  / \__  \ /  __//  \__  \ /    \/ __  \   Javaslang
+ *  _/  // _\  \  \/  / _\  \\_  \/  // _\  \  /\  \__/  /   Copyright 2014-2015 Daniel Dietrich
+ * /___/ \_____/\____/\_____/____/\___\_____/_/  \_/____/    Licensed under the Apache License, Version 2.0
+ */
+package javaslang.algebra;
+
+import javaslang.test.Arbitrary;
+import javaslang.test.CheckResult;
+import javaslang.test.Property;
+
+import java.util.function.Function;
+
+@SuppressWarnings("Convert2MethodRef")
+public interface MonadLaws<M extends Monad<M, ?>> extends FunctorLaws {
+
+    void shouldSatisfyMonadLeftIdentity();
+
+    void shouldSatisfyMonadRightIdentity();
+
+    void shouldSatisfyMonadAssociativity();
+
+    // unit(a).flatMap(f) ≡ f.apply(a)
+    default <T, U> CheckResult checkMonadLeftIdentity(Function<? super T, ? extends Monad<M, T>> unit,
+                                                      Arbitrary<T> ts,
+                                                      Arbitrary<Function<? super T, ? extends Monad<M, U>>> fs) {
+        return new Property("monad.left_identity")
+                .forAll(ts, fs)
+                .suchThat((t, f) -> {
+                    final Monad<M, U> term1 = unit.apply(t).flatMap((T tt) -> f.apply(tt));
+                    final Monad<M, U> term2 = f.apply(t);
+                    return term1.equals(term2);
+                })
+                .check();
+    }
+
+    // m.flatMap(unit) ≡ m
+    default <T> CheckResult checkMonadRightIdentity(Function<? super T, ? extends Monad<M, T>> unit,
+                                                    Arbitrary<? extends Monad<M, T>> ms) {
+        return new Property("monad.right_identity")
+                .forAll(ms)
+                .suchThat(m -> {
+                    final Monad<M, T> term = m.flatMap((T t) -> unit.apply(t));
+                    return term.equals(m);
+                })
+                .check();
+    }
+
+    // m.flatMap(f).flatMap(g) ≡ m.flatMap(x -> f.apply(x).flatMap(g))
+    default <T, U, V> CheckResult checkMonadAssociativity(Arbitrary<? extends Monad<M, T>> ms,
+                                                          Arbitrary<Function<? super T, ? extends Monad<M, U>>> fs,
+                                                          Arbitrary<Function<? super U, ? extends Monad<M, V>>> gs) {
+        return new Property("monad.associativity")
+                .forAll(ms, fs, gs)
+                .suchThat((m, f, g) -> {
+                    final Monad<M, V> term1 = m.flatMap((T t) -> f.apply(t)).flatMap((U u) -> g.apply(u));
+                    final Monad<M, V> term2 = m.flatMap((T t) -> f.apply(t).flatMap((U u) -> g.apply(u)));
+                    return term1.equals(term2);
+                })
+                .check();
+    }
+}

--- a/src/test/java/javaslang/collection/AbstractSeqTest.java
+++ b/src/test/java/javaslang/collection/AbstractSeqTest.java
@@ -15,28 +15,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests all methods defined in {@link javaslang.collection.Seq}.
  */
-public abstract class AbstractSeqTest extends AbstractTraversableTest {
+public abstract class AbstractSeqTest<M extends Seq<M, ?>> extends AbstractTraversableTest<M> {
 
     @Override
-    abstract protected <T> Seq<T> nil();
+    abstract protected <T> Seq<M, T> nil();
 
     @SuppressWarnings("unchecked")
     @Override
-    abstract protected <T> Seq<T> of(T... elements);
+    abstract protected <T> Seq<M, T> of(T... elements);
 
     // -- append
 
     @Test
     public void shouldAppendElementToNil() {
-        final Seq<Integer> actual = this.<Integer>nil().append(1);
-        final Seq<Integer> expected = this.of(1);
+        final Seq<M, Integer> actual = this.<Integer>nil().append(1);
+        final Seq<M, Integer> expected = this.of(1);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldAppendElementToNonNil() {
-        final Seq<Integer> actual = this.of(1, 2).append(3);
-        final Seq<Integer> expected = this.of(1, 2, 3);
+        final Seq<M, Integer> actual = this.of(1, 2).append(3);
+        final Seq<M, Integer> expected = this.of(1, 2, 3);
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -49,29 +49,29 @@ public abstract class AbstractSeqTest extends AbstractTraversableTest {
 
     @Test
     public void shouldAppendAllNilToNil() {
-        final Seq<Object> actual = this.nil().appendAll(this.nil());
-        final Seq<Object> expected = this.nil();
+        final Seq<M, Object> actual = this.nil().appendAll(this.nil());
+        final Seq<M, Object> expected = this.nil();
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldAppendAllNonNilToNil() {
-        final Seq<Integer> actual = this.<Integer>nil().appendAll(this.of(1, 2, 3));
-        final Seq<Integer> expected = this.of(1, 2, 3);
+        final Seq<M, Integer> actual = this.<Integer>nil().appendAll(this.of(1, 2, 3));
+        final Seq<M, Integer> expected = this.of(1, 2, 3);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldAppendAllNilToNonNil() {
-        final Seq<Integer> actual = this.of(1, 2, 3).appendAll(this.nil());
-        final Seq<Integer> expected = this.of(1, 2, 3);
+        final Seq<M, Integer> actual = this.of(1, 2, 3).appendAll(this.nil());
+        final Seq<M, Integer> expected = this.of(1, 2, 3);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldAppendAllNonNilToNonNil() {
-        final Seq<Integer> actual = this.of(1, 2, 3).appendAll(this.of(4, 5, 6));
-        final Seq<Integer> expected = this.of(1, 2, 3, 4, 5, 6);
+        final Seq<M, Integer> actual = this.of(1, 2, 3).appendAll(this.of(4, 5, 6));
+        final Seq<M, Integer> expected = this.of(1, 2, 3, 4, 5, 6);
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -140,29 +140,29 @@ public abstract class AbstractSeqTest extends AbstractTraversableTest {
 
     @Test
     public void shouldInsertIntoNil() {
-        final Seq<Integer> actual = this.<Integer>nil().insert(0, 1);
-        final Seq<Integer> expected = this.of(1);
+        final Seq<M, Integer> actual = this.<Integer>nil().insert(0, 1);
+        final Seq<M, Integer> expected = this.of(1);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldInsertInFrontOfElement() {
-        final Seq<Integer> actual = this.of(4).insert(0, 1);
-        final Seq<Integer> expected = this.of(1, 4);
+        final Seq<M, Integer> actual = this.of(4).insert(0, 1);
+        final Seq<M, Integer> expected = this.of(1, 4);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldInsertBehindOfElement() {
-        final Seq<Integer> actual = this.of(4).insert(1, 1);
-        final Seq<Integer> expected = this.of(4, 1);
+        final Seq<M, Integer> actual = this.of(4).insert(1, 1);
+        final Seq<M, Integer> expected = this.of(4, 1);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldInsertIntoSeq() {
-        final Seq<Integer> actual = this.of(1, 2, 3).insert(2, 4);
-        final Seq<Integer> expected = this.of(1, 2, 4, 3);
+        final Seq<M, Integer> actual = this.of(1, 2, 3).insert(2, 4);
+        final Seq<M, Integer> expected = this.of(1, 2, 4, 3);
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -180,29 +180,29 @@ public abstract class AbstractSeqTest extends AbstractTraversableTest {
 
     @Test
     public void shouldInserAlltIntoNil() {
-        final Seq<Integer> actual = this.<Integer>nil().insertAll(0, this.of(1, 2, 3));
-        final Seq<Integer> expected = this.of(1, 2, 3);
+        final Seq<M, Integer> actual = this.<Integer>nil().insertAll(0, this.of(1, 2, 3));
+        final Seq<M, Integer> expected = this.of(1, 2, 3);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldInsertAllInFrontOfElement() {
-        final Seq<Integer> actual = this.of(4).insertAll(0, this.of(1, 2, 3));
-        final Seq<Integer> expected = this.of(1, 2, 3, 4);
+        final Seq<M, Integer> actual = this.of(4).insertAll(0, this.of(1, 2, 3));
+        final Seq<M, Integer> expected = this.of(1, 2, 3, 4);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldInsertAllBehindOfElement() {
-        final Seq<Integer> actual = this.of(4).insertAll(1, this.of(1, 2, 3));
-        final Seq<Integer> expected = this.of(4, 1, 2, 3);
+        final Seq<M, Integer> actual = this.of(4).insertAll(1, this.of(1, 2, 3));
+        final Seq<M, Integer> expected = this.of(4, 1, 2, 3);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldInsertAllIntoSeq() {
-        final Seq<Integer> actual = this.of(1, 2, 3).insertAll(2, this.of(4, 5));
-        final Seq<Integer> expected = this.of(1, 2, 4, 5, 3);
+        final Seq<M, Integer> actual = this.of(1, 2, 3).insertAll(2, this.of(4, 5));
+        final Seq<M, Integer> expected = this.of(1, 2, 4, 5, 3);
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -258,15 +258,15 @@ public abstract class AbstractSeqTest extends AbstractTraversableTest {
 
     @Test
     public void shouldPrependElementToNil() {
-        final Seq<Integer> actual = this.<Integer>nil().prepend(1);
-        final Seq<Integer> expected = this.of(1);
+        final Seq<M, Integer> actual = this.<Integer>nil().prepend(1);
+        final Seq<M, Integer> expected = this.of(1);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldPrependElementToNonNil() {
-        final Seq<Integer> actual = this.of(2, 3).prepend(1);
-        final Seq<Integer> expected = this.of(1, 2, 3);
+        final Seq<M, Integer> actual = this.of(2, 3).prepend(1);
+        final Seq<M, Integer> expected = this.of(1, 2, 3);
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -279,29 +279,29 @@ public abstract class AbstractSeqTest extends AbstractTraversableTest {
 
     @Test
     public void shouldPrependAllNilToNil() {
-        final Seq<Integer> actual = this.<Integer>nil().prependAll(this.nil());
-        final Seq<Integer> expected = this.nil();
+        final Seq<M, Integer> actual = this.<Integer>nil().prependAll(this.nil());
+        final Seq<M, Integer> expected = this.nil();
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldPrependAllNilToNonNil() {
-        final Seq<Integer> actual = this.of(1, 2, 3).prependAll(this.nil());
-        final Seq<Integer> expected = this.of(1, 2, 3);
+        final Seq<M, Integer> actual = this.of(1, 2, 3).prependAll(this.nil());
+        final Seq<M, Integer> expected = this.of(1, 2, 3);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldPrependAllNonNilToNil() {
-        final Seq<Integer> actual = this.<Integer>nil().prependAll(this.of(1, 2, 3));
-        final Seq<Integer> expected = this.of(1, 2, 3);
+        final Seq<M, Integer> actual = this.<Integer>nil().prependAll(this.of(1, 2, 3));
+        final Seq<M, Integer> expected = this.of(1, 2, 3);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldPrependAllNonNilToNonNil() {
-        final Seq<Integer> actual = this.of(4, 5, 6).prependAll(this.of(1, 2, 3));
-        final Seq<Integer> expected = this.of(1, 2, 3, 4, 5, 6);
+        final Seq<M, Integer> actual = this.of(4, 5, 6).prependAll(this.of(1, 2, 3));
+        final Seq<M, Integer> expected = this.of(1, 2, 3, 4, 5, 6);
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -382,31 +382,31 @@ public abstract class AbstractSeqTest extends AbstractTraversableTest {
 
     @Test
     public void shouldReturnNilWhenSubsequenceFrom0OnNil() {
-        final Seq<Integer> actual = this.<Integer>nil().subsequence(0);
+        final Seq<M, Integer> actual = this.<Integer>nil().subsequence(0);
         assertThat(actual).isEqualTo(this.nil());
     }
 
     @Test
     public void shouldReturnIdentityWhenSubsequenceFrom0OnNonNil() {
-        final Seq<Integer> actual = this.of(1).subsequence(0);
+        final Seq<M, Integer> actual = this.of(1).subsequence(0);
         assertThat(actual).isEqualTo(this.of(1));
     }
 
     @Test
     public void shouldReturnNilWhenSubsequenceFrom1OnSeqOf1() {
-        final Seq<Integer> actual = this.of(1).subsequence(1);
+        final Seq<M, Integer> actual = this.of(1).subsequence(1);
         assertThat(actual).isEqualTo(this.nil());
     }
 
     @Test
     public void shouldReturnSubsequenceWhenIndexIsWithinRange() {
-        final Seq<Integer> actual = this.of(1, 2, 3).subsequence(1);
+        final Seq<M, Integer> actual = this.of(1, 2, 3).subsequence(1);
         assertThat(actual).isEqualTo(this.of(2, 3));
     }
 
     @Test
     public void shouldReturnNilWhenSubsequenceBeginningWithSize() {
-        final Seq<Integer> actual = this.of(1, 2, 3).subsequence(3);
+        final Seq<M, Integer> actual = this.of(1, 2, 3).subsequence(3);
         assertThat(actual).isEqualTo(this.nil());
     }
 
@@ -429,37 +429,37 @@ public abstract class AbstractSeqTest extends AbstractTraversableTest {
 
     @Test
     public void shouldReturnNilWhenSubsequenceFrom0To0OnNil() {
-        final Seq<Integer> actual = this.<Integer>nil().subsequence(0, 0);
+        final Seq<M, Integer> actual = this.<Integer>nil().subsequence(0, 0);
         assertThat(actual).isEqualTo(this.nil());
     }
 
     @Test
     public void shouldReturnNilWhenSubsequenceFrom0To0OnNonNil() {
-        final Seq<Integer> actual = this.of(1).subsequence(0, 0);
+        final Seq<M, Integer> actual = this.of(1).subsequence(0, 0);
         assertThat(actual).isEqualTo(this.nil());
     }
 
     @Test
     public void shouldReturnSeqWithFirstElementWhenSubsequenceFrom0To1OnNonNil() {
-        final Seq<Integer> actual = this.of(1).subsequence(0, 1);
+        final Seq<M, Integer> actual = this.of(1).subsequence(0, 1);
         assertThat(actual).isEqualTo(this.of(1));
     }
 
     @Test
     public void shouldReturnNilWhenSubsequenceFrom1To1OnNonNil() {
-        final Seq<Integer> actual = this.of(1).subsequence(1, 1);
+        final Seq<M, Integer> actual = this.of(1).subsequence(1, 1);
         assertThat(actual).isEqualTo(this.nil());
     }
 
     @Test
     public void shouldReturnSubsequenceWhenIndicesAreWithinRange() {
-        final Seq<Integer> actual = this.of(1, 2, 3).subsequence(1, 3);
+        final Seq<M, Integer> actual = this.of(1, 2, 3).subsequence(1, 3);
         assertThat(actual).isEqualTo(this.of(2, 3));
     }
 
     @Test
     public void shouldReturnNilWhenIndicesBothAreUpperBound() {
-        final Seq<Integer> actual = this.of(1, 2, 3).subsequence(3, 3);
+        final Seq<M, Integer> actual = this.of(1, 2, 3).subsequence(3, 3);
         assertThat(actual).isEqualTo(this.nil());
     }
 

--- a/src/test/java/javaslang/collection/ListTest.java
+++ b/src/test/java/javaslang/collection/ListTest.java
@@ -6,16 +6,23 @@
 package javaslang.collection;
 
 import javaslang.Serializables;
+import javaslang.algebra.Functor;
+import javaslang.algebra.Monad;
+import javaslang.algebra.MonadLaws;
 import javaslang.collection.List.Cons;
 import javaslang.collection.List.Nil;
+import javaslang.test.Arbitrary;
+import javaslang.test.CheckResult;
+import javaslang.test.CheckResultAssertions;
 import org.junit.Test;
 
 import java.io.InvalidObjectException;
 import java.util.Arrays;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ListTest extends AbstractSeqTest {
+public class ListTest extends AbstractSeqTest<List<?>> implements MonadLaws<List<?>> {
 
     @Override
     protected <T> List<T> nil() {
@@ -228,5 +235,58 @@ public class ListTest extends AbstractSeqTest {
         } catch (IllegalStateException x) {
             throw (x.getCause() != null) ? x.getCause() : x;
         }
+    }
+
+    // -- FunctorLaws
+
+    @Test
+    @Override
+    public void shouldSatisfyFunctorIdentity() {
+        final Arbitrary<? extends Functor<Integer>> lists = Arbitrary.list(Arbitrary.integer());
+        final CheckResult result = checkFunctorIdentity(lists);
+        CheckResultAssertions.assertThat(result).isSatisfiedWithExhaustion(false);
+    }
+
+    @Test
+    @Override
+    public void shouldSatisfyFunctorComposition() {
+        final Arbitrary<? extends Functor<Integer>> lists = Arbitrary.list(Arbitrary.integer());
+        final Arbitrary<Function<? super Integer, ? extends Double>> before =
+                size -> random -> Double::valueOf;
+        final Arbitrary<Function<? super Double, ? extends String>> after =
+                size -> random -> String::valueOf;
+        final CheckResult result = checkFunctorComposition(lists, before, after);
+        CheckResultAssertions.assertThat(result).isSatisfiedWithExhaustion(false);
+    }
+
+    // -- MonadLaws
+
+    @Test
+    @Override
+    public void shouldSatisfyMonadLeftIdentity() {
+        final Arbitrary<Function<? super Integer, ? extends Monad<List<?>, String>>> mappers =
+                size -> random -> i -> List.of(i).map(String::valueOf);
+        final CheckResult result = checkMonadLeftIdentity(List::of, Arbitrary.integer(), mappers);
+        CheckResultAssertions.assertThat(result).isSatisfiedWithExhaustion(false);
+    }
+
+    @Test
+    @Override
+    public void shouldSatisfyMonadRightIdentity() {
+        final Arbitrary<? extends Monad<List<?>, Integer>> lists = Arbitrary.list(Arbitrary.integer());
+        final CheckResult result = checkMonadRightIdentity(List::of, lists);
+        CheckResultAssertions.assertThat(result).isSatisfiedWithExhaustion(false);
+    }
+
+    @Test
+    @Override
+    public void shouldSatisfyMonadAssociativity() {
+        final Arbitrary<? extends Monad<List<?>, Integer>> lists = Arbitrary.list(Arbitrary.integer());
+        final Arbitrary<Function<? super Integer, ? extends Monad<List<?>, Double>>> before =
+                size -> random -> i -> List.of(i).map(Double::valueOf);
+        final Arbitrary<Function<? super Double, ? extends Monad<List<?>, String>>> after =
+                size -> random -> d -> List.of(d).map(String::valueOf);
+        final CheckResult result = checkMonadAssociativity(lists, before, after);
+        CheckResultAssertions.assertThat(result).isSatisfiedWithExhaustion(false);
     }
 }

--- a/src/test/java/javaslang/control/TryTest.java
+++ b/src/test/java/javaslang/control/TryTest.java
@@ -6,6 +6,13 @@
 package javaslang.control;
 
 import javaslang.Serializables;
+import javaslang.Tuple;
+import javaslang.algebra.CheckedMonad;
+import javaslang.algebra.CheckedMonadLaws;
+import javaslang.test.Arbitrary;
+import javaslang.test.CheckResult;
+import javaslang.test.CheckResultAssertions;
+import javaslang.test.Gen;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
@@ -17,7 +24,7 @@ import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TryTest {
+public class TryTest implements CheckedMonadLaws<Try<?>> {
 
     private static final String OK = "ok";
     private static final String FAILURE = "failure";
@@ -632,5 +639,78 @@ public class TryTest {
 
     private Try<String> success() {
         return Try.of(() -> "ok");
+    }
+
+    // -- CheckedFunctor1Laws
+
+    static final Arbitrary<Try<Integer>> TRIES = size -> random -> Gen.frequency(
+            Tuple.of(1, Gen.<Try<Integer>>of(new Failure<>(new Error("test")))),
+            Tuple.of(4, Gen.choose(-size, size).<Try<Integer>>map(Success::new))
+    ).apply(random);
+
+    @Test
+    @Override
+    public void shouldSatisfyCheckedFunctorIdentity() {
+        final CheckResult result = checkCheckedFunctorIdentity(TRIES);
+        CheckResultAssertions.assertThat(result).isSatisfiedWithExhaustion(false);
+    }
+
+    @Test
+    @Override
+    public void shouldSatisfyCheckedFunctorComposition() {
+        final Arbitrary<Try.CheckedFunction<? super Integer, ? extends Double>> before =
+                size -> random -> Double::valueOf;
+        final Arbitrary<Try.CheckedFunction<? super Double, ? extends String>> after =
+                size -> random -> String::valueOf;
+        final CheckResult result = checkCheckedFunctorComposition(TRIES, before, after);
+        CheckResultAssertions.assertThat(result).isSatisfiedWithExhaustion(false);
+    }
+
+    // -- CheckedMonad1Laws
+
+    static final Arbitrary<Integer> INTEGERS = size -> random -> Gen.frequency(
+            Tuple.of(1, Gen.of(null)),
+            Tuple.of(4, Gen.choose(-size, size))
+    ).apply(random);
+
+    static <T> Try.CheckedFunction<? super T, ? extends CheckedMonad<Try<?>, T>> unit() {
+        return i -> Try.of(() -> {
+            if (i == null) {
+                throw new Error("test");
+            } else {
+                return i;
+            }
+        });
+    }
+
+    static <T, R> CheckedMonad<Try<?>, R> mapTry(T t, Try.CheckedFunction<? super T, R> mapper) throws Throwable {
+        return TryTest.<T>unit().apply(t).map(mapper::apply);
+    }
+
+    @Test
+    @Override
+    public void shouldSatisfyCheckedMonadLeftIdentity() {
+        final Arbitrary<Try.CheckedFunction<? super Integer, ? extends CheckedMonad<Try<?>, String>>> mappers =
+                size -> random -> i -> TryTest.mapTry(i, String::valueOf);
+        final CheckResult result = checkCheckedMonadLeftIdentity(TryTest.<Integer>unit(), INTEGERS, mappers);
+        CheckResultAssertions.assertThat(result).isSatisfiedWithExhaustion(false);
+    }
+
+    @Test
+    @Override
+    public void shouldSatisfyCheckedMonadRightIdentity() {
+        final CheckResult result = checkCheckedMonadRightIdentity(TryTest.<Integer>unit(), TRIES);
+        CheckResultAssertions.assertThat(result).isSatisfiedWithExhaustion(false);
+    }
+
+    @Test
+    @Override
+    public void shouldSatisfyCheckedMonadAssociativity() {
+        final Arbitrary<Try.CheckedFunction<? super Integer, ? extends CheckedMonad<Try<?>, Double>>> before =
+                size -> random -> i -> TryTest.mapTry(i, Double::valueOf);
+        final Arbitrary<Try.CheckedFunction<? super Double, ? extends CheckedMonad<Try<?>, String>>> after =
+                size -> random -> d -> TryTest.mapTry(d, String::valueOf);
+        final CheckResult result = checkCheckedMonadAssociativity(TRIES, before, after);
+        CheckResultAssertions.assertThat(result).isSatisfiedWithExhaustion(false);
     }
 }

--- a/src/test/java/javaslang/control/ValencesTest.java
+++ b/src/test/java/javaslang/control/ValencesTest.java
@@ -1,0 +1,18 @@
+/*     / \____  _    ______   _____ / \____   ____  _____
+ *    /  \__  \/ \  / \__  \ /  __//  \__  \ /    \/ __  \   Javaslang
+ *  _/  // _\  \  \/  / _\  \\_  \/  // _\  \  /\  \__/  /   Copyright 2014-2015 Daniel Dietrich
+ * /___/ \_____/\____/\_____/____/\___\_____/_/  \_/____/    Licensed under the Apache License, Version 2.0
+ */
+package javaslang.control;
+
+import javaslang.AssertionsExtensions;
+import org.junit.Test;
+
+public class ValencesTest {
+
+    @Test
+    public void shouldNotBeInstantiable() {
+        AssertionsExtensions.assertThat(Valences.class).isNotInstantiable();
+    }
+
+}


### PR DESCRIPTION
Reverts javaslang/javaslang#257

A common interface for all Monads enriches the API. It is no good idea to remove it, before the javaslang-pure module has a replacement.