### PR TITLE
Revert "Renamed Traversable.unit() to .cons()"

### DIFF
--- a/src/main/java/javaslang/collection/List.java
+++ b/src/main/java/javaslang/collection/List.java
@@ -1202,7 +1202,7 @@ public interface List<T> extends Seq<T>, Stack<T> {
     }
 
     @Override
-    default List<T> cons(Iterable<? extends T> iterable) {
+    default List<T> unit(Iterable<? extends T> iterable) {
         return List.ofAll(iterable);
     }
 

--- a/src/main/java/javaslang/collection/Queue.java
+++ b/src/main/java/javaslang/collection/Queue.java
@@ -911,7 +911,7 @@ public class Queue<T> implements Seq<T>, Serializable {
     }
 
     @Override
-    public Queue<T> cons(Iterable<? extends T> iterable) {
+    public Queue<T> unit(Iterable<? extends T> iterable) {
         return Queue.ofAll(iterable);
     }
 

--- a/src/main/java/javaslang/collection/Seq.java
+++ b/src/main/java/javaslang/collection/Seq.java
@@ -377,7 +377,7 @@ public interface Seq<T> extends Traversable<T>, IntFunction<T> {
     Seq<T> takeWhile(Predicate<? super T> predicate);
 
     @Override
-    Seq<T> cons(Iterable<? extends T> iterable);
+    Seq<T> unit(Iterable<? extends T> iterable);
 
     @Override
     <T1, T2> Tuple2<? extends Seq<T1>, ? extends Seq<T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper);

--- a/src/main/java/javaslang/collection/Stack.java
+++ b/src/main/java/javaslang/collection/Stack.java
@@ -612,7 +612,7 @@ public interface Stack<T> extends Seq<T> {
     Stack<T> takeWhile(Predicate<? super T> predicate);
 
     @Override
-    Stack<T> cons(Iterable<? extends T> iterable);
+    Stack<T> unit(Iterable<? extends T> iterable);
 
     @Override
     <T1, T2> Tuple2<? extends Stack<T1>, ? extends Stack<T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper);

--- a/src/main/java/javaslang/collection/Stream.java
+++ b/src/main/java/javaslang/collection/Stream.java
@@ -1143,7 +1143,7 @@ public interface Stream<T> extends Seq<T> {
     Stream<T> takeWhile(Predicate<? super T> predicate);
 
     @Override
-    default Stream<T> cons(Iterable<? extends T> iterable) {
+    default Stream<T> unit(Iterable<? extends T> iterable) {
         return Stream.ofAll(iterable);
     }
 

--- a/src/main/java/javaslang/collection/Traversable.java
+++ b/src/main/java/javaslang/collection/Traversable.java
@@ -38,7 +38,7 @@ import java.util.stream.StreamSupport;
  * <li>{@link #length()}</li>
  * <li>{@link #tail()}</li>
  * <li>{@link #tailOption()}</li>
- * <li>{@link #cons(Iterable)}</li>
+ * <li>{@link #unit(Iterable)}</li>
  * </ul>
  *
  * Conversion:
@@ -295,7 +295,7 @@ public interface Traversable<T> extends TraversableOnce<T> {
             }
         }
 
-        return new Util().checkSlice(this, cons(that));
+        return new Util().checkSlice(this, unit(that));
     }
 
     /**
@@ -1188,7 +1188,7 @@ public interface Traversable<T> extends TraversableOnce<T> {
      * @param iterable an {@code Iterable}
      * @return A new instance of this collection containing the elements of the given {@code iterable}.
      */
-    Traversable<T> cons(Iterable<? extends T> iterable);
+    Traversable<T> unit(Iterable<? extends T> iterable);
 
     /**
      * Unzips this elements by mapping this elements to pairs which are subsequentially split into to distinct


### PR DESCRIPTION
Reverts javaslang/javaslang#401

@mperry gave the hint that cons() is usually used in a different context. `unit` is perfectly fine.