### PR TITLE
Rewrote Match (Function)

### DIFF
--- a/src/main/java/javaslang/collection/Tree.java
+++ b/src/main/java/javaslang/collection/Tree.java
@@ -191,10 +191,10 @@ public interface Tree<T> extends Iterable<T> {
         } else {
             final Flatten flatten = new Flatten();
             return Match
-                    .when(Order.PRE_ORDER).then(ignored -> flatten.preOrder(this))
-                    .when(Order.IN_ORDER).then(ignored -> flatten.inOrder(this))
-                    .when(Order.POST_ORDER).then(ignored -> flatten.postOrder(this))
-                    .when(Order.LEVEL_ORDER).then(ignored -> flatten.levelOrder(this))
+                    .whenIs(Order.PRE_ORDER).then(() -> flatten.preOrder(this))
+                    .whenIs(Order.IN_ORDER).then(() -> flatten.inOrder(this))
+                    .whenIs(Order.POST_ORDER).then(() -> flatten.postOrder(this))
+                    .whenIs(Order.LEVEL_ORDER).then(() -> flatten.levelOrder(this))
                     .apply(order);
         }
     }

--- a/src/main/java/javaslang/control/Match.java
+++ b/src/main/java/javaslang/control/Match.java
@@ -5,13 +5,14 @@
  */
 package javaslang.control;
 
-import javaslang.*;
+import javaslang.Function1;
+import javaslang.Function2;
+import javaslang.Lazy;
+import javaslang.Value;
 import javaslang.collection.List;
 import javaslang.collection.Stream;
 import javaslang.collection.TraversableOnce;
 
-import java.lang.invoke.MethodType;
-import java.lang.invoke.SerializedLambda;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
@@ -121,6 +122,7 @@ public interface Match<R> extends Function<Object, R> {
     }
 
     static <T, R> MatchFunction.WhenApplicable<T, R> whenApplicable(Function1<? super T, ? extends R> function) {
+        Objects.requireNonNull(function, "function is null");
         return new MatchFunction.WhenApplicable<>(function, List.empty());
     }
 
