### PR TITLE
Renamed Lazy.of(Supplier, Class) to Lazy.asVal(...)

### DIFF
--- a/src/main/java/javaslang/Lazy.java
+++ b/src/main/java/javaslang/Lazy.java
@@ -67,8 +67,6 @@ public final class Lazy<T> implements Supplier<T>, Value<T>, Serializable {
     /**
      * Creates a real _lazy value_ of type {@code T}, backed by a {@linkplain java.lang.reflect.Proxy} which delegates
      * to a {@code Lazy} instance.
-     * <p>
-     * Internally it behaves like {@link #of(Supplier)}.
      *
      * @param supplier A supplier
      * @param type     An interface
@@ -76,7 +74,7 @@ public final class Lazy<T> implements Supplier<T>, Value<T>, Serializable {
      * @return A new instance of T
      */
     @SuppressWarnings("unchecked")
-    public static <T> T of(Supplier<? extends T> supplier, Class<T> type) {
+    public static <T> T asVal(Supplier<? extends T> supplier, Class<T> type) {
         Objects.requireNonNull(supplier, "supplier is null");
         Objects.requireNonNull(type, "type is null");
         if (!type.isInterface()) {

--- a/src/test/java/javaslang/LazyTest.java
+++ b/src/test/java/javaslang/LazyTest.java
@@ -37,7 +37,7 @@ public class LazyTest {
 
         final String[] evaluated = new String[] { null };
 
-        final CharSequence chars = Lazy.of(() -> {
+        final CharSequence chars = Lazy.asVal(() -> {
             final String value = "Yay!";
             evaluated[0] = value;
             return value;
@@ -50,22 +50,22 @@ public class LazyTest {
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowWhenCreatingLazyProxyAndSupplierIsNull() {
-        Lazy.of(null, CharSequence.class);
+        Lazy.asVal(null, CharSequence.class);
     }
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowWhenCreatingLazyProxyAndTypeIsNull() {
-        Lazy.of(() -> "", null);
+        Lazy.asVal(() -> "", null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowWhenCreatingLazyProxyOfObjectType() {
-        Lazy.of(() -> "", String.class);
+        Lazy.asVal(() -> "", String.class);
     }
 
     @Test
-    public void shouldBehaveLikeLazyWhenCreatingAProxy() {
-        final CharSequence chars = Lazy.of(() -> "Yay!", CharSequence.class);
+    public void shouldBehaveLikeValueWhenCreatingProxy() {
+        final CharSequence chars = Lazy.asVal(() -> "Yay!", CharSequence.class);
         assertThat(chars.toString()).isEqualTo("Yay!");
     }
 


### PR DESCRIPTION
Closes #372 Add convenience method for creating lazy values

Adding a method `<T> T asVal(Supplier)` is not practicable. The Function type reflection does not recognize the interface type. Therefore we omit that method.

```java
// DEV-NOTE: We intentionally use Supplier<T> instead of Supplier<? extends T>, because we need the exact interface type.
@SuppressWarnings("unchecked")
public static <T> T asVal(Supplier<T> supplier) {
    Objects.requireNonNull(supplier, "supplier is null");
    final Class<T> type = (Class<T>) Function0.lift(supplier::get).getType().returnType();
    return Lazy.asVal(supplier, type);
}
```