### PR TITLE
Adding matching on a range of values.

### DIFF
--- a/src-gen/main/java/javaslang/control/Match.java
+++ b/src-gen/main/java/javaslang/control/Match.java
@@ -11,7 +11,6 @@ package javaslang.control;
 
 import java.io.Serializable;
 import java.lang.invoke.MethodType;
-import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -19,7 +18,6 @@ import java.util.function.Supplier;
 import javaslang.Function1;
 import javaslang.Lazy;
 import javaslang.collection.List;
-import javaslang.collection.Stream;
 
 /**
  * {@code Match} is a better switch for Java. Some characteristics of {@code Match} are:

--- a/src-gen/main/java/javaslang/control/Match.java
+++ b/src-gen/main/java/javaslang/control/Match.java
@@ -11,6 +11,7 @@ package javaslang.control;
 
 import java.io.Serializable;
 import java.lang.invoke.MethodType;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -18,6 +19,7 @@ import java.util.function.Supplier;
 import javaslang.Function1;
 import javaslang.Lazy;
 import javaslang.collection.List;
+import javaslang.collection.Stream;
 
 /**
  * {@code Match} is a better switch for Java. Some characteristics of {@code Match} are:
@@ -110,6 +112,21 @@ public interface Match<R> extends Function<Object, R> {
     static <T, R> Case<R> when(T prototype, Function1<? super T, ? extends R> function) {
         Objects.requireNonNull(function, "function is null");
         return Case.of(prototype, function);
+    }
+
+    /**
+     * Creates a {@code Match.Case} by a collection of values.
+     *
+     * @param <T> type of the prototype values
+     * @param <R> result type of the matched case
+     * @param prototypes A specific set of values to be matched
+     * @param function A function which is applied to the values given a match
+     * @return a new {@code Case}
+     * @throws NullPointerException if {@code function} is null
+     */
+    static <T, R> Case<R> whenIn(T[] prototypes, Function1<? super T, ? extends R> function) {
+        Objects.requireNonNull(function, "function is null");
+        return Case.of(prototypes, function);
     }
 
     /**
@@ -256,6 +273,12 @@ public interface Match<R> extends Function<Object, R> {
         }
 
         @Override
+        public <T> Case<R> whenIn(T[] prototypes, Function1<? super T, ? extends R> function) {
+            Objects.requireNonNull(function, "function is null");
+            return Case.of(prototypes, function);
+        }
+
+        @Override
         public Case<R> when(Function1<?, ? extends R> function) {
             Objects.requireNonNull(function, "function is null");
             return Case.of(function);
@@ -334,6 +357,10 @@ public interface Match<R> extends Function<Object, R> {
             return new Case<>(List.of(Case.when(new Some<>(prototype), function)));
         }
 
+        private static <T, R> Case<R> of(T[] prototypes, Function1<? super T, ? extends R> function) {
+            return new Case<>(List.of(prototypes).map(t -> Case.when(new Some<>(t), function)));
+        }
+
         @SuppressWarnings("overloads")
         private static <R> Case<R> of(Function1<?, ? extends R> function) {
             return new Case<>(List.of(Case.when(None.instance(), function)));
@@ -389,6 +416,13 @@ public interface Match<R> extends Function<Object, R> {
             Objects.requireNonNull(function, "function is null");
             final Function<Object, Option<R>> when = when(new Some<>(prototype), function);
             return new Case<>(cases.prepend(when));
+        }
+
+        @Override
+        public <T> Case<R> whenIn(T[] prototypes, Function1<? super T, ? extends R> function) {
+            Objects.requireNonNull(function, "function is null");
+            List<Function<Object, Option<R>>> when = List.of(prototypes).map(p -> when(new Some<>(p), function));
+            return new Case<>(cases.prependAll(when));
         }
 
         @Override
@@ -543,6 +577,17 @@ public interface Match<R> extends Function<Object, R> {
              * @throws NullPointerException if {@code function} is null
              */
             <T> HasCases<R> when(T prototype, Function1<? super T, ? extends R> function);
+
+            /**
+             * Creates a {@code Match.Case} by values.
+             *
+             * @param <T> type of the prototype value
+             * @param prototypes A specific value to be matched
+             * @param function A function which is applied to the value given a match
+             * @return a new {@code Case}
+             * @throws NullPointerException if {@code function} is null
+             */
+            <T> HasCases<R> whenIn(T[] prototypes, Function1<? super T, ? extends R> function);
 
             /**
              * Creates a {@code Match.Case} by type.

--- a/src/test/java/javaslang/control/MatchTest.java
+++ b/src/test/java/javaslang/control/MatchTest.java
@@ -452,6 +452,27 @@ public class MatchTest {
         assertThat(number).isEqualTo(new BigDecimal("1"));
     }
 
+    @Test
+    public void shouldAllowValidMatchWithMultiPrototypes() {
+        final String result = Match
+                .whenIn(new Integer[] { 1, 3, 5, 7 }, x -> "true")
+                .whenIn(new Integer[] { 2, 4, 6, 8 }, x -> "false")
+                .apply(6);
+
+        assertThat(result).isEqualTo("false");
+    }
+
+    @Test
+    public void shouldAllowInvalidMatchWithMultiPrototypes() {
+        final String result = Match
+                .whenIn(new Integer[] { 1, 3, 5, 7 }, x -> "true")
+                .whenIn(new Integer[] { 2, 4, 6, 8 }, x -> "false")
+                .otherwise("Not Found")
+                .apply(9);
+
+        assertThat(result).isEqualTo("Not Found");
+    }
+
     // -- lambda type
 
     @Test


### PR DESCRIPTION
Hi Daniel,

I've implemented the matching which I raised an issue for the other day. I think this looks like a reasonable way to do it. 

```java
        final String result = Match
                .whenIn(new Integer[] { 1, 3, 5, 7 }, x -> "true")
                .whenIn(new Integer[] { 2, 4, 6, 8 }, x -> "false")
                .when(10, x -> "other")
                .apply(6);

        assertThat(result).isEqualTo("false");
```
The array creation inside the "whenIn" is a bit more verbose than I would have liked. It's a pity I can't use ```T... prototypes``` as the argument for the method as it's not the last argument.

Maybe something along the lines of this would be nice...

        final String result = Match
                .whenIn(1, 3, 5, 7).then(x -> "true")
                .whenIn(2, 4, 6, 8).then(x -> "false")
                .when(10).then(x -> "other")
                .apply(6);

Although this would most likely require a significant re-work.

Thanks

Martin