@@ -129,14 +131,17 @@ public interface Match<R> extends Function<Object, R> {
     }
 
     static <R> MatchFunction.Otherwise<R> otherwise(Function<? super Object, ? extends R> function) {
+        Objects.requireNonNull(function, "function is null");
         return new MatchFunction.Otherwise<>(function, List.empty());
     }
 
     static <R> MatchFunction.Otherwise<R> otherwise(Supplier<? extends R> supplier) {
+        Objects.requireNonNull(supplier, "supplier is null");
         return new MatchFunction.Otherwise<>(ignored -> supplier.get(), List.empty());
     }
 
     static <R> MatchFunction.Otherwise<R> otherwiseThrow(Supplier<? extends RuntimeException> supplier) {
+        Objects.requireNonNull(supplier, "supplier is null");
         return new MatchFunction.Otherwise<>(ignored -> {
             throw supplier.get();
         }, List.empty());
@@ -252,6 +257,7 @@ public interface Match<R> extends Function<Object, R> {
                 }
 
                 public <T> When<T, R> when(Function1<? super T, Boolean> predicate) {
+                    Objects.requireNonNull(predicate, "predicate is null");
                     return new When<>(When.of(predicate), cases);
                 }
 
@@ -271,6 +277,7 @@ public interface Match<R> extends Function<Object, R> {
                 }
 
                 public <T> WhenApplicable<T, R> whenApplicable(Function1<? super T, ? extends R> function) {
+                    Objects.requireNonNull(function, "function is null");
                     return new WhenApplicable<>(function, cases);
                 }
 
@@ -279,14 +286,17 @@ public interface Match<R> extends Function<Object, R> {
                 }
 
                 public Otherwise<R> otherwise(Function<? super Object, ? extends R> function) {
+                    Objects.requireNonNull(function, "function is null");
                     return new Otherwise<>(function, cases);
                 }
 
                 public Otherwise<R> otherwise(Supplier<? extends R> supplier) {
+                    Objects.requireNonNull(supplier, "supplier is null");
                     return new Otherwise<>(ignored -> supplier.get(), cases);
                 }
 
                 public Otherwise<R> otherwiseThrow(Supplier<? extends RuntimeException> supplier) {
+                    Objects.requireNonNull(supplier, "supplier is null");
                     return new Otherwise<>(ignored -> {
                         throw supplier.get();
                     }, cases);

--- a/src/test/java/javaslang/collection/AbstractTraversableTest.java
+++ b/src/test/java/javaslang/collection/AbstractTraversableTest.java
@@ -449,7 +449,6 @@ public abstract class AbstractTraversableTest {
     public void shouldFlattenTraversableOfTraversablesAndPlainElementsGivenAFunction() {
         final Traversable<?> xs = of(1, of(2, 3));
         final Traversable<Integer> actual = xs
-                .peek(System.out::println)
                 .flatten(x -> Match
                         .whenApplicable((Traversable<Integer> ys) -> ys).thenApply()
                         .whenType(Integer.class).then(i -> of(i))

--- a/src/test/java/javaslang/control/MatchErrorTest.java
+++ b/src/test/java/javaslang/control/MatchErrorTest.java
@@ -25,7 +25,7 @@ public class MatchErrorTest {
     public void shouldReturnCorrectObjectWhenMatchingByFunction() {
         final Object obj = new Object();
         try {
-            Match.when(0).then(0).apply(obj);
+            Match.whenIs(0).then(0).apply(obj);
         } catch (MatchError matchError) {
             assertThat(matchError.getObject()).isEqualTo(obj);
         }

--- a/src/test/java/javaslang/control/MatchFunctionTest.java
+++ b/src/test/java/javaslang/control/MatchFunctionTest.java
@@ -16,7 +16,7 @@ public class MatchFunctionTest {
     @Test
     public void shouldMatchNullByValue() {
         final boolean actual = Match
-                .when(null).then(true)
+                .whenIs(null).then(true)
                 .apply(null);
         assertThat(actual).isTrue();
     }
@@ -24,50 +24,50 @@ public class MatchFunctionTest {
     @Test
     public void shouldMatchIntByValue() {
         final boolean actual = Match
-                .when(1).then(false)
-                .when(2).then(true)
+                .whenIs(1).then(false)
+                .whenIs(2).then(true)
                 .apply(2);
         assertThat(actual).isTrue();
     }
 
-    // whenIn(Onject...)
+    // whenIsIn(Onject...)
 
     @SuppressWarnings("unchecked")
     @Test
     public void shouldMatchNullByValueIn() {
         final boolean actual = Match
-                .whenIn((Object) null).then(true)
+                .whenIsIn((Object) null).then(true)
                 .apply(null);
         assertThat(actual).isTrue();
     }
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowWhenMatchNullVarargsByValueIn() {
-        Match.whenIn((Object[]) null).then(false)
+        Match.whenIsIn((Object[]) null).then(false)
                 .apply(null);
     }
 
     @Test
     public void shouldMatchIntByValueIn() {
         final boolean actual = Match
-                .whenIn(1, 2, 3).then(true)
+                .whenIsIn(1, 2, 3).then(true)
                 .apply(2);
         assertThat(actual).isTrue();
     }
 
-    // whenTrue(Predicate)
+    // when(Predicate)
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowWhenMatchNullVarargsByPredicate() {
-        Match.whenTrue(null).then(false)
+        Match.when(null).then(false)
                 .apply(null);
     }
 
     @Test
     public void shouldMatchEvenIntByPredicate() {
         final String divisibility = Match
-                .whenTrue((String s) -> true).then("oops")
-                .whenTrue((Integer i) -> i % 2 == 0).then("even")
+                .when((String s) -> true).then("oops")
+                .when((Integer i) -> i % 2 == 0).then("even")
                 .otherwise("odd")
                 .apply(0);
         assertThat(divisibility).isEqualTo("even");
@@ -91,25 +91,7 @@ public class MatchFunctionTest {
         assertThat(actual).isEqualTo("Number 1");
     }
 
-    // whenTypeIn(Class...)
-
-    @Test(expected = NullPointerException.class)
-    public void shouldThrowWhenMatchNullVarargsByTypeIn() {
-        Match.whenTypeIn((Class<?>[]) null).then(false)
-                .apply(null);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldMatchNumberByTypeIn() {
-        final Number number = 1;
-        final String actual = Match
-                .whenTypeIn(Byte.class, Integer.class).then(s -> "matched")
-                .apply(number);
-        assertThat(actual).isEqualTo("matched");
-    }
-
-    // whenApplicable(Function1)
+    // whenApplicable(Function)
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowWhenMatchNullByFunction() {
@@ -131,7 +113,7 @@ public class MatchFunctionTest {
     public void shouldMatchSuperTypeByValue() {
         final Option<Integer> option = Option.of(1);
         final boolean actual = Match
-                .when(option).then(true)
+                .whenIs(option).then(true)
                 .apply(new Some<>(1));
         assertThat(actual).isTrue();
     }
@@ -141,7 +123,7 @@ public class MatchFunctionTest {
     public void shouldMatchSuperTypeByValueIn() {
         final Option<Integer> option = Option.of(1);
         final boolean actual = Match
-                .whenIn(None.instance(), option).then(true)
+                .whenIsIn(None.instance(), option).then(true)
                 .apply(new Some<>(1));
         assertThat(actual).isTrue();
     }
@@ -149,7 +131,7 @@ public class MatchFunctionTest {
     @Test
     public void shouldMatchSuperTypeByPredicate() {
         final boolean actual = Match
-                .whenTrue((Option<?> o) -> true).then(true)
+                .when((Option<?> o) -> true).then(true)
                 .apply(new Some<>(1));
         assertThat(actual).isTrue();
     }
@@ -158,15 +140,6 @@ public class MatchFunctionTest {
     public void shouldMatchSuperTypeByType() {
         final boolean actual = Match
                 .whenType(Option.class).then(true)
-                .apply(new Some<>(1));
-        assertThat(actual).isTrue();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldMatchSuperTypeByTypeIn() {
-        final boolean actual = Match
-                .whenTypeIn(Boolean.class, Option.class).then(true)
                 .apply(new Some<>(1));
         assertThat(actual).isTrue();
     }
@@ -185,7 +158,7 @@ public class MatchFunctionTest {
     public void shouldMatchSubTypeByValue() {
         final Option<Integer> option = Option.of(1);
         final boolean actual = Match
-                .when(new Some<>(1)).then(true)
+                .whenIs(new Some<>(1)).then(true)
                 .apply(option);
         assertThat(actual).isTrue();
     }
@@ -195,7 +168,7 @@ public class MatchFunctionTest {
     public void shouldMatchSubTypeByValueIn() {
         final Option<Integer> option = Option.of(1);
         final boolean actual = Match
-                .whenIn(None.instance(), new Some<>(1)).then(true)
+                .whenIsIn(None.instance(), new Some<>(1)).then(true)
                 .apply(option);
         assertThat(actual).isTrue();
     }
@@ -204,7 +177,7 @@ public class MatchFunctionTest {
     public void shouldMatchSubTypeByPredicate() {
         final Option<Integer> option = Option.of(1);
         final boolean actual = Match
-                .whenTrue((Some<?> o) -> true).then(true)
+                .when((Some<?> o) -> true).then(true)
                 .apply(option);
         assertThat(actual).isTrue();
     }
@@ -214,16 +187,6 @@ public class MatchFunctionTest {
         final Option<Integer> option = Option.of(1);
         final boolean actual = Match
                 .whenType(Some.class).then(true)
-                .apply(option);
-        assertThat(actual).isTrue();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldMatchSubTypeByTypeIn() {
-        final Option<Integer> option = Option.of(1);
-        final boolean actual = Match
-                .whenTypeIn(Boolean.class, Some.class).then(true)
                 .apply(option);
         assertThat(actual).isTrue();
     }
@@ -241,19 +204,19 @@ public class MatchFunctionTest {
 
     @Test
     public void shouldApplyThenValueWhenMatched() {
-        final boolean actual = Match.when(1).then(true).apply(1);
+        final boolean actual = Match.whenIs(1).then(true).apply(1);
         assertThat(actual).isTrue();
     }
 
     @Test
     public void shouldApplyThenSupplierWhenMatched() {
-        final boolean actual = Match.when(1).then(() -> true).apply(1);
+        final boolean actual = Match.whenIs(1).then(() -> true).apply(1);
         assertThat(actual).isTrue();
     }
 
     @Test
     public void shouldApplyThenFunctionWhenMatched() {
-        final boolean actual = Match.when(true).then(b -> b).apply(true);
+        final boolean actual = Match.whenIs(true).then(b -> b).apply(true);
         assertThat(actual).isTrue();
     }
 
@@ -267,19 +230,19 @@ public class MatchFunctionTest {
 
     @Test
     public void shouldNotApplyThenValueWhenUnmatched() {
-        final boolean actual = Match.when(1).then(false).otherwise(true).apply(0);
+        final boolean actual = Match.whenIs(1).then(false).otherwise(true).apply(0);
         assertThat(actual).isTrue();
     }
 
     @Test
     public void shouldNotApplyThenSupplierWhenUnmatched() {
-        final boolean actual = Match.when(1).then(() -> false).otherwise(true).apply(0);
+        final boolean actual = Match.whenIs(1).then(() -> false).otherwise(true).apply(0);
         assertThat(actual).isTrue();
     }
 
     @Test
     public void shouldNotApplyThenFunctionWhenUnmatched() {
-        final boolean actual = Match.when(false).then(b -> b).otherwise(true).apply(true);
+        final boolean actual = Match.whenIs(false).then(b -> b).otherwise(true).apply(true);
         assertThat(actual).isTrue();
     }
 
@@ -294,8 +257,8 @@ public class MatchFunctionTest {
     @Test
     public void shouldTransportMatchedValue() {
         final boolean actual = Match
-                .when(1).then(true)
-                .when(1).then(false)
+                .whenIs(1).then(true)
+                .whenIs(1).then(false)
                 .apply(1);
         assertThat(actual).isTrue();
     }
@@ -303,8 +266,8 @@ public class MatchFunctionTest {
     @Test
     public void shouldTransportMatchedValueIn() {
         final boolean actual = Match
-                .whenIn(1).then(true)
-                .whenIn(1).then(false)
+                .whenIsIn(1).then(true)
+                .whenIsIn(1).then(false)
                 .apply(1);
         assertThat(actual).isTrue();
     }
@@ -312,8 +275,8 @@ public class MatchFunctionTest {
     @Test
     public void shouldTransportMatchedPredicate() {
         final boolean actual = Match
-                .whenTrue((Integer i) -> true).then(true)
-                .whenTrue((Integer i) -> true).then(false)
+                .when((Integer i) -> true).then(true)
+                .when((Integer i) -> true).then(false)
                 .apply(1);
         assertThat(actual).isTrue();
     }
@@ -323,16 +286,6 @@ public class MatchFunctionTest {
         final boolean actual = Match
                 .whenType(Integer.class).then(true)
                 .whenType(Integer.class).then(false)
-                .apply(1);
-        assertThat(actual).isTrue();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldTransportMatchedTypeIn() {
-        final boolean actual = Match
-                .whenTypeIn(Integer.class).then(true)
-                .whenTypeIn(Integer.class).then(false)
                 .apply(1);
         assertThat(actual).isTrue();
     }
@@ -351,8 +304,8 @@ public class MatchFunctionTest {
     @Test
     public void shouldTransportUnmatchedValue() {
         final boolean actual = Match
-                .when(0).then(false)
-                .when(1).then(true)
+                .whenIs(0).then(false)
+                .whenIs(1).then(true)
                 .apply(1);
         assertThat(actual).isTrue();
     }
@@ -360,8 +313,8 @@ public class MatchFunctionTest {
     @Test
     public void shouldTransportUnmatchedValueIn() {
         final boolean actual = Match
-                .whenIn(0).then(false)
-                .whenIn(1).then(true)
+                .whenIsIn(0).then(false)
+                .whenIsIn(1).then(true)
                 .apply(1);
         assertThat(actual).isTrue();
     }
@@ -369,8 +322,8 @@ public class MatchFunctionTest {
     @Test
     public void shouldTransportUnmatchedPredicate() {
         final boolean actual = Match
-                .whenTrue((Boolean b) -> false).then(false)
-                .whenTrue((Integer i) -> true).then(true)
+                .when((Boolean b) -> false).then(false)
+                .when((Integer i) -> true).then(true)
                 .apply(1);
         assertThat(actual).isTrue();
     }
@@ -380,16 +333,6 @@ public class MatchFunctionTest {
         final boolean actual = Match
                 .whenType(Boolean.class).then(false)
                 .whenType(Integer.class).then(true)
-                .apply(1);
-        assertThat(actual).isTrue();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldTransportUnmatchedTypeIn() {
-        final boolean actual = Match
-                .whenTypeIn(Boolean.class).then(false)
-                .whenTypeIn(Integer.class).then(true)
                 .apply(1);
         assertThat(actual).isTrue();
     }
@@ -408,8 +351,8 @@ public class MatchFunctionTest {
     @Test
     public void shouldMatchTypedResultByValue() {
         final Number actual = Match.as(Number.class)
-                .when(0).then(0.0d)
-                .when(1).then(1)
+                .whenIs(0).then(0.0d)
+                .whenIs(1).then(1)
                 .apply(1);
         assertThat(actual).isEqualTo(1);
     }
@@ -417,16 +360,16 @@ public class MatchFunctionTest {
     @Test(expected = MatchError.class)
     public void shouldMatchTypedResultByValueNegativeCase() {
         Match.as(Number.class)
-                .when(0).then(0.0d)
-                .when(1).then(1)
+                .whenIs(0).then(0.0d)
+                .whenIs(1).then(1)
                 .apply(-1);
     }
 
     @Test
     public void shouldMatchTypedResultByValueIn() {
         final Number actual = Match.as(Number.class)
-                .whenIn(0).then(0.0d)
-                .whenIn(1).then(1)
+                .whenIsIn(0).then(0.0d)
+                .whenIsIn(1).then(1)
                 .apply(1);
         assertThat(actual).isEqualTo(1);
     }
@@ -434,16 +377,16 @@ public class MatchFunctionTest {
     @Test(expected = MatchError.class)
     public void shouldMatchTypedResultByValueInNegativeCase() {
         Match.as(Number.class)
-                .whenIn(0).then(0.0d)
-                .whenIn(1).then(1)
+                .whenIsIn(0).then(0.0d)
+                .whenIsIn(1).then(1)
                 .apply(-1);
     }
 
     @Test
     public void shouldMatchTypedResultByPredicate() {
         final Number actual = Match.as(Number.class)
-                .whenTrue((Double d) -> true).then(0.0d)
-                .whenTrue((Integer i) -> true).then(1)
+                .when((Double d) -> true).then(0.0d)
+                .when((Integer i) -> true).then(1)
                 .apply(1);
         assertThat(actual).isEqualTo(1);
     }
@@ -451,8 +394,8 @@ public class MatchFunctionTest {
     @Test(expected = MatchError.class)
     public void shouldMatchTypedResultByPredicateNegativeCase() {
         Match.as(Number.class)
-                .whenTrue((Double d) -> true).then(0.0d)
-                .whenTrue((Integer i) -> true).then(1)
+                .when((Double d) -> true).then(0.0d)
+                .when((Integer i) -> true).then(1)
                 .apply("x");
     }
 
@@ -470,25 +413,6 @@ public class MatchFunctionTest {
         Match.as(Number.class)
                 .whenType(Boolean.class).then(0.0d)
                 .whenType(Integer.class).then(1)
-                .apply("x");
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldMatchTypedResultByTypeIn() {
-        final Number actual = Match.as(Number.class)
-                .whenTypeIn(Boolean.class).then(0.0d)
-                .whenTypeIn(Integer.class).then(1)
-                .apply(1);
-        assertThat(actual).isEqualTo(1);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test(expected = MatchError.class)
-    public void shouldMatchTypedResultByTypeInNegativeCase() {
-        Match.as(Number.class)
-                .whenTypeIn(Boolean.class).then(0.0d)
-                .whenTypeIn(Integer.class).then(1)
                 .apply("x");
     }
 
@@ -514,7 +438,7 @@ public class MatchFunctionTest {
     @Test
     public void shouldHandleOtherwiseValueOfMatched() {
         final boolean actual = Match
-                .when(1).then(true)
+                .whenIs(1).then(true)
                 .otherwise(false)
                 .apply(1);
         assertThat(actual).isTrue();
@@ -523,7 +447,7 @@ public class MatchFunctionTest {
     @Test
     public void shouldHandleOtherwiseValueOfUnmatched() {
         final boolean actual = Match
-                .when(0).then(false)
+                .whenIs(0).then(false)
                 .otherwise(true)
                 .apply(1);
         assertThat(actual).isTrue();
@@ -532,7 +456,7 @@ public class MatchFunctionTest {
     @Test
     public void shouldHandleOtherwiseSupplierOfMatched() {
         final boolean actual = Match
-                .when(1).then(true)
+                .whenIs(1).then(true)
                 .otherwise(() -> false)
                 .apply(1);
         assertThat(actual).isTrue();
@@ -541,7 +465,7 @@ public class MatchFunctionTest {
     @Test
     public void shouldHandleOtherwiseSupplierOfUnmatched() {
         final boolean actual = Match
-                .when(0).then(false)
+                .whenIs(0).then(false)
                 .otherwise(() -> true)
                 .apply(1);
         assertThat(actual).isTrue();
@@ -550,7 +474,7 @@ public class MatchFunctionTest {
     @Test
     public void shouldHandleOtherwiseFunctionOfMatched() {
         final boolean actual = Match
-                .when(1).then(true)
+                .whenIs(1).then(true)
                 .otherwise(ignored -> false)
                 .apply(1);
         assertThat(actual).isTrue();
@@ -559,7 +483,7 @@ public class MatchFunctionTest {
     @Test
     public void shouldHandleOtherwiseFunctionOfUnmatched() {
         final boolean actual = Match
-                .when(0).then(false)
+                .whenIs(0).then(false)
                 .otherwise(ignored -> true)
                 .apply(1);
         assertThat(actual).isTrue();


### PR DESCRIPTION
Towards #384 Rename Match [when -> whenIs], [whenIn -> whenIsIn] and [whenTrue -> when]
Towards #385 Add Match.when*().thenThrow(? extends RuntimeException)