### PR TITLE
Additional Try functionality. Adding Consumers & value chaining.

### DIFF
--- a/src/main/java/javaslang/control/Failure.java
+++ b/src/main/java/javaslang/control/Failure.java
@@ -150,14 +150,8 @@ public final class Failure<T> implements Try<T>, Serializable {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <R> Failure<R> then(CheckedFunction1<T, R> f) {
+    public <R> Failure<R> mapTry(CheckedFunction1<T, R> f) {
         return (Failure<R>) this;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public Failure<T> thenRun(CheckedConsumer<T> f) {
-        return this;
     }
 
     @Override

--- a/src/main/java/javaslang/control/Failure.java
+++ b/src/main/java/javaslang/control/Failure.java
@@ -156,8 +156,8 @@ public final class Failure<T> implements Try<T>, Serializable {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Failure<Void> thenRun(CheckedConsumer<T> f) {
-        return (Failure<Void>) this;
+    public Failure<T> thenRun(CheckedConsumer<T> f) {
+        return this;
     }
 
     @Override

--- a/src/main/java/javaslang/control/Failure.java
+++ b/src/main/java/javaslang/control/Failure.java
@@ -150,8 +150,14 @@ public final class Failure<T> implements Try<T>, Serializable {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <R> Failure<R> mapTry(CheckedFunction1<T, R> f) {
+    public <R> Failure<R> mapTry(CheckedFunction1<? super T, ? extends R> f) {
         return (Failure<R>) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Failure<T> andThen(CheckedConsumer<? super T> f) {
+        return this;
     }
 
     @Override

--- a/src/main/java/javaslang/control/Failure.java
+++ b/src/main/java/javaslang/control/Failure.java
@@ -150,8 +150,14 @@ public final class Failure<T> implements Try<T>, Serializable {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <R> Failure<R> andThen(CheckedFunction1<T, R> f) {
+    public <R> Failure<R> then(CheckedFunction1<T, R> f) {
         return (Failure<R>) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Failure<Void> thenRun(CheckedConsumer<T> f) {
+        return (Failure<Void>) this;
     }
 
     @Override

--- a/src/main/java/javaslang/control/Success.java
+++ b/src/main/java/javaslang/control/Success.java
@@ -153,8 +153,14 @@ public final class Success<T> implements Try<T>, Serializable {
     }
 
     @Override
-    public <R> Try<R> mapTry(CheckedFunction1<T, R> f) {
+    public <R> Try<R> mapTry(CheckedFunction1<? super T, ? extends R> f) {
         return flatMap(value -> Try.of(() -> f.apply(value)));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Try<T> andThen(CheckedConsumer<? super T> consumer) {
+        return Try.run(() -> consumer.accept(value)).flatMap(ignored -> this);
     }
 
     @Override

--- a/src/main/java/javaslang/control/Success.java
+++ b/src/main/java/javaslang/control/Success.java
@@ -153,14 +153,8 @@ public final class Success<T> implements Try<T>, Serializable {
     }
 
     @Override
-    public <R> Try<R> then(CheckedFunction1<T, R> f) {
+    public <R> Try<R> mapTry(CheckedFunction1<T, R> f) {
         return flatMap(value -> Try.of(() -> f.apply(value)));
-    }
-
-    @Override
-    public Try<T> thenRun(CheckedConsumer<T> f) {
-        Try<Void> result = flatMap(value -> Try.run(() -> f.accept(value)));
-        return result.isSuccess() ? this : new Failure<T>(result.failed().get());
     }
 
     @Override

--- a/src/main/java/javaslang/control/Success.java
+++ b/src/main/java/javaslang/control/Success.java
@@ -158,8 +158,9 @@ public final class Success<T> implements Try<T>, Serializable {
     }
 
     @Override
-    public Try<Void> thenRun(CheckedConsumer<T> f) {
-        return flatMap(value -> Try.run(() -> f.accept(value)));
+    public Try<T> thenRun(CheckedConsumer<T> f) {
+        Try<Void> result = flatMap(value -> Try.run(() -> f.accept(value)));
+        return result.isSuccess() ? this : new Failure<T>(result.failed().get());
     }
 
     @Override

--- a/src/main/java/javaslang/control/Success.java
+++ b/src/main/java/javaslang/control/Success.java
@@ -153,8 +153,13 @@ public final class Success<T> implements Try<T>, Serializable {
     }
 
     @Override
-    public <R> Try<R> andThen(CheckedFunction1<T, R> f) {
+    public <R> Try<R> then(CheckedFunction1<T, R> f) {
         return flatMap(value -> Try.of(() -> f.apply(value)));
+    }
+
+    @Override
+    public Try<Void> thenRun(CheckedConsumer<T> f) {
+        return flatMap(value -> Try.run(() -> f.accept(value)));
     }
 
     @Override

--- a/src/main/java/javaslang/control/Try.java
+++ b/src/main/java/javaslang/control/Try.java
@@ -208,7 +208,7 @@ public interface Try<T> extends TraversableOnce<T> {
      *
      * <pre>
      * <code>
-     * Try.run(A::methodRef).then(B::methodRef).then(C::methodRef);
+     * Try.run(A::methodRef).andThen(B::methodRef).andThen(C::methodRef);
      * </code>
      * </pre>
      *
@@ -217,8 +217,8 @@ public interface Try<T> extends TraversableOnce<T> {
      * <pre>
      * <code>
      * Try.run(() -&gt; { doStuff(); })
-     *    .then(() -&gt; { doMoreStuff(); })
-     *    .then(() -&gt; { doEvenMoreStuff(); });
+     *    .andThen(() -&gt; { doMoreStuff(); })
+     *    .andThen(() -&gt; { doEvenMoreStuff(); });
      *
      * Try.run(() -&gt; {
      *     doStuff();
@@ -231,7 +231,7 @@ public interface Try<T> extends TraversableOnce<T> {
      * @param runnable A checked runnable
      * @return a new {@code Try}
      */
-    default Try<Void> then(CheckedRunnable runnable) {
+    default Try<Void> andThen(CheckedRunnable runnable) {
         return flatMap(ignored -> Try.run(runnable));
     }
 
@@ -246,8 +246,8 @@ public interface Try<T> extends TraversableOnce<T> {
      * <pre>
      * <code>
      * Try.of(() -&gt; 100)
-     *    .then(x -&gt; x + 100)
-     *    .then(x -&gt; x * 20);
+     *    .mapTry(x -&gt; x + 100)
+     *    .mapTry(x -&gt; x * 20);
      *
      * </code>
      * </pre>
@@ -255,28 +255,7 @@ public interface Try<T> extends TraversableOnce<T> {
      * @param f A checked function taking a single argument.
      * @return a new {@code Try}
      */
-    <R> Try<R> then(CheckedFunction1<T, R> f);
-
-    /**
-     * Runs the given checked consumer if this is a {@code Success},
-     * passing the result of the current expression to it.
-     * If this expression is a {@code Failure} then it'll return a new
-     * {@code Failure} of type T with the original exception.
-     *
-     * The main use case is chaining checked functions using method references:
-     *
-     * <pre>
-     * <code>
-     * Try.of(() -&gt; 100)
-     *    .thenRun(i -&gt; System.out.println(i));
-     *
-     * </code>
-     * </pre>
-     *
-     * @param f A checked consumer taking a single argument.
-     * @return a new {@code Try}
-     */
-    Try<T> thenRun(CheckedConsumer<T> f);
+    <R> Try<R> mapTry(CheckedFunction1<T, R> f);
 
     @Override
     boolean equals(Object o);

--- a/src/main/java/javaslang/control/Try.java
+++ b/src/main/java/javaslang/control/Try.java
@@ -208,7 +208,7 @@ public interface Try<T> extends TraversableOnce<T> {
      *
      * <pre>
      * <code>
-     * Try.run(A::methodRef).andThen(B::methodRef).andThen(C::methodRef);
+     * Try.run(A::methodRef).then(B::methodRef).then(C::methodRef);
      * </code>
      * </pre>
      *
@@ -217,8 +217,8 @@ public interface Try<T> extends TraversableOnce<T> {
      * <pre>
      * <code>
      * Try.run(() -&gt; { doStuff(); })
-     *    .andThen(() -&gt; { doMoreStuff(); })
-     *    .andThen(() -&gt; { doEvenMoreStuff(); });
+     *    .then(() -&gt; { doMoreStuff(); })
+     *    .then(() -&gt; { doEvenMoreStuff(); });
      *
      * Try.run(() -&gt; {
      *     doStuff();
@@ -231,7 +231,7 @@ public interface Try<T> extends TraversableOnce<T> {
      * @param runnable A checked runnable
      * @return a new {@code Try}
      */
-    default Try<Void> andThen(CheckedRunnable runnable) {
+    default Try<Void> then(CheckedRunnable runnable) {
         return flatMap(ignored -> Try.run(runnable));
     }
 
@@ -246,8 +246,8 @@ public interface Try<T> extends TraversableOnce<T> {
      * <pre>
      * <code>
      * Try.of(() -&gt; 100)
-     *    .andThen(x -&gt; x + 100)
-     *    .andThen(x -&gt; x * 20);
+     *    .then(x -&gt; x + 100)
+     *    .then(x -&gt; x * 20);
      *
      * </code>
      * </pre>
@@ -255,7 +255,28 @@ public interface Try<T> extends TraversableOnce<T> {
      * @param f A checked function taking a single argument.
      * @return a new {@code Try}
      */
-    <R> Try<R> andThen(CheckedFunction1<T, R> f);
+    <R> Try<R> then(CheckedFunction1<T, R> f);
+
+    /**
+     * Runs the given checked consumer if this is a {@code Success},
+     * passing the result of the current expression to it.
+     * If this expression is a {@code Failure} then it'll return a new
+     * {@code Failure} of type Void with the original exception.
+     *
+     * The main use case is chaining checked functions using method references:
+     *
+     * <pre>
+     * <code>
+     * Try.of(() -&gt; 100)
+     *    .thenRun(i -&gt; System.out.println(i));
+     *
+     * </code>
+     * </pre>
+     *
+     * @param f A checked consumer taking a single argument.
+     * @return a new {@code Try}
+     */
+    Try<Void> thenRun(CheckedConsumer<T> f);
 
     @Override
     boolean equals(Object o);
@@ -278,6 +299,22 @@ public interface Try<T> extends TraversableOnce<T> {
          * @throws Throwable if an error occurs
          */
         void run() throws Throwable;
+    }
+
+    /**
+     * A {@linkplain java.util.function.Consumer} which may throw.
+     *
+     * @param <R> the type of value supplied to this consumer.
+     */
+    @FunctionalInterface
+    interface CheckedConsumer<R> {
+
+        /**
+         * Performs side-effects.
+         *
+         * @throws Throwable if an error occurs
+         */
+        void accept(R value) throws Throwable;
     }
 
     /**

--- a/src/main/java/javaslang/control/Try.java
+++ b/src/main/java/javaslang/control/Try.java
@@ -276,7 +276,7 @@ public interface Try<T> extends TraversableOnce<T> {
      * @param f A checked consumer taking a single argument.
      * @return a new {@code Try}
      */
-    Try<Void> thenRun(CheckedConsumer<T> f);
+    Try<T> thenRun(CheckedConsumer<T> f);
 
     @Override
     boolean equals(Object o);

--- a/src/main/java/javaslang/control/Try.java
+++ b/src/main/java/javaslang/control/Try.java
@@ -255,7 +255,28 @@ public interface Try<T> extends TraversableOnce<T> {
      * @param f A checked function taking a single argument.
      * @return a new {@code Try}
      */
-    <R> Try<R> mapTry(CheckedFunction1<T, R> f);
+    <R> Try<R> mapTry(CheckedFunction1<? super T, ? extends R> f);
+
+    /**
+     * Runs the given checked consumer if this is a {@code Success},
+     * passing the result of the current expression to it.
+     * If this expression is a {@code Failure} then it'll return a new
+     * {@code Failure} of type Void with the original exception.
+     *
+     * The main use case is chaining checked functions using method references:
+     *
+     * <pre>
+     * <code>
+     * Try.of(() -&gt; 100)
+     *    .andThen(i -&gt; System.out.println(i));
+     *
+     * </code>
+     * </pre>
+     *
+     * @param consumer A checked consumer taking a single argument.
+     * @return a new {@code Try}
+     */
+    Try<T> andThen(CheckedConsumer<? super T> consumer);
 
     @Override
     boolean equals(Object o);

--- a/src/main/java/javaslang/control/Try.java
+++ b/src/main/java/javaslang/control/Try.java
@@ -261,7 +261,7 @@ public interface Try<T> extends TraversableOnce<T> {
      * Runs the given checked consumer if this is a {@code Success},
      * passing the result of the current expression to it.
      * If this expression is a {@code Failure} then it'll return a new
-     * {@code Failure} of type Void with the original exception.
+     * {@code Failure} of type T with the original exception.
      *
      * The main use case is chaining checked functions using method references:
      *

--- a/src/test/java/javaslang/TypeConsistencyTest.java
+++ b/src/test/java/javaslang/TypeConsistencyTest.java
@@ -44,6 +44,7 @@ public class TypeConsistencyTest {
             "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.map(java.util.function.Function)",
             "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.peek(java.util.function.Consumer)",
             "javaslang.control.Success//public default javaslang.control.Try javaslang.control.Try.andThen(javaslang.control.Try$CheckedRunnable)",
+            "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.andThen(javaslang.control.Try$CheckedConsumer)",
             "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.mapTry(javaslang.CheckedFunction1)",
 
             // control.None

--- a/src/test/java/javaslang/TypeConsistencyTest.java
+++ b/src/test/java/javaslang/TypeConsistencyTest.java
@@ -34,7 +34,7 @@ public class TypeConsistencyTest {
             "javaslang.control.Failure//public abstract javaslang.control.Try javaslang.control.Try.failed()",
             "javaslang.control.Failure//public default javaslang.control.Try javaslang.control.Try.flatten(java.util.function.Function)",
             "javaslang.control.Failure//public abstract javaslang.control.Try javaslang.control.Try.map(java.util.function.Function)",
-            "javaslang.control.Failure//public default javaslang.control.Try javaslang.control.Try.then(javaslang.control.Try$CheckedRunnable)",
+            "javaslang.control.Failure//public default javaslang.control.Try javaslang.control.Try.andThen(javaslang.control.Try$CheckedRunnable)",
 
             // control.Success
             "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.failed()",
@@ -43,9 +43,8 @@ public class TypeConsistencyTest {
             "javaslang.control.Success//public default javaslang.control.Try javaslang.control.Try.flatten(java.util.function.Function)",
             "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.map(java.util.function.Function)",
             "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.peek(java.util.function.Consumer)",
-            "javaslang.control.Success//public default javaslang.control.Try javaslang.control.Try.then(javaslang.control.Try$CheckedRunnable)",
-            "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.then(javaslang.CheckedFunction1)",
-            "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.thenRun(javaslang.control.Try$CheckedConsumer)",
+            "javaslang.control.Success//public default javaslang.control.Try javaslang.control.Try.andThen(javaslang.control.Try$CheckedRunnable)",
+            "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.mapTry(javaslang.CheckedFunction1)",
 
             // control.None
             "javaslang.control.None//public default javaslang.control.Option javaslang.control.Option.filter(java.util.function.Predicate)",

--- a/src/test/java/javaslang/TypeConsistencyTest.java
+++ b/src/test/java/javaslang/TypeConsistencyTest.java
@@ -34,7 +34,7 @@ public class TypeConsistencyTest {
             "javaslang.control.Failure//public abstract javaslang.control.Try javaslang.control.Try.failed()",
             "javaslang.control.Failure//public default javaslang.control.Try javaslang.control.Try.flatten(java.util.function.Function)",
             "javaslang.control.Failure//public abstract javaslang.control.Try javaslang.control.Try.map(java.util.function.Function)",
-            "javaslang.control.Failure//public default javaslang.control.Try javaslang.control.Try.andThen(javaslang.control.Try$CheckedRunnable)",
+            "javaslang.control.Failure//public default javaslang.control.Try javaslang.control.Try.then(javaslang.control.Try$CheckedRunnable)",
 
             // control.Success
             "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.failed()",
@@ -43,8 +43,9 @@ public class TypeConsistencyTest {
             "javaslang.control.Success//public default javaslang.control.Try javaslang.control.Try.flatten(java.util.function.Function)",
             "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.map(java.util.function.Function)",
             "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.peek(java.util.function.Consumer)",
-            "javaslang.control.Success//public default javaslang.control.Try javaslang.control.Try.andThen(javaslang.control.Try$CheckedRunnable)",
-            "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.andThen(javaslang.CheckedFunction1)",
+            "javaslang.control.Success//public default javaslang.control.Try javaslang.control.Try.then(javaslang.control.Try$CheckedRunnable)",
+            "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.then(javaslang.CheckedFunction1)",
+            "javaslang.control.Success//public abstract javaslang.control.Try javaslang.control.Try.thenRun(javaslang.control.Try$CheckedConsumer)",
 
             // control.None
             "javaslang.control.None//public default javaslang.control.Option javaslang.control.Option.filter(java.util.function.Predicate)",

--- a/src/test/java/javaslang/control/TryTest.java
+++ b/src/test/java/javaslang/control/TryTest.java
@@ -328,7 +328,7 @@ public class TryTest {
     public void shouldComposeFailureWithAndThenWhenFailing() {
         final Try<Void> actual = Try.run(() -> {
             throw new Error("err1");
-        }).andThen(() -> {
+        }).then(() -> {
             throw new Error("err2");
         });
         final Try<Void> expected = new Failure<>(new Error("err1"));
@@ -338,8 +338,8 @@ public class TryTest {
     @Test
     public void shouldChainSuccessWithAndThen() {
         final Try<Integer> actual = Try.of(() -> 100)
-                .andThen(x -> x + 100)
-                .andThen(x -> x + 50);
+                .then(x -> x + 100)
+                .then(x -> x + 50);
 
         final Try<Integer> expected = new Success<>(250);
         assertThat(actual).isEqualTo(expected);
@@ -348,9 +348,9 @@ public class TryTest {
     @Test
     public void shouldChainFailureWithAndThen() {
         final Try<Integer> actual = Try.of(() -> 100)
-                .andThen(x -> x + 100)
-                .andThen(x -> Integer.parseInt("aaa") + x)   //Throws exception.
-                .andThen(x -> x / 2);
+                .then(x -> x + 100)
+                .then(x -> Integer.parseInt("aaa") + x)   //Throws exception.
+                .then(x -> x / 2);
 
         final Try<Integer> expected = new Failure<>(new NumberFormatException("For input string: \"aaa\""));
         assertThat(actual).isEqualTo(expected);
@@ -543,7 +543,7 @@ public class TryTest {
     @Test
     public void shouldComposeSuccessWithAndThenWhenFailing() {
         final Try<Void> actual = Try.run(() -> {
-        }).andThen(() -> {
+        }).then(() -> {
             throw new Error("failure");
         });
         final Try<Void> expected = new Failure<>(new Error("failure"));
@@ -553,7 +553,7 @@ public class TryTest {
     @Test
     public void shouldComposeSuccessWithAndThenWhenSucceeding() {
         final Try<Void> actual = Try.run(() -> {
-        }).andThen(() -> {
+        }).then(() -> {
         });
         final Try<Void> expected = new Success<>(null);
         assertThat(actual).isEqualTo(expected);

--- a/src/test/java/javaslang/control/TryTest.java
+++ b/src/test/java/javaslang/control/TryTest.java
@@ -358,6 +358,30 @@ public class TryTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    public void shouldChainConsumableSuccessWithAndThen() {
+        final Try<Integer> actual = Try.of(() -> new ArrayList<Integer>())
+                .andThen(arr -> arr.add(10))
+                .andThen(arr -> arr.add(30))
+                .andThen(arr -> arr.add(20))
+                .mapTry(arr -> arr.get(1));
+
+        final Try<Integer> expected = new Success<>(30);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldChainConsumableFailureWithAndThen() {
+        final Try<Integer> actual = Try.of(() -> new ArrayList<Integer>())
+                .andThen(arr -> arr.add(10))
+                .andThen(arr -> arr.add(Integer.parseInt("aaa"))) //Throws exception.
+                .andThen(arr -> arr.add(20))
+                .mapTry(arr -> arr.get(1));
+
+        final Try<Integer> expected = new Failure<>(new NumberFormatException("For input string: \"aaa\""));
+        assertThat(actual).isEqualTo(expected);
+    }
+
     // peek
 
     @Test

--- a/src/test/java/javaslang/control/TryTest.java
+++ b/src/test/java/javaslang/control/TryTest.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -52,9 +51,7 @@ public class TryTest {
 
     @Test
     public void shouldReturnFailureWhenFlatteningSuccessThrows() {
-        assertThat(new Success<>(1).flatten(ignored -> {
-            throw new Error("error");
-        })).isEqualTo(new Failure<>(new Error("error")));
+        assertThat(new Success<>(1).flatten(ignored -> { throw new Error("error"); })).isEqualTo(new Failure<>(new Error("error")));
     }
 
     // -- exists
@@ -333,7 +330,7 @@ public class TryTest {
     public void shouldComposeFailureWithAndThenWhenFailing() {
         final Try<Void> actual = Try.run(() -> {
             throw new Error("err1");
-        }).then(() -> {
+        }).andThen(() -> {
             throw new Error("err2");
         });
         final Try<Void> expected = new Failure<>(new Error("err1"));
@@ -341,45 +338,21 @@ public class TryTest {
     }
 
     @Test
-    public void shouldChainSuccessWithAndThen() {
+    public void shouldChainSuccessWithMapTry() {
         final Try<Integer> actual = Try.of(() -> 100)
-                .then(x -> x + 100)
-                .then(x -> x + 50);
+                .mapTry(x -> x + 100)
+                .mapTry(x -> x + 50);
 
         final Try<Integer> expected = new Success<>(250);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
-    public void shouldChainFailureWithAndThen() {
+    public void shouldChainFailureWithMapTry() {
         final Try<Integer> actual = Try.of(() -> 100)
-                .then(x -> x + 100)
-                .then(x -> Integer.parseInt("aaa") + x)   //Throws exception.
-                .then(x -> x / 2);
-
-        final Try<Integer> expected = new Failure<>(new NumberFormatException("For input string: \"aaa\""));
-        assertThat(actual).isEqualTo(expected);
-    }
-
-    @Test
-    public void shouldChainConsumableSuccessWithThen() {
-        final Try<Integer> actual = Try.of(() -> new ArrayList<Integer>())
-                .thenRun(arr -> arr.add(10))
-                .thenRun(arr -> arr.add(30))
-                .thenRun(arr -> arr.add(20))
-                .then(arr -> arr.get(1));
-
-        final Try<Integer> expected = new Success<>(30);
-        assertThat(actual).isEqualTo(expected);
-    }
-
-    @Test
-    public void shouldChainConsumableFailureWithThen() {
-        final Try<Integer> actual = Try.of(() -> new ArrayList<Integer>())
-                .thenRun(arr -> arr.add(10))
-                .thenRun(arr -> arr.add(Integer.parseInt("aaa"))) //Throws exception.
-                .thenRun(arr -> arr.add(20))
-                .then(arr -> arr.get(1));
+                .mapTry(x -> x + 100)
+                .mapTry(x -> Integer.parseInt("aaa") + x)   //Throws exception.
+                .mapTry(x -> x / 2);
 
         final Try<Integer> expected = new Failure<>(new NumberFormatException("For input string: \"aaa\""));
         assertThat(actual).isEqualTo(expected);
@@ -572,7 +545,7 @@ public class TryTest {
     @Test
     public void shouldComposeSuccessWithAndThenWhenFailing() {
         final Try<Void> actual = Try.run(() -> {
-        }).then(() -> {
+        }).andThen(() -> {
             throw new Error("failure");
         });
         final Try<Void> expected = new Failure<>(new Error("failure"));
@@ -582,7 +555,7 @@ public class TryTest {
     @Test
     public void shouldComposeSuccessWithAndThenWhenSucceeding() {
         final Try<Void> actual = Try.run(() -> {
-        }).then(() -> {
+        }).andThen(() -> {
         });
         final Try<Void> expected = new Success<>(null);
         assertThat(actual).isEqualTo(expected);


### PR DESCRIPTION
I've made some slight additions to the Try class, allowing a bit more flexibility.

Firstly, updating "andThen" to handle Consumers, allowing methods that return Void to also be able to accept the previous value EG...

```java
Try.of(() -> 100).thenRun(val -> System.out.println(val))
```

Leading on from that, I thought it would be extremely useful to perform a Try.Run (to perform some type of side effect) without losing your previous value. Currently...

```java
Try.of(() -> 100)
  .thenRun(val -> System.out.println(val)) // Do something with val which returns void.
  .thenRun(val -> val + 100) // ** Doesn't work. The previous "theRun" has lost val.
```
So, I modified the "thenRun" to (on success) return the previous value (Try[T] instead of Try[Void] ). This allows us to collect the value and use it with both Consumers and Suppliers, eg...

```java
Try<Integer> actual = Try.of(() -> new ArrayList<Integer>()) // Returns a new array list.
                .thenRun(arr -> arr.add(10)) // Calls a methods which returns a void, passing the array down.
                .thenRun(arr -> arr.add(30)) // Same...
                .thenRun(arr -> arr.add(20)) // Same
                .thenRun(arr -> System.out.println(arr.size()) //Same
                .then(arr -> arr.get(1)); // Still have access to the array here after all the "thenRun"'s
```
I renamed "andThen" to "then", adding a "thenRun" as it seemed a bit shorter than "andThenRun"

I hope this functionality seems like a useful change. 

Thanks