### PR TITLE
Aligned Function.memoized() to tupled(), reversed() and curried().

### DIFF
--- a/src-gen/main/java/javaslang/CheckedFunction0.java
+++ b/src-gen/main/java/javaslang/CheckedFunction0.java
@@ -39,19 +39,6 @@ public interface CheckedFunction0<R> extends λ<R> {
     }
 
     /**
-     * Returns a memoizing function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     *
-     * @param <R> return type
-     * @param f a function
-     * @return a memoizing function
-     */
-    static <R> CheckedFunction0<R> memoize(CheckedFunction0<R> f) {
-        final Lazy<R> cache = Lazy.of(Try.of(f::apply)::get);
-        return cache::get;
-    }
-
-    /**
      * Applies this function to no arguments and returns the result.
      *
      * @return the result of function application
@@ -77,6 +64,12 @@ public interface CheckedFunction0<R> extends λ<R> {
     @Override
     default CheckedFunction0<R> reversed() {
         return this;
+    }
+
+    @Override
+    default CheckedFunction0<R> memoized() {
+        final Lazy<R> cache = Lazy.of(() -> Try.of(this::apply).get());
+        return cache::get;
     }
 
     /**

--- a/src-gen/main/java/javaslang/CheckedFunction1.java
+++ b/src-gen/main/java/javaslang/CheckedFunction1.java
@@ -53,21 +53,6 @@ public interface CheckedFunction1<T1, R> extends λ<R> {
     }
 
     /**
-     * Returns a memoizing function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     *
-     * @param <R> return type
-     * @param <T1> 1st argument
-     * @param f a function
-     * @return a memoizing function
-     */
-    static <T1, R> CheckedFunction1<T1, R> memoize(CheckedFunction1<T1, R> f) {
-        final Map<T1, R> cache = new ConcurrentHashMap<>();
-
-        return (t1) -> cache.computeIfAbsent(t1, t -> Try.of(() -> f.apply(t)).get());
-    }
-
-    /**
      * Applies this function to one argument and returns the result.
      *
      * @param t1 argument 1
@@ -94,6 +79,13 @@ public interface CheckedFunction1<T1, R> extends λ<R> {
     @Override
     default CheckedFunction1<T1, R> reversed() {
         return this;
+    }
+
+    @Override
+    default CheckedFunction1<T1, R> memoized() {
+        final Map<Tuple1<T1>, R> cache = new ConcurrentHashMap<>();
+        final CheckedFunction1<Tuple1<T1>, R> tupled = tupled();
+        return (t1) -> cache.computeIfAbsent(Tuple.of(t1), t -> Try.of(() -> tupled.apply(t)).get());
     }
 
     /**

--- a/src-gen/main/java/javaslang/CheckedFunction2.java
+++ b/src-gen/main/java/javaslang/CheckedFunction2.java
@@ -45,22 +45,6 @@ public interface CheckedFunction2<T1, T2, R> extends λ<R> {
     }
 
     /**
-     * Returns a memoizing function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     *
-     * @param <R> return type
-     * @param <T1> 1st argument
-     * @param <T2> 2nd argument
-     * @param f a function
-     * @return a memoizing function
-     */
-    static <T1, T2, R> CheckedFunction2<T1, T2, R> memoize(CheckedFunction2<T1, T2, R> f) {
-        final Map<Tuple2<T1, T2>, R> cache = new ConcurrentHashMap<>();
-        final CheckedFunction1<Tuple2<T1, T2>, R> tupled = f.tupled();
-        return (t1, t2) -> cache.computeIfAbsent(Tuple.of(t1, t2), t -> Try.of(() -> tupled.apply(t)).get());
-    }
-
-    /**
      * Applies this function to two arguments and returns the result.
      *
      * @param t1 argument 1
@@ -99,6 +83,13 @@ public interface CheckedFunction2<T1, T2, R> extends λ<R> {
     @Override
     default CheckedFunction2<T2, T1, R> reversed() {
         return (t2, t1) -> apply(t1, t2);
+    }
+
+    @Override
+    default CheckedFunction2<T1, T2, R> memoized() {
+        final Map<Tuple2<T1, T2>, R> cache = new ConcurrentHashMap<>();
+        final CheckedFunction1<Tuple2<T1, T2>, R> tupled = tupled();
+        return (t1, t2) -> cache.computeIfAbsent(Tuple.of(t1, t2), t -> Try.of(() -> tupled.apply(t)).get());
     }
 
     /**

--- a/src-gen/main/java/javaslang/CheckedFunction3.java
+++ b/src-gen/main/java/javaslang/CheckedFunction3.java
@@ -47,23 +47,6 @@ public interface CheckedFunction3<T1, T2, T3, R> extends λ<R> {
     }
 
     /**
-     * Returns a memoizing function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     *
-     * @param <R> return type
-     * @param <T1> 1st argument
-     * @param <T2> 2nd argument
-     * @param <T3> 3rd argument
-     * @param f a function
-     * @return a memoizing function
-     */
-    static <T1, T2, T3, R> CheckedFunction3<T1, T2, T3, R> memoize(CheckedFunction3<T1, T2, T3, R> f) {
-        final Map<Tuple3<T1, T2, T3>, R> cache = new ConcurrentHashMap<>();
-        final CheckedFunction1<Tuple3<T1, T2, T3>, R> tupled = f.tupled();
-        return (t1, t2, t3) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3), t -> Try.of(() -> tupled.apply(t)).get());
-    }
-
-    /**
      * Applies this function to three arguments and returns the result.
      *
      * @param t1 argument 1
@@ -115,6 +98,13 @@ public interface CheckedFunction3<T1, T2, T3, R> extends λ<R> {
     @Override
     default CheckedFunction3<T3, T2, T1, R> reversed() {
         return (t3, t2, t1) -> apply(t1, t2, t3);
+    }
+
+    @Override
+    default CheckedFunction3<T1, T2, T3, R> memoized() {
+        final Map<Tuple3<T1, T2, T3>, R> cache = new ConcurrentHashMap<>();
+        final CheckedFunction1<Tuple3<T1, T2, T3>, R> tupled = tupled();
+        return (t1, t2, t3) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3), t -> Try.of(() -> tupled.apply(t)).get());
     }
 
     /**

--- a/src-gen/main/java/javaslang/CheckedFunction4.java
+++ b/src-gen/main/java/javaslang/CheckedFunction4.java
@@ -49,24 +49,6 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends λ<R> {
     }
 
     /**
-     * Returns a memoizing function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     *
-     * @param <R> return type
-     * @param <T1> 1st argument
-     * @param <T2> 2nd argument
-     * @param <T3> 3rd argument
-     * @param <T4> 4th argument
-     * @param f a function
-     * @return a memoizing function
-     */
-    static <T1, T2, T3, T4, R> CheckedFunction4<T1, T2, T3, T4, R> memoize(CheckedFunction4<T1, T2, T3, T4, R> f) {
-        final Map<Tuple4<T1, T2, T3, T4>, R> cache = new ConcurrentHashMap<>();
-        final CheckedFunction1<Tuple4<T1, T2, T3, T4>, R> tupled = f.tupled();
-        return (t1, t2, t3, t4) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4), t -> Try.of(() -> tupled.apply(t)).get());
-    }
-
-    /**
      * Applies this function to 4 arguments and returns the result.
      *
      * @param t1 argument 1
@@ -132,6 +114,13 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends λ<R> {
     @Override
     default CheckedFunction4<T4, T3, T2, T1, R> reversed() {
         return (t4, t3, t2, t1) -> apply(t1, t2, t3, t4);
+    }
+
+    @Override
+    default CheckedFunction4<T1, T2, T3, T4, R> memoized() {
+        final Map<Tuple4<T1, T2, T3, T4>, R> cache = new ConcurrentHashMap<>();
+        final CheckedFunction1<Tuple4<T1, T2, T3, T4>, R> tupled = tupled();
+        return (t1, t2, t3, t4) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4), t -> Try.of(() -> tupled.apply(t)).get());
     }
 
     /**

--- a/src-gen/main/java/javaslang/CheckedFunction5.java
+++ b/src-gen/main/java/javaslang/CheckedFunction5.java
@@ -51,25 +51,6 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends λ<R> {
     }
 
     /**
-     * Returns a memoizing function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     *
-     * @param <R> return type
-     * @param <T1> 1st argument
-     * @param <T2> 2nd argument
-     * @param <T3> 3rd argument
-     * @param <T4> 4th argument
-     * @param <T5> 5th argument
-     * @param f a function
-     * @return a memoizing function
-     */
-    static <T1, T2, T3, T4, T5, R> CheckedFunction5<T1, T2, T3, T4, T5, R> memoize(CheckedFunction5<T1, T2, T3, T4, T5, R> f) {
-        final Map<Tuple5<T1, T2, T3, T4, T5>, R> cache = new ConcurrentHashMap<>();
-        final CheckedFunction1<Tuple5<T1, T2, T3, T4, T5>, R> tupled = f.tupled();
-        return (t1, t2, t3, t4, t5) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5), t -> Try.of(() -> tupled.apply(t)).get());
-    }
-
-    /**
      * Applies this function to 5 arguments and returns the result.
      *
      * @param t1 argument 1
@@ -150,6 +131,13 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends λ<R> {
     @Override
     default CheckedFunction5<T5, T4, T3, T2, T1, R> reversed() {
         return (t5, t4, t3, t2, t1) -> apply(t1, t2, t3, t4, t5);
+    }
+
+    @Override
+    default CheckedFunction5<T1, T2, T3, T4, T5, R> memoized() {
+        final Map<Tuple5<T1, T2, T3, T4, T5>, R> cache = new ConcurrentHashMap<>();
+        final CheckedFunction1<Tuple5<T1, T2, T3, T4, T5>, R> tupled = tupled();
+        return (t1, t2, t3, t4, t5) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5), t -> Try.of(() -> tupled.apply(t)).get());
     }
 
     /**

--- a/src-gen/main/java/javaslang/CheckedFunction6.java
+++ b/src-gen/main/java/javaslang/CheckedFunction6.java
@@ -53,26 +53,6 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
     }
 
     /**
-     * Returns a memoizing function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     *
-     * @param <R> return type
-     * @param <T1> 1st argument
-     * @param <T2> 2nd argument
-     * @param <T3> 3rd argument
-     * @param <T4> 4th argument
-     * @param <T5> 5th argument
-     * @param <T6> 6th argument
-     * @param f a function
-     * @return a memoizing function
-     */
-    static <T1, T2, T3, T4, T5, T6, R> CheckedFunction6<T1, T2, T3, T4, T5, T6, R> memoize(CheckedFunction6<T1, T2, T3, T4, T5, T6, R> f) {
-        final Map<Tuple6<T1, T2, T3, T4, T5, T6>, R> cache = new ConcurrentHashMap<>();
-        final CheckedFunction1<Tuple6<T1, T2, T3, T4, T5, T6>, R> tupled = f.tupled();
-        return (t1, t2, t3, t4, t5, t6) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5, t6), t -> Try.of(() -> tupled.apply(t)).get());
-    }
-
-    /**
      * Applies this function to 6 arguments and returns the result.
      *
      * @param t1 argument 1
@@ -169,6 +149,13 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
     @Override
     default CheckedFunction6<T6, T5, T4, T3, T2, T1, R> reversed() {
         return (t6, t5, t4, t3, t2, t1) -> apply(t1, t2, t3, t4, t5, t6);
+    }
+
+    @Override
+    default CheckedFunction6<T1, T2, T3, T4, T5, T6, R> memoized() {
+        final Map<Tuple6<T1, T2, T3, T4, T5, T6>, R> cache = new ConcurrentHashMap<>();
+        final CheckedFunction1<Tuple6<T1, T2, T3, T4, T5, T6>, R> tupled = tupled();
+        return (t1, t2, t3, t4, t5, t6) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5, t6), t -> Try.of(() -> tupled.apply(t)).get());
     }
 
     /**

--- a/src-gen/main/java/javaslang/CheckedFunction7.java
+++ b/src-gen/main/java/javaslang/CheckedFunction7.java
@@ -55,27 +55,6 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
     }
 
     /**
-     * Returns a memoizing function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     *
-     * @param <R> return type
-     * @param <T1> 1st argument
-     * @param <T2> 2nd argument
-     * @param <T3> 3rd argument
-     * @param <T4> 4th argument
-     * @param <T5> 5th argument
-     * @param <T6> 6th argument
-     * @param <T7> 7th argument
-     * @param f a function
-     * @return a memoizing function
-     */
-    static <T1, T2, T3, T4, T5, T6, T7, R> CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> memoize(CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> f) {
-        final Map<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> cache = new ConcurrentHashMap<>();
-        final CheckedFunction1<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> tupled = f.tupled();
-        return (t1, t2, t3, t4, t5, t6, t7) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5, t6, t7), t -> Try.of(() -> tupled.apply(t)).get());
-    }
-
-    /**
      * Applies this function to 7 arguments and returns the result.
      *
      * @param t1 argument 1
@@ -189,6 +168,13 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
     @Override
     default CheckedFunction7<T7, T6, T5, T4, T3, T2, T1, R> reversed() {
         return (t7, t6, t5, t4, t3, t2, t1) -> apply(t1, t2, t3, t4, t5, t6, t7);
+    }
+
+    @Override
+    default CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> memoized() {
+        final Map<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> cache = new ConcurrentHashMap<>();
+        final CheckedFunction1<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> tupled = tupled();
+        return (t1, t2, t3, t4, t5, t6, t7) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5, t6, t7), t -> Try.of(() -> tupled.apply(t)).get());
     }
 
     /**

--- a/src-gen/main/java/javaslang/CheckedFunction8.java
+++ b/src-gen/main/java/javaslang/CheckedFunction8.java
@@ -57,28 +57,6 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<
     }
 
     /**
-     * Returns a memoizing function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     *
-     * @param <R> return type
-     * @param <T1> 1st argument
-     * @param <T2> 2nd argument
-     * @param <T3> 3rd argument
-     * @param <T4> 4th argument
-     * @param <T5> 5th argument
-     * @param <T6> 6th argument
-     * @param <T7> 7th argument
-     * @param <T8> 8th argument
-     * @param f a function
-     * @return a memoizing function
-     */
-    static <T1, T2, T3, T4, T5, T6, T7, T8, R> CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> memoize(CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> f) {
-        final Map<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> cache = new ConcurrentHashMap<>();
-        final CheckedFunction1<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> tupled = f.tupled();
-        return (t1, t2, t3, t4, t5, t6, t7, t8) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5, t6, t7, t8), t -> Try.of(() -> tupled.apply(t)).get());
-    }
-
-    /**
      * Applies this function to 8 arguments and returns the result.
      *
      * @param t1 argument 1
@@ -210,6 +188,13 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<
     @Override
     default CheckedFunction8<T8, T7, T6, T5, T4, T3, T2, T1, R> reversed() {
         return (t8, t7, t6, t5, t4, t3, t2, t1) -> apply(t1, t2, t3, t4, t5, t6, t7, t8);
+    }
+
+    @Override
+    default CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> memoized() {
+        final Map<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> cache = new ConcurrentHashMap<>();
+        final CheckedFunction1<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> tupled = tupled();
+        return (t1, t2, t3, t4, t5, t6, t7, t8) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5, t6, t7, t8), t -> Try.of(() -> tupled.apply(t)).get());
     }
 
     /**

--- a/src-gen/main/java/javaslang/Function0.java
+++ b/src-gen/main/java/javaslang/Function0.java
@@ -39,18 +39,6 @@ public interface Function0<R> extends λ<R> {
     }
 
     /**
-     * Returns a memoizing function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     *
-     * @param <R> return type
-     * @param f a function
-     * @return a memoizing function
-     */
-    static <R> Function0<R> memoize(Function0<R> f) {
-        return Lazy.of(f::apply)::get;
-    }
-
-    /**
      * Applies this function to no arguments and returns the result.
      *
      * @return the result of function application
@@ -76,6 +64,11 @@ public interface Function0<R> extends λ<R> {
     @Override
     default Function0<R> reversed() {
         return this;
+    }
+
+    @Override
+    default Function0<R> memoized() {
+        return Lazy.of(this::apply)::get;
     }
 
     /**

--- a/src-gen/main/java/javaslang/Function1.java
+++ b/src-gen/main/java/javaslang/Function1.java
@@ -53,21 +53,6 @@ public interface Function1<T1, R> extends λ<R> {
     }
 
     /**
-     * Returns a memoizing function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     *
-     * @param <R> return type
-     * @param <T1> 1st argument
-     * @param f a function
-     * @return a memoizing function
-     */
-    static <T1, R> Function1<T1, R> memoize(Function1<T1, R> f) {
-        final Map<T1, R> cache = new ConcurrentHashMap<>();
-
-        return (t1) -> cache.computeIfAbsent(t1, f::apply);
-    }
-
-    /**
      * Applies this function to one argument and returns the result.
      *
      * @param t1 argument 1
@@ -94,6 +79,13 @@ public interface Function1<T1, R> extends λ<R> {
     @Override
     default Function1<T1, R> reversed() {
         return this;
+    }
+
+    @Override
+    default Function1<T1, R> memoized() {
+        final Map<Tuple1<T1>, R> cache = new ConcurrentHashMap<>();
+        final Function1<Tuple1<T1>, R> tupled = tupled();
+        return (t1) -> cache.computeIfAbsent(Tuple.of(t1), tupled::apply);
     }
 
     /**

--- a/src-gen/main/java/javaslang/Function2.java
+++ b/src-gen/main/java/javaslang/Function2.java
@@ -45,22 +45,6 @@ public interface Function2<T1, T2, R> extends λ<R> {
     }
 
     /**
-     * Returns a memoizing function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     *
-     * @param <R> return type
-     * @param <T1> 1st argument
-     * @param <T2> 2nd argument
-     * @param f a function
-     * @return a memoizing function
-     */
-    static <T1, T2, R> Function2<T1, T2, R> memoize(Function2<T1, T2, R> f) {
-        final Map<Tuple2<T1, T2>, R> cache = new ConcurrentHashMap<>();
-        final Function1<Tuple2<T1, T2>, R> tupled = f.tupled();
-        return (t1, t2) -> cache.computeIfAbsent(Tuple.of(t1, t2), tupled::apply);
-    }
-
-    /**
      * Applies this function to two arguments and returns the result.
      *
      * @param t1 argument 1
@@ -99,6 +83,13 @@ public interface Function2<T1, T2, R> extends λ<R> {
     @Override
     default Function2<T2, T1, R> reversed() {
         return (t2, t1) -> apply(t1, t2);
+    }
+
+    @Override
+    default Function2<T1, T2, R> memoized() {
+        final Map<Tuple2<T1, T2>, R> cache = new ConcurrentHashMap<>();
+        final Function1<Tuple2<T1, T2>, R> tupled = tupled();
+        return (t1, t2) -> cache.computeIfAbsent(Tuple.of(t1, t2), tupled::apply);
     }
 
     /**

--- a/src-gen/main/java/javaslang/Function3.java
+++ b/src-gen/main/java/javaslang/Function3.java
@@ -47,23 +47,6 @@ public interface Function3<T1, T2, T3, R> extends λ<R> {
     }
 
     /**
-     * Returns a memoizing function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     *
-     * @param <R> return type
-     * @param <T1> 1st argument
-     * @param <T2> 2nd argument
-     * @param <T3> 3rd argument
-     * @param f a function
-     * @return a memoizing function
-     */
-    static <T1, T2, T3, R> Function3<T1, T2, T3, R> memoize(Function3<T1, T2, T3, R> f) {
-        final Map<Tuple3<T1, T2, T3>, R> cache = new ConcurrentHashMap<>();
-        final Function1<Tuple3<T1, T2, T3>, R> tupled = f.tupled();
-        return (t1, t2, t3) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3), tupled::apply);
-    }
-
-    /**
      * Applies this function to three arguments and returns the result.
      *
      * @param t1 argument 1
@@ -115,6 +98,13 @@ public interface Function3<T1, T2, T3, R> extends λ<R> {
     @Override
     default Function3<T3, T2, T1, R> reversed() {
         return (t3, t2, t1) -> apply(t1, t2, t3);
+    }
+
+    @Override
+    default Function3<T1, T2, T3, R> memoized() {
+        final Map<Tuple3<T1, T2, T3>, R> cache = new ConcurrentHashMap<>();
+        final Function1<Tuple3<T1, T2, T3>, R> tupled = tupled();
+        return (t1, t2, t3) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3), tupled::apply);
     }
 
     /**

--- a/src-gen/main/java/javaslang/Function4.java
+++ b/src-gen/main/java/javaslang/Function4.java
@@ -49,24 +49,6 @@ public interface Function4<T1, T2, T3, T4, R> extends λ<R> {
     }
 
     /**
-     * Returns a memoizing function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     *
-     * @param <R> return type
-     * @param <T1> 1st argument
-     * @param <T2> 2nd argument
-     * @param <T3> 3rd argument
-     * @param <T4> 4th argument
-     * @param f a function
-     * @return a memoizing function
-     */
-    static <T1, T2, T3, T4, R> Function4<T1, T2, T3, T4, R> memoize(Function4<T1, T2, T3, T4, R> f) {
-        final Map<Tuple4<T1, T2, T3, T4>, R> cache = new ConcurrentHashMap<>();
-        final Function1<Tuple4<T1, T2, T3, T4>, R> tupled = f.tupled();
-        return (t1, t2, t3, t4) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4), tupled::apply);
-    }
-
-    /**
      * Applies this function to 4 arguments and returns the result.
      *
      * @param t1 argument 1
@@ -132,6 +114,13 @@ public interface Function4<T1, T2, T3, T4, R> extends λ<R> {
     @Override
     default Function4<T4, T3, T2, T1, R> reversed() {
         return (t4, t3, t2, t1) -> apply(t1, t2, t3, t4);
+    }
+
+    @Override
+    default Function4<T1, T2, T3, T4, R> memoized() {
+        final Map<Tuple4<T1, T2, T3, T4>, R> cache = new ConcurrentHashMap<>();
+        final Function1<Tuple4<T1, T2, T3, T4>, R> tupled = tupled();
+        return (t1, t2, t3, t4) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4), tupled::apply);
     }
 
     /**

--- a/src-gen/main/java/javaslang/Function5.java
+++ b/src-gen/main/java/javaslang/Function5.java
@@ -51,25 +51,6 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends λ<R> {
     }
 
     /**
-     * Returns a memoizing function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     *
-     * @param <R> return type
-     * @param <T1> 1st argument
-     * @param <T2> 2nd argument
-     * @param <T3> 3rd argument
-     * @param <T4> 4th argument
-     * @param <T5> 5th argument
-     * @param f a function
-     * @return a memoizing function
-     */
-    static <T1, T2, T3, T4, T5, R> Function5<T1, T2, T3, T4, T5, R> memoize(Function5<T1, T2, T3, T4, T5, R> f) {
-        final Map<Tuple5<T1, T2, T3, T4, T5>, R> cache = new ConcurrentHashMap<>();
-        final Function1<Tuple5<T1, T2, T3, T4, T5>, R> tupled = f.tupled();
-        return (t1, t2, t3, t4, t5) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5), tupled::apply);
-    }
-
-    /**
      * Applies this function to 5 arguments and returns the result.
      *
      * @param t1 argument 1
@@ -150,6 +131,13 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends λ<R> {
     @Override
     default Function5<T5, T4, T3, T2, T1, R> reversed() {
         return (t5, t4, t3, t2, t1) -> apply(t1, t2, t3, t4, t5);
+    }
+
+    @Override
+    default Function5<T1, T2, T3, T4, T5, R> memoized() {
+        final Map<Tuple5<T1, T2, T3, T4, T5>, R> cache = new ConcurrentHashMap<>();
+        final Function1<Tuple5<T1, T2, T3, T4, T5>, R> tupled = tupled();
+        return (t1, t2, t3, t4, t5) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5), tupled::apply);
     }
 
     /**

--- a/src-gen/main/java/javaslang/Function6.java
+++ b/src-gen/main/java/javaslang/Function6.java
@@ -53,26 +53,6 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
     }
 
     /**
-     * Returns a memoizing function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     *
-     * @param <R> return type
-     * @param <T1> 1st argument
-     * @param <T2> 2nd argument
-     * @param <T3> 3rd argument
-     * @param <T4> 4th argument
-     * @param <T5> 5th argument
-     * @param <T6> 6th argument
-     * @param f a function
-     * @return a memoizing function
-     */
-    static <T1, T2, T3, T4, T5, T6, R> Function6<T1, T2, T3, T4, T5, T6, R> memoize(Function6<T1, T2, T3, T4, T5, T6, R> f) {
-        final Map<Tuple6<T1, T2, T3, T4, T5, T6>, R> cache = new ConcurrentHashMap<>();
-        final Function1<Tuple6<T1, T2, T3, T4, T5, T6>, R> tupled = f.tupled();
-        return (t1, t2, t3, t4, t5, t6) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5, t6), tupled::apply);
-    }
-
-    /**
      * Applies this function to 6 arguments and returns the result.
      *
      * @param t1 argument 1
@@ -169,6 +149,13 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
     @Override
     default Function6<T6, T5, T4, T3, T2, T1, R> reversed() {
         return (t6, t5, t4, t3, t2, t1) -> apply(t1, t2, t3, t4, t5, t6);
+    }
+
+    @Override
+    default Function6<T1, T2, T3, T4, T5, T6, R> memoized() {
+        final Map<Tuple6<T1, T2, T3, T4, T5, T6>, R> cache = new ConcurrentHashMap<>();
+        final Function1<Tuple6<T1, T2, T3, T4, T5, T6>, R> tupled = tupled();
+        return (t1, t2, t3, t4, t5, t6) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5, t6), tupled::apply);
     }
 
     /**

--- a/src-gen/main/java/javaslang/Function7.java
+++ b/src-gen/main/java/javaslang/Function7.java
@@ -55,27 +55,6 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
     }
 
     /**
-     * Returns a memoizing function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     *
-     * @param <R> return type
-     * @param <T1> 1st argument
-     * @param <T2> 2nd argument
-     * @param <T3> 3rd argument
-     * @param <T4> 4th argument
-     * @param <T5> 5th argument
-     * @param <T6> 6th argument
-     * @param <T7> 7th argument
-     * @param f a function
-     * @return a memoizing function
-     */
-    static <T1, T2, T3, T4, T5, T6, T7, R> Function7<T1, T2, T3, T4, T5, T6, T7, R> memoize(Function7<T1, T2, T3, T4, T5, T6, T7, R> f) {
-        final Map<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> cache = new ConcurrentHashMap<>();
-        final Function1<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> tupled = f.tupled();
-        return (t1, t2, t3, t4, t5, t6, t7) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5, t6, t7), tupled::apply);
-    }
-
-    /**
      * Applies this function to 7 arguments and returns the result.
      *
      * @param t1 argument 1
@@ -189,6 +168,13 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
     @Override
     default Function7<T7, T6, T5, T4, T3, T2, T1, R> reversed() {
         return (t7, t6, t5, t4, t3, t2, t1) -> apply(t1, t2, t3, t4, t5, t6, t7);
+    }
+
+    @Override
+    default Function7<T1, T2, T3, T4, T5, T6, T7, R> memoized() {
+        final Map<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> cache = new ConcurrentHashMap<>();
+        final Function1<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> tupled = tupled();
+        return (t1, t2, t3, t4, t5, t6, t7) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5, t6, t7), tupled::apply);
     }
 
     /**

--- a/src-gen/main/java/javaslang/Function8.java
+++ b/src-gen/main/java/javaslang/Function8.java
@@ -57,28 +57,6 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<R> {
     }
 
     /**
-     * Returns a memoizing function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     *
-     * @param <R> return type
-     * @param <T1> 1st argument
-     * @param <T2> 2nd argument
-     * @param <T3> 3rd argument
-     * @param <T4> 4th argument
-     * @param <T5> 5th argument
-     * @param <T6> 6th argument
-     * @param <T7> 7th argument
-     * @param <T8> 8th argument
-     * @param f a function
-     * @return a memoizing function
-     */
-    static <T1, T2, T3, T4, T5, T6, T7, T8, R> Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> memoize(Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> f) {
-        final Map<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> cache = new ConcurrentHashMap<>();
-        final Function1<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> tupled = f.tupled();
-        return (t1, t2, t3, t4, t5, t6, t7, t8) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5, t6, t7, t8), tupled::apply);
-    }
-
-    /**
      * Applies this function to 8 arguments and returns the result.
      *
      * @param t1 argument 1
@@ -210,6 +188,13 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<R> {
     @Override
     default Function8<T8, T7, T6, T5, T4, T3, T2, T1, R> reversed() {
         return (t8, t7, t6, t5, t4, t3, t2, t1) -> apply(t1, t2, t3, t4, t5, t6, t7, t8);
+    }
+
+    @Override
+    default Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> memoized() {
+        final Map<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> cache = new ConcurrentHashMap<>();
+        final Function1<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> tupled = tupled();
+        return (t1, t2, t3, t4, t5, t6, t7, t8) -> cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5, t6, t7, t8), tupled::apply);
     }
 
     /**

--- a/src/main/java/javaslang/λ.java
+++ b/src/main/java/javaslang/λ.java
@@ -80,7 +80,7 @@ public interface λ<R> extends Serializable {
     /**
      * Returns a curried version of this function.
      *
-     * @return A curried function equivalent to this.
+     * @return a curried function equivalent to this.
      */
     // generic argument count varies
     @SuppressWarnings("rawtypes")
@@ -89,16 +89,24 @@ public interface λ<R> extends Serializable {
     /**
      * Returns a tupled version of this function.
      *
-     * @return A tupled function equivalent to this.
+     * @return a tupled function equivalent to this.
      */
     λ<R> tupled();
 
     /**
      * Returns a reversed version of this function. This may be useful in a recursive context.
      *
-     * @return A reversed function equivalent to this.
+     * @return a reversed function equivalent to this.
      */
     λ<R> reversed();
+
+    /**
+     * Returns a memoizing version of this function, which computes the return value for given arguments only one time.
+     * On subsequent calls given the same arguments the memoized value is returned.
+     *
+     * @return a memoizing function equivalent to this.
+     */
+    λ<R> memoized();
 
     /**
      * Get reflective type information about lambda parameters and return type.


### PR DESCRIPTION
Includes some minor bug fixes towards javaslang/javaslang#264

In order to allow `null` arguments for (Checked)Function1, which is disallowed by the underlying cache of type `ConcurrentHashMap`, the single parameter is tupled. This should be arguably ok - memoization is considered to be used in cases it is time consuming to calculate a return value.

Also, allowing `null` as argument for (Checked)Function1 is consistent with the case of arity > 1, where `null` is allowed.