### PR TITLE
Refactoring of Match (Monad and Function)

### DIFF
--- a/src/main/java/javaslang/Value.java
+++ b/src/main/java/javaslang/Value.java
@@ -9,6 +9,7 @@ import javaslang.control.None;
 import javaslang.control.Option;
 import javaslang.control.Some;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -23,34 +24,85 @@ import java.util.function.Supplier;
  */
 public interface Value<T> {
 
-    boolean isEmpty();
-
+    /**
+     * Gets the underlying value of throws if no value is present.
+     *
+     * @return the underlying value
+     * @throws java.util.NoSuchElementException if no value is defined
+     */
     T get();
 
+    /**
+     * Checks, this {@code Value} is empty, i.e. if the underlying value is absent.
+     *
+     * @return false, if no underlying value is present, true otherwise.
+     */
+    boolean isEmpty();
+
+    /**
+     * Checks, this {@code Value} is defined, i.e. if the underlying value is present.
+     *
+     * @return true, if an underlying value is present, false otherwise.
+     */
     default boolean isDefined() {
         return !isEmpty();
     }
 
+    /**
+     * Returns the underlying value if present, otherwise {@code other}.
+     *
+     * @param other An alternative value.
+     * @return A value of type {@code T}
+     */
     default T orElse(T other) {
         return isEmpty() ? other : get();
     }
 
+    /**
+     * Returns the underlying value if present, otherwise {@code other}.
+     *
+     * @param supplier An alternative value.
+     * @return A value of type {@code T}
+     * @throws NullPointerException if supplier is null
+     */
     default T orElseGet(Supplier<? extends T> supplier) {
+        Objects.requireNonNull(supplier, "supplier is null");
         return isEmpty() ? supplier.get() : get();
     }
 
-    default <X extends Throwable> T orElseThrow(Supplier<X> exceptionSupplier) throws X {
+    /**
+     * Returns the underlying value if present, otherwise throws {@code supplier.get()}.
+     *
+     * @param <X>      a Throwable type
+     * @param supplier An exception supplier.
+     * @return A value of type {@code T}
+     * @throws NullPointerException if supplier is null
+     * @throws X                    if no value is present
+     */
+    default <X extends Throwable> T orElseThrow(Supplier<X> supplier) throws X {
+        Objects.requireNonNull(supplier, "supplier is null");
         if (isEmpty()) {
-            throw exceptionSupplier.get();
+            throw supplier.get();
         } else {
             return get();
         }
     }
 
+    /**
+     * Converts this value to an {@link javaslang.control.Option}.
+     *
+     * @return {@code Some(value)} if a value is present <strong>(may be null)</strong>, {@code None} otherwise.
+     */
     default Option<T> toOption() {
         return isEmpty() ? None.instance() : new Some<>(get());
     }
 
+    /**
+     * Converts this value to an {@link java.util.Optional}.
+     *
+     * @return An empty {@code Optional}, if no value is present <string>or the value is null</string>,
+     * otherwise a non-empty {@code Option} containing the value.
+     */
     default Optional<T> toJavaOptional() {
         return isEmpty() ? Optional.empty() : Optional.ofNullable(get());
     }

--- a/src/main/java/javaslang/Value.java
+++ b/src/main/java/javaslang/Value.java
@@ -100,7 +100,7 @@ public interface Value<T> {
     /**
      * Converts this value to an {@link java.util.Optional}.
      *
-     * @return An empty {@code Optional}, if no value is present <string>or the value is null</string>,
+     * @return An empty {@code Optional}, if no value is present <strong>or the value is null</strong>,
      * otherwise a non-empty {@code Option} containing the value.
      */
     default Optional<T> toJavaOptional() {

--- a/src/main/java/javaslang/control/Match.java
+++ b/src/main/java/javaslang/control/Match.java
@@ -120,7 +120,10 @@ public interface Match<R> extends Function<Object, R> {
         return new MatchFunction.WhenUntyped<>(MatchFunction.When.type(type));
     }
 
-    // TODO: whenTypeIn
+    static MatchFunction.WhenUntyped<Object> whenTypeIn(Class<?>... types) {
+        Objects.requireNonNull(types, "types is null");
+        return new MatchFunction.WhenUntyped<>(MatchFunction.When.isIn(types));
+    }
 
     static <T, R> MatchFunction.WhenApplicable<T, R> whenApplicable(Function1<? super T, ? extends R> function) {
         Objects.requireNonNull(function, "function is null");
@@ -221,7 +224,8 @@ public interface Match<R> extends Function<Object, R> {
                 });
             }
 
-            // TODO: these private methods should move to the outer Monad interface with Java 9 because they are used by MatchFunction and MatchMonad
+            // NOTE: These private methods should move to the outer Monad interface with Java 9+ because they are used by MatchFunction and MatchMonad
+
             @SuppressWarnings("unchecked")
             private static <T> Predicate<? super Object> of(Function1<? super T, ? extends Boolean> predicate) {
                 final Class<?> type = predicate.getType().parameterType(0);
@@ -243,8 +247,6 @@ public interface Match<R> extends Function<Object, R> {
                 return value -> value != null && type.isAssignableFrom(value.getClass());
             }
 
-            @SuppressWarnings({ "unchecked", "varargs" })
-            @SafeVarargs
             private static <T> Predicate<? super Object> typeIn(Class<?>... types) {
                 return value -> Stream.of(types).findFirst(type -> type(type).test(value)).isDefined();
             }
@@ -286,7 +288,10 @@ public interface Match<R> extends Function<Object, R> {
                     return new When<>(When.type(type), cases);
                 }
 
-                // TODO: whenTypeIn
+                public When<Object, R> whenTypeIn(Class<?>... types) {
+                    Objects.requireNonNull(types, "types is null");
+                    return new When<>(When.typeIn(types), cases);
+                }
 
                 public <T> WhenApplicable<T, R> whenApplicable(Function1<? super T, ? extends R> function) {
                     Objects.requireNonNull(function, "function is null");
@@ -322,7 +327,6 @@ public interface Match<R> extends Function<Object, R> {
             private final Function1<? super T, ? extends R> function;
             private final List<Case<R>> cases;
 
-            @SuppressWarnings("unchecked")
             private WhenApplicable(Function1<? super T, ? extends R> function, List<Case<R>> cases) {
                 final Class<?> type = function.getType().parameterType(0);
                 this.predicate = When.type(type);
@@ -578,7 +582,6 @@ public interface Match<R> extends Function<Object, R> {
                     return new When<>(value, result, isMatching);
                 }
 
-                @SuppressWarnings({ "unchecked", "varargs" })
                 public When<T, R> whenTypeIn(Class<?>... types) {
                     Objects.requireNonNull(types, "types is null");
                     final boolean isMatching = isMatching(() -> MatchFunction.When.typeIn(types));

--- a/src/test/java/javaslang/collection/StreamTest.java
+++ b/src/test/java/javaslang/collection/StreamTest.java
@@ -139,6 +139,19 @@ public class StreamTest extends AbstractSeqTest {
         assertThat(Stream.from(Integer.MAX_VALUE).take(2)).isEqualTo(Stream.of(Integer.MAX_VALUE, Integer.MAX_VALUE + 1));
     }
 
+    // -- static from(long)
+
+    @Test
+    public void shouldGenerateLongStream() {
+        assertThat(Stream.from(-1L).take(3)).isEqualTo(Stream.of(-1L, 0L, 1L));
+    }
+
+    @Test
+    public void shouldGenerateTerminatingLongStream() {
+        //noinspection NumericOverflow
+        assertThat(Stream.from(Long.MAX_VALUE).take(2)).isEqualTo(Stream.of(Long.MAX_VALUE, Long.MAX_VALUE + 1));
+    }
+
     // -- static gen(Supplier)
 
     @Test

--- a/src/test/java/javaslang/control/MatchErrorTest.java
+++ b/src/test/java/javaslang/control/MatchErrorTest.java
@@ -15,7 +15,7 @@ public class MatchErrorTest {
     public void shouldReturnCorrectObjectWhenMatchingByMonad() {
         final Object obj = new Object();
         try {
-            Match.of(obj).when(0).then(0).get();
+            Match.of(obj).whenIs(0).then(0).get();
         } catch (MatchError matchError) {
             assertThat(matchError.getObject()).isEqualTo(obj);
         }

--- a/src/test/java/javaslang/control/MatchFunctionTest.java
+++ b/src/test/java/javaslang/control/MatchFunctionTest.java
@@ -5,8 +5,10 @@
  */
 package javaslang.control;
 
+import javaslang.Function1;
 import org.junit.Test;
 
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -73,6 +75,20 @@ public class MatchFunctionTest {
                 .otherwise("odd")
                 .apply(0);
         assertThat(divisibility).isEqualTo("even");
+    }
+
+    @Test
+    public void shouldMatchIntByMatcher() {
+        class Matcher {
+            Function1<? super Object, Boolean> is(Object prototype) {
+                return value -> value == prototype || (value != null && value.equals(prototype));
+            }
+        }
+        final Matcher matcher = new Matcher();
+        final boolean actual = Match
+                .when(matcher.is(0)).then(true)
+                .apply(0);
+        assertThat(actual).isTrue();
     }
 
     // whenType(Class)
@@ -499,7 +515,7 @@ public class MatchFunctionTest {
                     .whenApplicable((Double d) -> d).thenThrow(() -> new RuntimeException("case1"))
                     .whenApplicable((Integer i) -> i).thenThrow(() -> new RuntimeException("case2"))
                     .apply(1);
-        } catch(RuntimeException x) {
+        } catch (RuntimeException x) {
             assertThat(x.getMessage()).isEqualTo("case2");
         }
     }

--- a/src/test/java/javaslang/control/MatchFunctionTest.java
+++ b/src/test/java/javaslang/control/MatchFunctionTest.java
@@ -230,14 +230,14 @@ public class MatchFunctionTest {
         assertThat(actual).isTrue();
     }
 
-     @SuppressWarnings("unchecked")
-     @Test
-     public void shouldMatchSuperTypeByTypeIn() {
-         final boolean actual = Match
-                 .whenTypeIn(Boolean.class, Option.class).then(true)
-                 .apply(new Some<>(1));
-         assertThat(actual).isTrue();
-     }
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldMatchSuperTypeByTypeIn() {
+        final boolean actual = Match
+                .whenTypeIn(Boolean.class, Option.class).then(true)
+                .apply(new Some<>(1));
+        assertThat(actual).isTrue();
+    }
 
     @Test
     public void shouldMatchSuperTypeByFunction() {
@@ -463,15 +463,15 @@ public class MatchFunctionTest {
         assertThat(actual).isTrue();
     }
 
-     @SuppressWarnings("unchecked")
-     @Test
-     public void shouldTransportUnmatchedTypeIn() {
-         final boolean actual = Match
-                 .whenTypeIn(Boolean.class).then(false)
-                 .whenTypeIn(Integer.class).then(true)
-                 .apply(1);
-         assertThat(actual).isTrue();
-     }
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldTransportUnmatchedTypeIn() {
+        final boolean actual = Match
+                .whenTypeIn(Boolean.class).then(false)
+                .whenTypeIn(Integer.class).then(true)
+                .apply(1);
+        assertThat(actual).isTrue();
+    }
 
     @Test
     public void shouldTransportUnmatchedFunction() {

--- a/src/test/java/javaslang/control/MatchFunctionTest.java
+++ b/src/test/java/javaslang/control/MatchFunctionTest.java
@@ -8,7 +8,6 @@ package javaslang.control;
 import javaslang.Function1;
 import org.junit.Test;
 
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/javaslang/control/MatchFunctionTest.java
+++ b/src/test/java/javaslang/control/MatchFunctionTest.java
@@ -34,6 +34,11 @@ public class MatchFunctionTest {
         assertThat(actual).isTrue();
     }
 
+    @Test(expected = RuntimeException.class)
+    public void shouldMatchIntByValueAndThenThrow() {
+        Match.whenIs(1).thenThrow(RuntimeException::new).apply(1);
+    }
+
     // whenIsIn(Onject...)
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/javaslang/control/MatchFunctionTest.java
+++ b/src/test/java/javaslang/control/MatchFunctionTest.java
@@ -113,6 +113,24 @@ public class MatchFunctionTest {
         assertThat(actual).isEqualTo("Number 1");
     }
 
+    // whenTypeIn(Class...)
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowWhenMatchNullVarargsByTypeIn() {
+        Match.whenTypeIn((Class<?>[]) null).then(false)
+                .apply(null);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldMatchNumberByTypeIn() {
+        final Number number = 1;
+        final String actual = Match
+                .whenTypeIn(Byte.class, Integer.class).then(s -> "matched")
+                .apply(number);
+        assertThat(actual).isEqualTo("matched");
+    }
+
     // whenApplicable(Function)
 
     @Test(expected = NullPointerException.class)
@@ -212,6 +230,15 @@ public class MatchFunctionTest {
         assertThat(actual).isTrue();
     }
 
+     @SuppressWarnings("unchecked")
+     @Test
+     public void shouldMatchSuperTypeByTypeIn() {
+         final boolean actual = Match
+                 .whenTypeIn(Boolean.class, Option.class).then(true)
+                 .apply(new Some<>(1));
+         assertThat(actual).isTrue();
+     }
+
     @Test
     public void shouldMatchSuperTypeByFunction() {
         final boolean actual = Match
@@ -255,6 +282,16 @@ public class MatchFunctionTest {
         final Option<Integer> option = Option.of(1);
         final boolean actual = Match
                 .whenType(Some.class).then(true)
+                .apply(option);
+        assertThat(actual).isTrue();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldMatchSubTypeByTypeIn() {
+        final Option<Integer> option = Option.of(1);
+        final boolean actual = Match
+                .whenTypeIn(Boolean.class, Some.class).then(true)
                 .apply(option);
         assertThat(actual).isTrue();
     }
@@ -369,6 +406,16 @@ public class MatchFunctionTest {
         assertThat(actual).isTrue();
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldTransportMatchedTypeIn() {
+        final boolean actual = Match
+                .whenTypeIn(Integer.class).then(true)
+                .whenTypeIn(Integer.class).then(false)
+                .apply(1);
+        assertThat(actual).isTrue();
+    }
+
     @Test
     public void shouldTransportMatchedFunction() {
         final boolean actual = Match
@@ -415,6 +462,16 @@ public class MatchFunctionTest {
                 .apply(1);
         assertThat(actual).isTrue();
     }
+
+     @SuppressWarnings("unchecked")
+     @Test
+     public void shouldTransportUnmatchedTypeIn() {
+         final boolean actual = Match
+                 .whenTypeIn(Boolean.class).then(false)
+                 .whenTypeIn(Integer.class).then(true)
+                 .apply(1);
+         assertThat(actual).isTrue();
+     }
 
     @Test
     public void shouldTransportUnmatchedFunction() {

--- a/src/test/java/javaslang/control/MatchFunctionTest.java
+++ b/src/test/java/javaslang/control/MatchFunctionTest.java
@@ -8,9 +8,10 @@ package javaslang.control;
 import javaslang.Function1;
 import org.junit.Test;
 
+import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 public class MatchFunctionTest {
 
@@ -650,5 +651,32 @@ public class MatchFunctionTest {
         Match.whenIs(0).then(false)
                 .otherwiseThrow(RuntimeException::new)
                 .apply(1);
+    }
+
+    // thenThrow
+
+    @Test
+    public void shouldThrowLate() {
+        final Function<?, ?> match = Match.whenIs(null).thenThrow(RuntimeException::new);
+        try {
+            match.apply(null);
+            fail("nothing thrown");
+        } catch(RuntimeException x) {
+            // ok
+        }
+    }
+
+    @Test
+    public void shouldThrowLateWhenMultipleCases() {
+        final Function<?, ?> match = Match
+                .whenIs(0).then(0)
+                .whenIs(null).thenThrow(RuntimeException::new)
+                .otherwise(0);
+        try {
+            match.apply(null);
+            fail("nothing thrown");
+        } catch(RuntimeException x) {
+            // ok
+        }
     }
 }

--- a/src/test/java/javaslang/control/MatchMonadTest.java
+++ b/src/test/java/javaslang/control/MatchMonadTest.java
@@ -121,6 +121,35 @@ public class MatchMonadTest {
         assertThat(actual).isEqualTo("unknown");
     }
 
+    // whenTypeIn(Class...)
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowWhenMatchNullVarargsByTypeIn() {
+        Match.of(null)
+                .whenTypeIn((Class<?>[]) null).then(false)
+                .get();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldMatchNumberByTypeIn() {
+        final Number number = 1;
+        final String actual = Match.of(number)
+                .whenTypeIn(Byte.class, Integer.class).then(s -> "matched")
+                .orElse("unknown");
+        assertThat(actual).isEqualTo("matched");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldMatchOrElseByTypeIn() {
+        final Number number = 1;
+        final String actual = Match.of(number)
+                .whenTypeIn(Byte.class, Short.class).then(s -> "matched")
+                .orElse("unknown");
+        assertThat(actual).isEqualTo("unknown");
+    }
+
     // whenApplicable(Function1)
 
     @Test(expected = NullPointerException.class)
@@ -183,6 +212,15 @@ public class MatchMonadTest {
         assertThat(actual).isTrue();
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldMatchSuperTypeByTypeIn() {
+        final boolean actual = Match.of(new Some<>(1))
+                .whenTypeIn(Boolean.class, Option.class).then(true)
+                .get();
+        assertThat(actual).isTrue();
+    }
+
     @Test
     public void shouldMatchSuperTypeByFunction() {
         final boolean actual = Match.of(new Some<>(1))
@@ -226,6 +264,16 @@ public class MatchMonadTest {
         final Option<Integer> option = Option.of(1);
         final boolean actual = Match.of(option)
                 .whenType(Some.class).then(true)
+                .get();
+        assertThat(actual).isTrue();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldMatchSubTypeByTypeIn() {
+        final Option<Integer> option = Option.of(1);
+        final boolean actual = Match.of(option)
+                .whenTypeIn(Boolean.class, Some.class).then(true)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -370,6 +418,16 @@ public class MatchMonadTest {
         assertThat(actual).isTrue();
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldTransportMatchedTypeIn() {
+        final boolean actual = Match.of(1)
+                .whenTypeIn(Integer.class).then(true)
+                .whenTypeIn(Integer.class).then(false)
+                .get();
+        assertThat(actual).isTrue();
+    }
+
     @Test
     public void shouldTransportMatchedFunction() {
         final boolean actual = Match.of(1)
@@ -413,6 +471,16 @@ public class MatchMonadTest {
         final boolean actual = Match.of(1)
                 .whenType(Boolean.class).then(false)
                 .whenType(Integer.class).then(true)
+                .get();
+        assertThat(actual).isTrue();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldTransportUnmatchedTypeIn() {
+        final boolean actual = Match.of(1)
+                .whenTypeIn(Boolean.class).then(false)
+                .whenTypeIn(Integer.class).then(true)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -493,6 +561,25 @@ public class MatchMonadTest {
         Match.of("x").as(Number.class)
                 .whenType(Boolean.class).then(0.0d)
                 .whenType(Integer.class).then(1)
+                .get();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldMatchTypedResultByTypeIn() {
+        final Number actual = Match.of(1).as(Number.class)
+                .whenTypeIn(Boolean.class).then(0.0d)
+                .whenTypeIn(Integer.class).then(1)
+                .get();
+        assertThat(actual).isEqualTo(1);
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test(expected = MatchError.class)
+    public void shouldMatchTypedResultByTypeInNegativeCase() {
+        Match.of("x").as(Number.class)
+                .whenTypeIn(Boolean.class).then(0.0d)
+                .whenTypeIn(Integer.class).then(1)
                 .get();
     }
 

--- a/src/test/java/javaslang/control/MatchMonadTest.java
+++ b/src/test/java/javaslang/control/MatchMonadTest.java
@@ -8,8 +8,10 @@ package javaslang.control;
 import org.junit.Test;
 
 import java.util.Iterator;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.StrictAssertions.fail;
 
 public class MatchMonadTest {
 
@@ -769,5 +771,32 @@ public class MatchMonadTest {
                 .iterator();
         assertThat(actual.next()).isEqualTo(-1);
         assertThat(actual.hasNext()).isFalse();
+    }
+
+    // thenThrow
+
+    @Test
+    public void shouldThrowLate() {
+        final Match.MatchMonad<?> match = Match.of(null).whenIs(null).thenThrow(RuntimeException::new);
+        try {
+            match.get();
+            fail("nothing thrown");
+        } catch(RuntimeException x) {
+            // ok
+        }
+    }
+
+    @Test
+    public void shouldThrowLateWhenMultipleCases() {
+        final Match.MatchMonad<?> match = Match.of(null)
+                .whenIs(0).then(0)
+                .whenIs(null).thenThrow(RuntimeException::new)
+                .otherwise(0);
+        try {
+            match.get();
+            fail("nothing thrown");
+        } catch(RuntimeException x) {
+            // ok
+        }
     }
 }

--- a/src/test/java/javaslang/control/MatchMonadTest.java
+++ b/src/test/java/javaslang/control/MatchMonadTest.java
@@ -573,7 +573,7 @@ public class MatchMonadTest {
                 .get();
         assertThat(actual).isEqualTo(1);
     }
-    
+
     @SuppressWarnings("unchecked")
     @Test(expected = MatchError.class)
     public void shouldMatchTypedResultByTypeInNegativeCase() {

--- a/src/test/java/javaslang/control/MatchMonadTest.java
+++ b/src/test/java/javaslang/control/MatchMonadTest.java
@@ -18,7 +18,7 @@ public class MatchMonadTest {
     @Test
     public void shouldMatchNullByValue() {
         final boolean actual = Match.of(null)
-                .when(null).then(true)
+                .whenIs(null).then(true)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -26,8 +26,8 @@ public class MatchMonadTest {
     @Test
     public void shouldMatchIntByValue() {
         final boolean actual = Match.of(2)
-                .when(1).then(false)
-                .when(2).then(true)
+                .whenIs(1).then(false)
+                .whenIs(2).then(true)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -38,7 +38,7 @@ public class MatchMonadTest {
     @Test
     public void shouldMatchNullByValueIn() {
         final boolean actual = Match.of(null)
-                .whenIn((Object) null).then(true)
+                .whenIsIn((Object) null).then(true)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -46,14 +46,14 @@ public class MatchMonadTest {
     @Test(expected = NullPointerException.class)
     public void shouldThrowWhenMatchNullVarargsByValueIn() {
         Match.of(null)
-                .whenIn((Object[]) null).then(false)
+                .whenIsIn((Object[]) null).then(false)
                 .get();
     }
 
     @Test
     public void shouldMatchIntByValueIn() {
         final boolean actual = Match.of(2)
-                .whenIn(1, 2, 3).then(true)
+                .whenIsIn(1, 2, 3).then(true)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -61,7 +61,7 @@ public class MatchMonadTest {
     @Test
     public void shouldMatchOrElseByValueIn() {
         final boolean actual = Match.of(4)
-                .whenIn(1, 2, 3).then(false)
+                .whenIsIn(1, 2, 3).then(false)
                 .orElse(true);
         assertThat(actual).isTrue();
     }
@@ -71,15 +71,15 @@ public class MatchMonadTest {
     @Test(expected = NullPointerException.class)
     public void shouldThrowWhenMatchNullVarargsByPredicate() {
         Match.of(null)
-                .whenTrue(null).then(false)
+                .when(null).then(false)
                 .get();
     }
 
     @Test
     public void shouldMatchEvenIntByPredicate() {
         final String divisibility = Match.of(0)
-                .whenTrue((String s) -> true).then("oops")
-                .whenTrue((Integer i) -> i % 2 == 0).then("even")
+                .when((String s) -> true).then("oops")
+                .when((Integer i) -> i % 2 == 0).then("even")
                 .orElse("odd");
         assertThat(divisibility).isEqualTo("even");
     }
@@ -87,8 +87,8 @@ public class MatchMonadTest {
     @Test
     public void shouldMatchOddIntWithOrElseHavingUnmatchedPredicates() {
         final String divisibility = Match.of(1)
-                .whenTrue((String s) -> true).then("oops")
-                .whenTrue((Integer i) -> i % 2 == 0).then("even")
+                .when((String s) -> true).then("oops")
+                .when((Integer i) -> i % 2 == 0).then("even")
                 .orElse("odd");
         assertThat(divisibility).isEqualTo("odd");
     }
@@ -121,35 +121,6 @@ public class MatchMonadTest {
         assertThat(actual).isEqualTo("unknown");
     }
 
-    // whenTypeIn(Class...)
-
-    @Test(expected = NullPointerException.class)
-    public void shouldThrowWhenMatchNullVarargsByTypeIn() {
-        Match.of(null)
-                .whenTypeIn((Class<?>[]) null).then(false)
-                .get();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldMatchNumberByTypeIn() {
-        final Number number = 1;
-        final String actual = Match.of(number)
-                .whenTypeIn(Byte.class, Integer.class).then(s -> "matched")
-                .orElse("unknown");
-        assertThat(actual).isEqualTo("matched");
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldMatchOrElseByTypeIn() {
-        final Number number = 1;
-        final String actual = Match.of(number)
-                .whenTypeIn(Byte.class, Short.class).then(s -> "matched")
-                .orElse("unknown");
-        assertThat(actual).isEqualTo("unknown");
-    }
-
     // whenApplicable(Function1)
 
     @Test(expected = NullPointerException.class)
@@ -170,7 +141,7 @@ public class MatchMonadTest {
     @Test
     public void shouldMatchOrElseByFunction() {
         final boolean actual = Match.of(4)
-                .whenIn(1, 2, 3).then(false)
+                .whenIsIn(1, 2, 3).then(false)
                 .orElse(true);
         assertThat(actual).isTrue();
     }
@@ -181,7 +152,7 @@ public class MatchMonadTest {
     public void shouldMatchSuperTypeByValue() {
         final Option<Integer> option = Option.of(1);
         final boolean actual = Match.of(new Some<>(1))
-                .when(option).then(true)
+                .whenIs(option).then(true)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -191,7 +162,7 @@ public class MatchMonadTest {
     public void shouldMatchSuperTypeByValueIn() {
         final Option<Integer> option = Option.of(1);
         final boolean actual = Match.of(new Some<>(1))
-                .whenIn(None.instance(), option).then(true)
+                .whenIsIn(None.instance(), option).then(true)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -199,7 +170,7 @@ public class MatchMonadTest {
     @Test
     public void shouldMatchSuperTypeByPredicate() {
         final boolean actual = Match.of(new Some<>(1))
-                .whenTrue((Option<?> o) -> true).then(true)
+                .when((Option<?> o) -> true).then(true)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -208,15 +179,6 @@ public class MatchMonadTest {
     public void shouldMatchSuperTypeByType() {
         final boolean actual = Match.of(new Some<>(1))
                 .whenType(Option.class).then(true)
-                .get();
-        assertThat(actual).isTrue();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldMatchSuperTypeByTypeIn() {
-        final boolean actual = Match.of(new Some<>(1))
-                .whenTypeIn(Boolean.class, Option.class).then(true)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -235,7 +197,7 @@ public class MatchMonadTest {
     public void shouldMatchSubTypeByValue() {
         final Option<Integer> option = Option.of(1);
         final boolean actual = Match.of(option)
-                .when(new Some<>(1)).then(true)
+                .whenIs(new Some<>(1)).then(true)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -245,7 +207,7 @@ public class MatchMonadTest {
     public void shouldMatchSubTypeByValueIn() {
         final Option<Integer> option = Option.of(1);
         final boolean actual = Match.of(option)
-                .whenIn(None.instance(), new Some<>(1)).then(true)
+                .whenIsIn(None.instance(), new Some<>(1)).then(true)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -254,7 +216,7 @@ public class MatchMonadTest {
     public void shouldMatchSubTypeByPredicate() {
         final Option<Integer> option = Option.of(1);
         final boolean actual = Match.of(option)
-                .whenTrue((Some<?> o) -> true).then(true)
+                .when((Some<?> o) -> true).then(true)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -264,16 +226,6 @@ public class MatchMonadTest {
         final Option<Integer> option = Option.of(1);
         final boolean actual = Match.of(option)
                 .whenType(Some.class).then(true)
-                .get();
-        assertThat(actual).isTrue();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldMatchSubTypeByTypeIn() {
-        final Option<Integer> option = Option.of(1);
-        final boolean actual = Match.of(option)
-                .whenTypeIn(Boolean.class, Some.class).then(true)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -291,19 +243,19 @@ public class MatchMonadTest {
 
     @Test
     public void shouldApplyThenValueWhenMatched() {
-        final boolean actual = Match.of(1).when(1).then(true).get();
+        final boolean actual = Match.of(1).whenIs(1).then(true).get();
         assertThat(actual).isTrue();
     }
 
     @Test
     public void shouldApplyThenSupplierWhenMatched() {
-        final boolean actual = Match.of(1).when(1).then(() -> true).get();
+        final boolean actual = Match.of(1).whenIs(1).then(() -> true).get();
         assertThat(actual).isTrue();
     }
 
     @Test
     public void shouldApplyThenFunctionWhenMatched() {
-        final boolean actual = Match.of(true).when(true).then(b -> b).get();
+        final boolean actual = Match.of(true).whenIs(true).then(b -> b).get();
         assertThat(actual).isTrue();
     }
 
@@ -317,19 +269,19 @@ public class MatchMonadTest {
 
     @Test
     public void shouldNotApplyThenValueWhenUnmatched() {
-        final boolean actual = Match.of(0).when(1).then(false).orElse(true);
+        final boolean actual = Match.of(0).whenIs(1).then(false).orElse(true);
         assertThat(actual).isTrue();
     }
 
     @Test
     public void shouldNotApplyThenSupplierWhenUnmatched() {
-        final boolean actual = Match.of(0).when(1).then(() -> false).orElse(true);
+        final boolean actual = Match.of(0).whenIs(1).then(() -> false).orElse(true);
         assertThat(actual).isTrue();
     }
 
     @Test
     public void shouldNotApplyThenFunctionWhenUnmatched() {
-        final boolean actual = Match.of(true).when(false).then(b -> b).orElse(true);
+        final boolean actual = Match.of(true).whenIs(false).then(b -> b).orElse(true);
         assertThat(actual).isTrue();
     }
 
@@ -385,8 +337,8 @@ public class MatchMonadTest {
     @Test
     public void shouldTransportMatchedValue() {
         final boolean actual = Match.of(1)
-                .when(1).then(true)
-                .when(1).then(false)
+                .whenIs(1).then(true)
+                .whenIs(1).then(false)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -394,8 +346,8 @@ public class MatchMonadTest {
     @Test
     public void shouldTransportMatchedValueIn() {
         final boolean actual = Match.of(1)
-                .whenIn(1).then(true)
-                .whenIn(1).then(false)
+                .whenIsIn(1).then(true)
+                .whenIsIn(1).then(false)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -403,8 +355,8 @@ public class MatchMonadTest {
     @Test
     public void shouldTransportMatchedPredicate() {
         final boolean actual = Match.of(1)
-                .whenTrue((Integer i) -> true).then(true)
-                .whenTrue((Integer i) -> true).then(false)
+                .when((Integer i) -> true).then(true)
+                .when((Integer i) -> true).then(false)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -414,16 +366,6 @@ public class MatchMonadTest {
         final boolean actual = Match.of(1)
                 .whenType(Integer.class).then(true)
                 .whenType(Integer.class).then(false)
-                .get();
-        assertThat(actual).isTrue();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldTransportMatchedTypeIn() {
-        final boolean actual = Match.of(1)
-                .whenTypeIn(Integer.class).then(true)
-                .whenTypeIn(Integer.class).then(false)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -442,8 +384,8 @@ public class MatchMonadTest {
     @Test
     public void shouldTransportUnmatchedValue() {
         final boolean actual = Match.of(1)
-                .when(0).then(false)
-                .when(1).then(true)
+                .whenIs(0).then(false)
+                .whenIs(1).then(true)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -451,8 +393,8 @@ public class MatchMonadTest {
     @Test
     public void shouldTransportUnmatchedValueIn() {
         final boolean actual = Match.of(1)
-                .whenIn(0).then(false)
-                .whenIn(1).then(true)
+                .whenIsIn(0).then(false)
+                .whenIsIn(1).then(true)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -460,8 +402,8 @@ public class MatchMonadTest {
     @Test
     public void shouldTransportUnmatchedPredicate() {
         final boolean actual = Match.of(1)
-                .whenTrue((Boolean b) -> false).then(false)
-                .whenTrue((Integer i) -> true).then(true)
+                .when((Boolean b) -> false).then(false)
+                .when((Integer i) -> true).then(true)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -471,16 +413,6 @@ public class MatchMonadTest {
         final boolean actual = Match.of(1)
                 .whenType(Boolean.class).then(false)
                 .whenType(Integer.class).then(true)
-                .get();
-        assertThat(actual).isTrue();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldTransportUnmatchedTypeIn() {
-        final boolean actual = Match.of(1)
-                .whenTypeIn(Boolean.class).then(false)
-                .whenTypeIn(Integer.class).then(true)
                 .get();
         assertThat(actual).isTrue();
     }
@@ -499,8 +431,8 @@ public class MatchMonadTest {
     @Test
     public void shouldMatchTypedResultByValue() {
         final Number actual = Match.of(1).as(Number.class)
-                .when(0).then(0.0d)
-                .when(1).then(1)
+                .whenIs(0).then(0.0d)
+                .whenIs(1).then(1)
                 .get();
         assertThat(actual).isEqualTo(1);
     }
@@ -508,16 +440,16 @@ public class MatchMonadTest {
     @Test(expected = MatchError.class)
     public void shouldMatchTypedResultByValueNegativeCase() {
         Match.of(-1).as(Number.class)
-                .when(0).then(0.0d)
-                .when(1).then(1)
+                .whenIs(0).then(0.0d)
+                .whenIs(1).then(1)
                 .get();
     }
 
     @Test
     public void shouldMatchTypedResultByValueIn() {
         final Number actual = Match.of(1).as(Number.class)
-                .whenIn(0).then(0.0d)
-                .whenIn(1).then(1)
+                .whenIsIn(0).then(0.0d)
+                .whenIsIn(1).then(1)
                 .get();
         assertThat(actual).isEqualTo(1);
     }
@@ -525,16 +457,16 @@ public class MatchMonadTest {
     @Test(expected = MatchError.class)
     public void shouldMatchTypedResultByValueInNegativeCase() {
         Match.of(-1).as(Number.class)
-                .whenIn(0).then(0.0d)
-                .whenIn(1).then(1)
+                .whenIsIn(0).then(0.0d)
+                .whenIsIn(1).then(1)
                 .get();
     }
 
     @Test
     public void shouldMatchTypedResultByPredicate() {
         final Number actual = Match.of(1).as(Number.class)
-                .whenTrue((Double d) -> true).then(0.0d)
-                .whenTrue((Integer i) -> true).then(1)
+                .when((Double d) -> true).then(0.0d)
+                .when((Integer i) -> true).then(1)
                 .get();
         assertThat(actual).isEqualTo(1);
     }
@@ -542,8 +474,8 @@ public class MatchMonadTest {
     @Test(expected = MatchError.class)
     public void shouldMatchTypedResultByPredicateNegativeCase() {
         Match.of("x").as(Number.class)
-                .whenTrue((Double d) -> true).then(0.0d)
-                .whenTrue((Integer i) -> true).then(1)
+                .when((Double d) -> true).then(0.0d)
+                .when((Integer i) -> true).then(1)
                 .get();
     }
 
@@ -561,25 +493,6 @@ public class MatchMonadTest {
         Match.of("x").as(Number.class)
                 .whenType(Boolean.class).then(0.0d)
                 .whenType(Integer.class).then(1)
-                .get();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldMatchTypedResultByTypeIn() {
-        final Number actual = Match.of(1).as(Number.class)
-                .whenTypeIn(Boolean.class).then(0.0d)
-                .whenTypeIn(Integer.class).then(1)
-                .get();
-        assertThat(actual).isEqualTo(1);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test(expected = MatchError.class)
-    public void shouldMatchTypedResultByTypeInNegativeCase() {
-        Match.of("x").as(Number.class)
-                .whenTypeIn(Boolean.class).then(0.0d)
-                .whenTypeIn(Integer.class).then(1)
                 .get();
     }
 
@@ -605,7 +518,7 @@ public class MatchMonadTest {
     @Test
     public void shouldHandleOtherwiseValueOfMatched() {
         final boolean actual = Match.of(1)
-                .when(1).then(true)
+                .whenIs(1).then(true)
                 .otherwise(false)
                 .get();
         assertThat(actual).isTrue();
@@ -614,7 +527,7 @@ public class MatchMonadTest {
     @Test
     public void shouldHandleOtherwiseValueOfUnmatched() {
         final boolean actual = Match.of(1)
-                .when(0).then(false)
+                .whenIs(0).then(false)
                 .otherwise(true)
                 .get();
         assertThat(actual).isTrue();
@@ -623,7 +536,7 @@ public class MatchMonadTest {
     @Test
     public void shouldHandleOtherwiseSupplierOfMatched() {
         final boolean actual = Match.of(1)
-                .when(1).then(true)
+                .whenIs(1).then(true)
                 .otherwise(() -> false)
                 .get();
         assertThat(actual).isTrue();
@@ -632,7 +545,7 @@ public class MatchMonadTest {
     @Test
     public void shouldHandleOtherwiseSupplierOfUnmatched() {
         final boolean actual = Match.of(1)
-                .when(0).then(false)
+                .whenIs(0).then(false)
                 .otherwise(() -> true)
                 .get();
         assertThat(actual).isTrue();
@@ -641,7 +554,7 @@ public class MatchMonadTest {
     @Test
     public void shouldHandleOtherwiseFunctionOfMatched() {
         final boolean actual = Match.of(1)
-                .when(1).then(true)
+                .whenIs(1).then(true)
                 .otherwise(i -> i != 1)
                 .get();
         assertThat(actual).isTrue();
@@ -650,7 +563,7 @@ public class MatchMonadTest {
     @Test
     public void shouldHandleOtherwiseFunctionOfUnmatched() {
         final boolean actual = Match.of(1)
-                .when(0).then(false)
+                .whenIs(0).then(false)
                 .otherwise(i -> i == 1)
                 .get();
         assertThat(actual).isTrue();
@@ -661,8 +574,8 @@ public class MatchMonadTest {
     @Test
     public void shouldFlatMapMatched() {
         final int actual = Match.of(1)
-                .when(1).then(1)
-                .flatMap(i -> Match.of(i).when(1).then(2))
+                .whenIs(1).then(1)
+                .flatMap(i -> Match.of(i).whenIs(1).then(2))
                 .get();
         assertThat(actual).isEqualTo(2);
     }
@@ -670,8 +583,8 @@ public class MatchMonadTest {
     @Test
     public void shouldFlatMapUnmatched() {
         final int actual = Match.of(0)
-                .when(1).then(1)
-                .flatMap(i -> Match.of(i).when(1).then(1))
+                .whenIs(1).then(1)
+                .flatMap(i -> Match.of(i).whenIs(1).then(1))
                 .orElse(-1);
         assertThat(actual).isEqualTo(-1);
     }
@@ -679,9 +592,9 @@ public class MatchMonadTest {
     @Test
     public void shouldFlatMapOtherwise() {
         final int actual = Match.of(0)
-                .when(1).then(1)
+                .whenIs(1).then(1)
                 .otherwise(-1)
-                .flatMap(i -> Match.of(i).when(-1).then(2))
+                .flatMap(i -> Match.of(i).whenIs(-1).then(2))
                 .get();
         assertThat(actual).isEqualTo(2);
     }
@@ -689,8 +602,8 @@ public class MatchMonadTest {
     @Test
     public void shouldFlatttenMatched() {
         final int actual = Match.of(1)
-                .when(1).then(1)
-                .flatten(i -> Match.of(i).when(1).then(2))
+                .whenIs(1).then(1)
+                .flatten(i -> Match.of(i).whenIs(1).then(2))
                 .get();
         assertThat(actual).isEqualTo(2);
     }
@@ -698,8 +611,8 @@ public class MatchMonadTest {
     @Test
     public void shouldFlattenUnmatched() {
         final int actual = Match.of(0)
-                .when(1).then(1)
-                .flatten(i -> Match.of(i).when(1).then(1))
+                .whenIs(1).then(1)
+                .flatten(i -> Match.of(i).whenIs(1).then(1))
                 .orElse(-1);
         assertThat(actual).isEqualTo(-1);
     }
@@ -707,9 +620,9 @@ public class MatchMonadTest {
     @Test
     public void shouldFlattenOtherwise() {
         final int actual = Match.of(0)
-                .when(1).then(1)
+                .whenIs(1).then(1)
                 .otherwise(-1)
-                .flatten(i -> Match.of(i).when(-1).then(2))
+                .flatten(i -> Match.of(i).whenIs(-1).then(2))
                 .get();
         assertThat(actual).isEqualTo(2);
     }
@@ -717,7 +630,7 @@ public class MatchMonadTest {
     @Test
     public void shouldMapMatched() {
         final int actual = Match.of(1)
-                .when(1).then(1)
+                .whenIs(1).then(1)
                 .map(i -> i + 1)
                 .get();
         assertThat(actual).isEqualTo(2);
@@ -726,7 +639,7 @@ public class MatchMonadTest {
     @Test
     public void shouldMapUnmatched() {
         final int actual = Match.of(0)
-                .when(1).then(1)
+                .whenIs(1).then(1)
                 .map(i -> i + 1)
                 .orElse(-1);
         assertThat(actual).isEqualTo(-1);
@@ -735,7 +648,7 @@ public class MatchMonadTest {
     @Test
     public void shouldMapOtherwise() {
         final int actual = Match.of(0)
-                .when(1).then(1)
+                .whenIs(1).then(1)
                 .otherwise(-1)
                 .map(i -> i + 1)
                 .get();
@@ -747,7 +660,7 @@ public class MatchMonadTest {
     @Test
     public void shouldGetIteratorOfMatched() {
         final Iterator<Integer> actual = Match.of(1)
-                .when(1).then(1)
+                .whenIs(1).then(1)
                 .iterator();
         assertThat(actual.next()).isEqualTo(1);
         assertThat(actual.hasNext()).isFalse();
@@ -756,7 +669,7 @@ public class MatchMonadTest {
     @Test
     public void shouldGetIteratorOfUnmatched() {
         final Iterator<Integer> actual = Match.of(0)
-                .when(1).then(1)
+                .whenIs(1).then(1)
                 .iterator();
         assertThat(actual.hasNext()).isFalse();
     }
@@ -764,7 +677,7 @@ public class MatchMonadTest {
     @Test
     public void shouldGetIteratorOfOtherwise() {
         final Iterator<Integer> actual = Match.of(0)
-                .when(1).then(1)
+                .whenIs(1).then(1)
                 .otherwise(-1)
                 .iterator();
         assertThat(actual.next()).isEqualTo(-1);


### PR DESCRIPTION
Fixes #390 [Epic] Refactor the new Match DSL (Match.MatchFunction, Match.MatchMonad)

* Fixes #384 Rename Match [when -> whenIs], [whenIn -> whenIsIn] and [whenTrue -> when]
* Fixes #385 Add Match.when*().thenThrow(? extends RuntimeException)