### PR TITLE
Refactored Function*.getType(). Got interface/class design right.

### DIFF
--- a/generator/Generator.scala
+++ b/generator/Generator.scala
@@ -550,6 +550,7 @@ def generateMainClasses(): Unit = {
                * @param <R> the return type of the function
                * @since 2.0.0
                */
+              @SuppressWarnings("deprecation")
               final class Type$fullGenerics extends λ.AbstractType<R> {
 
                   private static final long serialVersionUID = 1L;

--- a/src-gen/main/java/javaslang/CheckedFunction0.java
+++ b/src-gen/main/java/javaslang/CheckedFunction0.java
@@ -126,6 +126,7 @@ public interface CheckedFunction0<R> extends λ<R> {
      * @param <R> the return type of the function
      * @since 2.0.0
      */
+    @SuppressWarnings("deprecation")
     final class Type<R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;

--- a/src-gen/main/java/javaslang/CheckedFunction0.java
+++ b/src-gen/main/java/javaslang/CheckedFunction0.java
@@ -9,7 +9,13 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
+import java.io.Serializable;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Objects;
+import javaslang.collection.List;
 import javaslang.control.Try;
 
 /**
@@ -115,38 +121,7 @@ public interface CheckedFunction0<R> extends λ<R> {
 
     @Override
     default Type<R> getType() {
-
-        final λ.Type<R> superType = λ.super.getType();
-
-        return new Type<R>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public Class<R> returnType() {
-                return superType.returnType();
-            }
-
-            @Override
-            public Class<?>[] parameterArray() {
-                return superType.parameterArray();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                return superType.equals(o);
-            }
-
-            @Override
-            public int hashCode() {
-                return superType.hashCode();
-            }
-
-            @Override
-            public String toString() {
-                return superType.toString();
-            }
-        };
+        return Type.of(this);
     }
 
     /**
@@ -156,9 +131,79 @@ public interface CheckedFunction0<R> extends λ<R> {
      *
      * @param <R> the return type of the function
      */
-    interface Type<R> extends λ.Type<R> {
+    final class Type<R> implements λ.Type<R>, Serializable {
 
-        long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
+        private final Class<R> returnType;
+        private final Class<?>[] parameterArray;
+
+        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
+                .map(c -> c.getName().hashCode())
+                .fold(1, (acc, i) -> acc * 31 + i)
+                * 31 + returnType().getName().hashCode()
+        );
+
+        private Type(Class<R> returnType, Class<?>[] parameterArray) {
+            this.returnType = returnType;
+            this.parameterArray = parameterArray;
+        }
+
+        @SuppressWarnings("unchecked")
+        private static <R> Type<R> of(CheckedFunction0<R> f) {
+            final MethodType methodType = getLambdaSignature(f);
+            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
+        }
+
+        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
+        private static MethodType getLambdaSignature(Serializable lambda) {
+            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
+            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
+        }
+
+        private static SerializedLambda getSerializedLambda(Serializable lambda) {
+            return Try.of(() -> {
+                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+                method.setAccessible(true);
+                return (SerializedLambda) method.invoke(lambda);
+            }).get();
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public Class<R> returnType() {
+            return returnType;
+        }
+
+        @Override
+        public Class<?>[] parameterArray() {
+            return parameterArray;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof Type) {
+                final Type<?> that = (Type<?>) o;
+                return this.hashCode() == that.hashCode()
+                        && this.returnType.equals(that.returnType)
+                        && Arrays.equals(this.parameterArray, that.parameterArray);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode.get();
+        }
+
+        @Override
+        public String toString() {
+            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
+                    + " -> "
+                    + returnType.getName();
+        }
     }
 }

--- a/src-gen/main/java/javaslang/CheckedFunction0.java
+++ b/src-gen/main/java/javaslang/CheckedFunction0.java
@@ -9,13 +9,7 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import java.io.Serializable;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.SerializedLambda;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Objects;
-import javaslang.collection.List;
 import javaslang.control.Try;
 
 /**
@@ -121,7 +115,7 @@ public interface CheckedFunction0<R> extends λ<R> {
 
     @Override
     default Type<R> getType() {
-        return Type.of(this);
+        return new Type<>(this);
     }
 
     /**
@@ -130,80 +124,16 @@ public interface CheckedFunction0<R> extends λ<R> {
      *
      *
      * @param <R> the return type of the function
+     * @since 2.0.0
      */
-    final class Type<R> implements λ.Type<R>, Serializable {
+    final class Type<R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;
 
-        private final Class<R> returnType;
-        private final Class<?>[] parameterArray;
-
-        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
-                .map(c -> c.getName().hashCode())
-                .fold(1, (acc, i) -> acc * 31 + i)
-                * 31 + returnType().getName().hashCode()
-        );
-
-        private Type(Class<R> returnType, Class<?>[] parameterArray) {
-            this.returnType = returnType;
-            this.parameterArray = parameterArray;
+        @SuppressWarnings("deprecation")
+        private Type(CheckedFunction0<R> λ) {
+            super(λ);
         }
 
-        @SuppressWarnings("unchecked")
-        private static <R> Type<R> of(CheckedFunction0<R> f) {
-            final MethodType methodType = getLambdaSignature(f);
-            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
-        }
-
-        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
-        private static MethodType getLambdaSignature(Serializable lambda) {
-            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
-            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
-        }
-
-        private static SerializedLambda getSerializedLambda(Serializable lambda) {
-            return Try.of(() -> {
-                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
-                method.setAccessible(true);
-                return (SerializedLambda) method.invoke(lambda);
-            }).get();
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Class<R> returnType() {
-            return returnType;
-        }
-
-        @Override
-        public Class<?>[] parameterArray() {
-            return parameterArray;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) {
-                return true;
-            } else if (o instanceof Type) {
-                final Type<?> that = (Type<?>) o;
-                return this.hashCode() == that.hashCode()
-                        && this.returnType.equals(that.returnType)
-                        && Arrays.equals(this.parameterArray, that.parameterArray);
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return hashCode.get();
-        }
-
-        @Override
-        public String toString() {
-            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
-                    + " -> "
-                    + returnType.getName();
-        }
     }
 }

--- a/src-gen/main/java/javaslang/CheckedFunction1.java
+++ b/src-gen/main/java/javaslang/CheckedFunction1.java
@@ -9,9 +9,15 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
+import java.io.Serializable;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import javaslang.collection.List;
 import javaslang.control.Try;
 
 /**
@@ -174,38 +180,7 @@ public interface CheckedFunction1<T1, R> extends λ<R> {
 
     @Override
     default Type<T1, R> getType() {
-
-        final λ.Type<R> superType = λ.super.getType();
-
-        return new Type<T1, R>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public Class<R> returnType() {
-                return superType.returnType();
-            }
-
-            @Override
-            public Class<?>[] parameterArray() {
-                return superType.parameterArray();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                return superType.equals(o);
-            }
-
-            @Override
-            public int hashCode() {
-                return superType.hashCode();
-            }
-
-            @Override
-            public String toString() {
-                return superType.toString();
-            }
-        };
+        return Type.of(this);
     }
 
     /**
@@ -216,13 +191,84 @@ public interface CheckedFunction1<T1, R> extends λ<R> {
      * @param <T1> the 1st parameter type of the function
      * @param <R> the return type of the function
      */
-    interface Type<T1, R> extends λ.Type<R> {
+    final class Type<T1, R> implements λ.Type<R>, Serializable {
 
-        long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
+
+        private final Class<R> returnType;
+        private final Class<?>[] parameterArray;
+
+        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
+                .map(c -> c.getName().hashCode())
+                .fold(1, (acc, i) -> acc * 31 + i)
+                * 31 + returnType().getName().hashCode()
+        );
+
+        private Type(Class<R> returnType, Class<?>[] parameterArray) {
+            this.returnType = returnType;
+            this.parameterArray = parameterArray;
+        }
 
         @SuppressWarnings("unchecked")
-        default Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray()[0];
+        private static <T1, R> Type<T1, R> of(CheckedFunction1<T1, R> f) {
+            final MethodType methodType = getLambdaSignature(f);
+            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
+        }
+
+        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
+        private static MethodType getLambdaSignature(Serializable lambda) {
+            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
+            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
+        }
+
+        private static SerializedLambda getSerializedLambda(Serializable lambda) {
+            return Try.of(() -> {
+                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+                method.setAccessible(true);
+                return (SerializedLambda) method.invoke(lambda);
+            }).get();
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public Class<R> returnType() {
+            return returnType;
+        }
+
+        @Override
+        public Class<?>[] parameterArray() {
+            return parameterArray;
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T1> parameterType1() {
+            return (Class<T1>) parameterArray[0];
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof Type) {
+                final Type<?, ?> that = (Type<?, ?>) o;
+                return this.hashCode() == that.hashCode()
+                        && this.returnType.equals(that.returnType)
+                        && Arrays.equals(this.parameterArray, that.parameterArray);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode.get();
+        }
+
+        @Override
+        public String toString() {
+            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
+                    + " -> "
+                    + returnType.getName();
         }
     }
 }

--- a/src-gen/main/java/javaslang/CheckedFunction1.java
+++ b/src-gen/main/java/javaslang/CheckedFunction1.java
@@ -186,6 +186,7 @@ public interface CheckedFunction1<T1, R> extends λ<R> {
      * @param <R> the return type of the function
      * @since 2.0.0
      */
+    @SuppressWarnings("deprecation")
     final class Type<T1, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;

--- a/src-gen/main/java/javaslang/CheckedFunction1.java
+++ b/src-gen/main/java/javaslang/CheckedFunction1.java
@@ -9,15 +9,9 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import java.io.Serializable;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.SerializedLambda;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import javaslang.collection.List;
 import javaslang.control.Try;
 
 /**
@@ -101,7 +95,7 @@ public interface CheckedFunction1<T1, R> extends λ<R> {
      * @return true, if this function is applicable to the given objects, false otherwise.
      */
     default boolean isApplicableTo(Object o1) {
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 (o1 == null || paramTypes[0].isAssignableFrom(o1.getClass()));
     }
@@ -114,7 +108,7 @@ public interface CheckedFunction1<T1, R> extends λ<R> {
      */
     default boolean isApplicableToType(Class<?> type1) {
         Objects.requireNonNull(type1, "type1 is null");
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 paramTypes[0].isAssignableFrom(type1);
     }
@@ -180,7 +174,7 @@ public interface CheckedFunction1<T1, R> extends λ<R> {
 
     @Override
     default Type<T1, R> getType() {
-        return Type.of(this);
+        return new Type<>(this);
     }
 
     /**
@@ -190,85 +184,20 @@ public interface CheckedFunction1<T1, R> extends λ<R> {
      *
      * @param <T1> the 1st parameter type of the function
      * @param <R> the return type of the function
+     * @since 2.0.0
      */
-    final class Type<T1, R> implements λ.Type<R>, Serializable {
+    final class Type<T1, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;
 
-        private final Class<R> returnType;
-        private final Class<?>[] parameterArray;
-
-        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
-                .map(c -> c.getName().hashCode())
-                .fold(1, (acc, i) -> acc * 31 + i)
-                * 31 + returnType().getName().hashCode()
-        );
-
-        private Type(Class<R> returnType, Class<?>[] parameterArray) {
-            this.returnType = returnType;
-            this.parameterArray = parameterArray;
-        }
-
-        @SuppressWarnings("unchecked")
-        private static <T1, R> Type<T1, R> of(CheckedFunction1<T1, R> f) {
-            final MethodType methodType = getLambdaSignature(f);
-            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
-        }
-
-        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
-        private static MethodType getLambdaSignature(Serializable lambda) {
-            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
-            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
-        }
-
-        private static SerializedLambda getSerializedLambda(Serializable lambda) {
-            return Try.of(() -> {
-                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
-                method.setAccessible(true);
-                return (SerializedLambda) method.invoke(lambda);
-            }).get();
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Class<R> returnType() {
-            return returnType;
-        }
-
-        @Override
-        public Class<?>[] parameterArray() {
-            return parameterArray;
+        @SuppressWarnings("deprecation")
+        private Type(CheckedFunction1<T1, R> λ) {
+            super(λ);
         }
 
         @SuppressWarnings("unchecked")
         public Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray[0];
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) {
-                return true;
-            } else if (o instanceof Type) {
-                final Type<?, ?> that = (Type<?, ?>) o;
-                return this.hashCode() == that.hashCode()
-                        && this.returnType.equals(that.returnType)
-                        && Arrays.equals(this.parameterArray, that.parameterArray);
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return hashCode.get();
-        }
-
-        @Override
-        public String toString() {
-            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
-                    + " -> "
-                    + returnType.getName();
+            return (Class<T1>) parameterTypes()[0];
         }
     }
 }

--- a/src-gen/main/java/javaslang/CheckedFunction2.java
+++ b/src-gen/main/java/javaslang/CheckedFunction2.java
@@ -182,6 +182,7 @@ public interface CheckedFunction2<T1, T2, R> extends λ<R> {
      * @param <R> the return type of the function
      * @since 2.0.0
      */
+    @SuppressWarnings("deprecation")
     final class Type<T1, T2, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;

--- a/src-gen/main/java/javaslang/CheckedFunction2.java
+++ b/src-gen/main/java/javaslang/CheckedFunction2.java
@@ -9,15 +9,9 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import java.io.Serializable;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.SerializedLambda;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import javaslang.collection.List;
 import javaslang.control.Try;
 
 /**
@@ -95,7 +89,7 @@ public interface CheckedFunction2<T1, T2, R> extends λ<R> {
      * @return true, if this function is applicable to the given objects, false otherwise.
      */
     default boolean isApplicableTo(Object o1, Object o2) {
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 (o1 == null || paramTypes[0].isAssignableFrom(o1.getClass())) &&
                 (o2 == null || paramTypes[1].isAssignableFrom(o2.getClass()));
@@ -111,7 +105,7 @@ public interface CheckedFunction2<T1, T2, R> extends λ<R> {
     default boolean isApplicableToTypes(Class<?> type1, Class<?> type2) {
         Objects.requireNonNull(type1, "type1 is null");
         Objects.requireNonNull(type2, "type2 is null");
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 paramTypes[0].isAssignableFrom(type1) &&
                 paramTypes[1].isAssignableFrom(type2);
@@ -175,7 +169,7 @@ public interface CheckedFunction2<T1, T2, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, R> getType() {
-        return Type.of(this);
+        return new Type<>(this);
     }
 
     /**
@@ -186,90 +180,25 @@ public interface CheckedFunction2<T1, T2, R> extends λ<R> {
      * @param <T1> the 1st parameter type of the function
      * @param <T2> the 2nd parameter type of the function
      * @param <R> the return type of the function
+     * @since 2.0.0
      */
-    final class Type<T1, T2, R> implements λ.Type<R>, Serializable {
+    final class Type<T1, T2, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;
 
-        private final Class<R> returnType;
-        private final Class<?>[] parameterArray;
-
-        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
-                .map(c -> c.getName().hashCode())
-                .fold(1, (acc, i) -> acc * 31 + i)
-                * 31 + returnType().getName().hashCode()
-        );
-
-        private Type(Class<R> returnType, Class<?>[] parameterArray) {
-            this.returnType = returnType;
-            this.parameterArray = parameterArray;
-        }
-
-        @SuppressWarnings("unchecked")
-        private static <T1, T2, R> Type<T1, T2, R> of(CheckedFunction2<T1, T2, R> f) {
-            final MethodType methodType = getLambdaSignature(f);
-            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
-        }
-
-        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
-        private static MethodType getLambdaSignature(Serializable lambda) {
-            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
-            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
-        }
-
-        private static SerializedLambda getSerializedLambda(Serializable lambda) {
-            return Try.of(() -> {
-                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
-                method.setAccessible(true);
-                return (SerializedLambda) method.invoke(lambda);
-            }).get();
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Class<R> returnType() {
-            return returnType;
-        }
-
-        @Override
-        public Class<?>[] parameterArray() {
-            return parameterArray;
+        @SuppressWarnings("deprecation")
+        private Type(CheckedFunction2<T1, T2, R> λ) {
+            super(λ);
         }
 
         @SuppressWarnings("unchecked")
         public Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray[0];
+            return (Class<T1>) parameterTypes()[0];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray[1];
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) {
-                return true;
-            } else if (o instanceof Type) {
-                final Type<?, ?, ?> that = (Type<?, ?, ?>) o;
-                return this.hashCode() == that.hashCode()
-                        && this.returnType.equals(that.returnType)
-                        && Arrays.equals(this.parameterArray, that.parameterArray);
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return hashCode.get();
-        }
-
-        @Override
-        public String toString() {
-            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
-                    + " -> "
-                    + returnType.getName();
+            return (Class<T2>) parameterTypes()[1];
         }
     }
 }

--- a/src-gen/main/java/javaslang/CheckedFunction3.java
+++ b/src-gen/main/java/javaslang/CheckedFunction3.java
@@ -9,15 +9,9 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import java.io.Serializable;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.SerializedLambda;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import javaslang.collection.List;
 import javaslang.control.Try;
 
 /**
@@ -99,7 +93,7 @@ public interface CheckedFunction3<T1, T2, T3, R> extends λ<R> {
      * @return true, if this function is applicable to the given objects, false otherwise.
      */
     default boolean isApplicableTo(Object o1, Object o2, Object o3) {
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 (o1 == null || paramTypes[0].isAssignableFrom(o1.getClass())) &&
                 (o2 == null || paramTypes[1].isAssignableFrom(o2.getClass())) &&
@@ -118,7 +112,7 @@ public interface CheckedFunction3<T1, T2, T3, R> extends λ<R> {
         Objects.requireNonNull(type1, "type1 is null");
         Objects.requireNonNull(type2, "type2 is null");
         Objects.requireNonNull(type3, "type3 is null");
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 paramTypes[0].isAssignableFrom(type1) &&
                 paramTypes[1].isAssignableFrom(type2) &&
@@ -195,7 +189,7 @@ public interface CheckedFunction3<T1, T2, T3, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, R> getType() {
-        return Type.of(this);
+        return new Type<>(this);
     }
 
     /**
@@ -207,95 +201,30 @@ public interface CheckedFunction3<T1, T2, T3, R> extends λ<R> {
      * @param <T2> the 2nd parameter type of the function
      * @param <T3> the 3rd parameter type of the function
      * @param <R> the return type of the function
+     * @since 2.0.0
      */
-    final class Type<T1, T2, T3, R> implements λ.Type<R>, Serializable {
+    final class Type<T1, T2, T3, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;
 
-        private final Class<R> returnType;
-        private final Class<?>[] parameterArray;
-
-        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
-                .map(c -> c.getName().hashCode())
-                .fold(1, (acc, i) -> acc * 31 + i)
-                * 31 + returnType().getName().hashCode()
-        );
-
-        private Type(Class<R> returnType, Class<?>[] parameterArray) {
-            this.returnType = returnType;
-            this.parameterArray = parameterArray;
-        }
-
-        @SuppressWarnings("unchecked")
-        private static <T1, T2, T3, R> Type<T1, T2, T3, R> of(CheckedFunction3<T1, T2, T3, R> f) {
-            final MethodType methodType = getLambdaSignature(f);
-            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
-        }
-
-        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
-        private static MethodType getLambdaSignature(Serializable lambda) {
-            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
-            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
-        }
-
-        private static SerializedLambda getSerializedLambda(Serializable lambda) {
-            return Try.of(() -> {
-                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
-                method.setAccessible(true);
-                return (SerializedLambda) method.invoke(lambda);
-            }).get();
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Class<R> returnType() {
-            return returnType;
-        }
-
-        @Override
-        public Class<?>[] parameterArray() {
-            return parameterArray;
+        @SuppressWarnings("deprecation")
+        private Type(CheckedFunction3<T1, T2, T3, R> λ) {
+            super(λ);
         }
 
         @SuppressWarnings("unchecked")
         public Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray[0];
+            return (Class<T1>) parameterTypes()[0];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray[1];
+            return (Class<T2>) parameterTypes()[1];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray[2];
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) {
-                return true;
-            } else if (o instanceof Type) {
-                final Type<?, ?, ?, ?> that = (Type<?, ?, ?, ?>) o;
-                return this.hashCode() == that.hashCode()
-                        && this.returnType.equals(that.returnType)
-                        && Arrays.equals(this.parameterArray, that.parameterArray);
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return hashCode.get();
-        }
-
-        @Override
-        public String toString() {
-            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
-                    + " -> "
-                    + returnType.getName();
+            return (Class<T3>) parameterTypes()[2];
         }
     }
 }

--- a/src-gen/main/java/javaslang/CheckedFunction3.java
+++ b/src-gen/main/java/javaslang/CheckedFunction3.java
@@ -9,9 +9,15 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
+import java.io.Serializable;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import javaslang.collection.List;
 import javaslang.control.Try;
 
 /**
@@ -189,38 +195,7 @@ public interface CheckedFunction3<T1, T2, T3, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, R> getType() {
-
-        final λ.Type<R> superType = λ.super.getType();
-
-        return new Type<T1, T2, T3, R>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public Class<R> returnType() {
-                return superType.returnType();
-            }
-
-            @Override
-            public Class<?>[] parameterArray() {
-                return superType.parameterArray();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                return superType.equals(o);
-            }
-
-            @Override
-            public int hashCode() {
-                return superType.hashCode();
-            }
-
-            @Override
-            public String toString() {
-                return superType.toString();
-            }
-        };
+        return Type.of(this);
     }
 
     /**
@@ -233,23 +208,94 @@ public interface CheckedFunction3<T1, T2, T3, R> extends λ<R> {
      * @param <T3> the 3rd parameter type of the function
      * @param <R> the return type of the function
      */
-    interface Type<T1, T2, T3, R> extends λ.Type<R> {
+    final class Type<T1, T2, T3, R> implements λ.Type<R>, Serializable {
 
-        long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
-        @SuppressWarnings("unchecked")
-        default Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray()[0];
+        private final Class<R> returnType;
+        private final Class<?>[] parameterArray;
+
+        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
+                .map(c -> c.getName().hashCode())
+                .fold(1, (acc, i) -> acc * 31 + i)
+                * 31 + returnType().getName().hashCode()
+        );
+
+        private Type(Class<R> returnType, Class<?>[] parameterArray) {
+            this.returnType = returnType;
+            this.parameterArray = parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray()[1];
+        private static <T1, T2, T3, R> Type<T1, T2, T3, R> of(CheckedFunction3<T1, T2, T3, R> f) {
+            final MethodType methodType = getLambdaSignature(f);
+            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
+        }
+
+        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
+        private static MethodType getLambdaSignature(Serializable lambda) {
+            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
+            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
+        }
+
+        private static SerializedLambda getSerializedLambda(Serializable lambda) {
+            return Try.of(() -> {
+                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+                method.setAccessible(true);
+                return (SerializedLambda) method.invoke(lambda);
+            }).get();
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray()[2];
+        @Override
+        public Class<R> returnType() {
+            return returnType;
+        }
+
+        @Override
+        public Class<?>[] parameterArray() {
+            return parameterArray;
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T1> parameterType1() {
+            return (Class<T1>) parameterArray[0];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T2> parameterType2() {
+            return (Class<T2>) parameterArray[1];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T3> parameterType3() {
+            return (Class<T3>) parameterArray[2];
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof Type) {
+                final Type<?, ?, ?, ?> that = (Type<?, ?, ?, ?>) o;
+                return this.hashCode() == that.hashCode()
+                        && this.returnType.equals(that.returnType)
+                        && Arrays.equals(this.parameterArray, that.parameterArray);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode.get();
+        }
+
+        @Override
+        public String toString() {
+            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
+                    + " -> "
+                    + returnType.getName();
         }
     }
 }

--- a/src-gen/main/java/javaslang/CheckedFunction3.java
+++ b/src-gen/main/java/javaslang/CheckedFunction3.java
@@ -203,6 +203,7 @@ public interface CheckedFunction3<T1, T2, T3, R> extends λ<R> {
      * @param <R> the return type of the function
      * @since 2.0.0
      */
+    @SuppressWarnings("deprecation")
     final class Type<T1, T2, T3, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;

--- a/src-gen/main/java/javaslang/CheckedFunction4.java
+++ b/src-gen/main/java/javaslang/CheckedFunction4.java
@@ -9,15 +9,9 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import java.io.Serializable;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.SerializedLambda;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import javaslang.collection.List;
 import javaslang.control.Try;
 
 /**
@@ -103,7 +97,7 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends λ<R> {
      * @return true, if this function is applicable to the given objects, false otherwise.
      */
     default boolean isApplicableTo(Object o1, Object o2, Object o3, Object o4) {
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 (o1 == null || paramTypes[0].isAssignableFrom(o1.getClass())) &&
                 (o2 == null || paramTypes[1].isAssignableFrom(o2.getClass())) &&
@@ -125,7 +119,7 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends λ<R> {
         Objects.requireNonNull(type2, "type2 is null");
         Objects.requireNonNull(type3, "type3 is null");
         Objects.requireNonNull(type4, "type4 is null");
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 paramTypes[0].isAssignableFrom(type1) &&
                 paramTypes[1].isAssignableFrom(type2) &&
@@ -216,7 +210,7 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, T4, R> getType() {
-        return Type.of(this);
+        return new Type<>(this);
     }
 
     /**
@@ -229,100 +223,35 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends λ<R> {
      * @param <T3> the 3rd parameter type of the function
      * @param <T4> the 4th parameter type of the function
      * @param <R> the return type of the function
+     * @since 2.0.0
      */
-    final class Type<T1, T2, T3, T4, R> implements λ.Type<R>, Serializable {
+    final class Type<T1, T2, T3, T4, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;
 
-        private final Class<R> returnType;
-        private final Class<?>[] parameterArray;
-
-        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
-                .map(c -> c.getName().hashCode())
-                .fold(1, (acc, i) -> acc * 31 + i)
-                * 31 + returnType().getName().hashCode()
-        );
-
-        private Type(Class<R> returnType, Class<?>[] parameterArray) {
-            this.returnType = returnType;
-            this.parameterArray = parameterArray;
-        }
-
-        @SuppressWarnings("unchecked")
-        private static <T1, T2, T3, T4, R> Type<T1, T2, T3, T4, R> of(CheckedFunction4<T1, T2, T3, T4, R> f) {
-            final MethodType methodType = getLambdaSignature(f);
-            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
-        }
-
-        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
-        private static MethodType getLambdaSignature(Serializable lambda) {
-            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
-            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
-        }
-
-        private static SerializedLambda getSerializedLambda(Serializable lambda) {
-            return Try.of(() -> {
-                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
-                method.setAccessible(true);
-                return (SerializedLambda) method.invoke(lambda);
-            }).get();
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Class<R> returnType() {
-            return returnType;
-        }
-
-        @Override
-        public Class<?>[] parameterArray() {
-            return parameterArray;
+        @SuppressWarnings("deprecation")
+        private Type(CheckedFunction4<T1, T2, T3, T4, R> λ) {
+            super(λ);
         }
 
         @SuppressWarnings("unchecked")
         public Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray[0];
+            return (Class<T1>) parameterTypes()[0];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray[1];
+            return (Class<T2>) parameterTypes()[1];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray[2];
+            return (Class<T3>) parameterTypes()[2];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray[3];
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) {
-                return true;
-            } else if (o instanceof Type) {
-                final Type<?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?>) o;
-                return this.hashCode() == that.hashCode()
-                        && this.returnType.equals(that.returnType)
-                        && Arrays.equals(this.parameterArray, that.parameterArray);
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return hashCode.get();
-        }
-
-        @Override
-        public String toString() {
-            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
-                    + " -> "
-                    + returnType.getName();
+            return (Class<T4>) parameterTypes()[3];
         }
     }
 }

--- a/src-gen/main/java/javaslang/CheckedFunction4.java
+++ b/src-gen/main/java/javaslang/CheckedFunction4.java
@@ -225,6 +225,7 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends λ<R> {
      * @param <R> the return type of the function
      * @since 2.0.0
      */
+    @SuppressWarnings("deprecation")
     final class Type<T1, T2, T3, T4, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;

--- a/src-gen/main/java/javaslang/CheckedFunction4.java
+++ b/src-gen/main/java/javaslang/CheckedFunction4.java
@@ -9,9 +9,15 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
+import java.io.Serializable;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import javaslang.collection.List;
 import javaslang.control.Try;
 
 /**
@@ -210,38 +216,7 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, T4, R> getType() {
-
-        final λ.Type<R> superType = λ.super.getType();
-
-        return new Type<T1, T2, T3, T4, R>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public Class<R> returnType() {
-                return superType.returnType();
-            }
-
-            @Override
-            public Class<?>[] parameterArray() {
-                return superType.parameterArray();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                return superType.equals(o);
-            }
-
-            @Override
-            public int hashCode() {
-                return superType.hashCode();
-            }
-
-            @Override
-            public String toString() {
-                return superType.toString();
-            }
-        };
+        return Type.of(this);
     }
 
     /**
@@ -255,28 +230,99 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends λ<R> {
      * @param <T4> the 4th parameter type of the function
      * @param <R> the return type of the function
      */
-    interface Type<T1, T2, T3, T4, R> extends λ.Type<R> {
+    final class Type<T1, T2, T3, T4, R> implements λ.Type<R>, Serializable {
 
-        long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
-        @SuppressWarnings("unchecked")
-        default Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray()[0];
+        private final Class<R> returnType;
+        private final Class<?>[] parameterArray;
+
+        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
+                .map(c -> c.getName().hashCode())
+                .fold(1, (acc, i) -> acc * 31 + i)
+                * 31 + returnType().getName().hashCode()
+        );
+
+        private Type(Class<R> returnType, Class<?>[] parameterArray) {
+            this.returnType = returnType;
+            this.parameterArray = parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray()[1];
+        private static <T1, T2, T3, T4, R> Type<T1, T2, T3, T4, R> of(CheckedFunction4<T1, T2, T3, T4, R> f) {
+            final MethodType methodType = getLambdaSignature(f);
+            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
+        }
+
+        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
+        private static MethodType getLambdaSignature(Serializable lambda) {
+            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
+            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
+        }
+
+        private static SerializedLambda getSerializedLambda(Serializable lambda) {
+            return Try.of(() -> {
+                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+                method.setAccessible(true);
+                return (SerializedLambda) method.invoke(lambda);
+            }).get();
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray()[2];
+        @Override
+        public Class<R> returnType() {
+            return returnType;
+        }
+
+        @Override
+        public Class<?>[] parameterArray() {
+            return parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray()[3];
+        public Class<T1> parameterType1() {
+            return (Class<T1>) parameterArray[0];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T2> parameterType2() {
+            return (Class<T2>) parameterArray[1];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T3> parameterType3() {
+            return (Class<T3>) parameterArray[2];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T4> parameterType4() {
+            return (Class<T4>) parameterArray[3];
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof Type) {
+                final Type<?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?>) o;
+                return this.hashCode() == that.hashCode()
+                        && this.returnType.equals(that.returnType)
+                        && Arrays.equals(this.parameterArray, that.parameterArray);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode.get();
+        }
+
+        @Override
+        public String toString() {
+            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
+                    + " -> "
+                    + returnType.getName();
         }
     }
 }

--- a/src-gen/main/java/javaslang/CheckedFunction5.java
+++ b/src-gen/main/java/javaslang/CheckedFunction5.java
@@ -248,6 +248,7 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends λ<R> {
      * @param <R> the return type of the function
      * @since 2.0.0
      */
+    @SuppressWarnings("deprecation")
     final class Type<T1, T2, T3, T4, T5, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;

--- a/src-gen/main/java/javaslang/CheckedFunction5.java
+++ b/src-gen/main/java/javaslang/CheckedFunction5.java
@@ -9,9 +9,15 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
+import java.io.Serializable;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import javaslang.collection.List;
 import javaslang.control.Try;
 
 /**
@@ -232,38 +238,7 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, T4, T5, R> getType() {
-
-        final λ.Type<R> superType = λ.super.getType();
-
-        return new Type<T1, T2, T3, T4, T5, R>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public Class<R> returnType() {
-                return superType.returnType();
-            }
-
-            @Override
-            public Class<?>[] parameterArray() {
-                return superType.parameterArray();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                return superType.equals(o);
-            }
-
-            @Override
-            public int hashCode() {
-                return superType.hashCode();
-            }
-
-            @Override
-            public String toString() {
-                return superType.toString();
-            }
-        };
+        return Type.of(this);
     }
 
     /**
@@ -278,33 +253,104 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends λ<R> {
      * @param <T5> the 5th parameter type of the function
      * @param <R> the return type of the function
      */
-    interface Type<T1, T2, T3, T4, T5, R> extends λ.Type<R> {
+    final class Type<T1, T2, T3, T4, T5, R> implements λ.Type<R>, Serializable {
 
-        long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
-        @SuppressWarnings("unchecked")
-        default Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray()[0];
+        private final Class<R> returnType;
+        private final Class<?>[] parameterArray;
+
+        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
+                .map(c -> c.getName().hashCode())
+                .fold(1, (acc, i) -> acc * 31 + i)
+                * 31 + returnType().getName().hashCode()
+        );
+
+        private Type(Class<R> returnType, Class<?>[] parameterArray) {
+            this.returnType = returnType;
+            this.parameterArray = parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray()[1];
+        private static <T1, T2, T3, T4, T5, R> Type<T1, T2, T3, T4, T5, R> of(CheckedFunction5<T1, T2, T3, T4, T5, R> f) {
+            final MethodType methodType = getLambdaSignature(f);
+            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
+        }
+
+        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
+        private static MethodType getLambdaSignature(Serializable lambda) {
+            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
+            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
+        }
+
+        private static SerializedLambda getSerializedLambda(Serializable lambda) {
+            return Try.of(() -> {
+                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+                method.setAccessible(true);
+                return (SerializedLambda) method.invoke(lambda);
+            }).get();
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray()[2];
+        @Override
+        public Class<R> returnType() {
+            return returnType;
+        }
+
+        @Override
+        public Class<?>[] parameterArray() {
+            return parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray()[3];
+        public Class<T1> parameterType1() {
+            return (Class<T1>) parameterArray[0];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T5> parameterType5() {
-            return (Class<T5>) parameterArray()[4];
+        public Class<T2> parameterType2() {
+            return (Class<T2>) parameterArray[1];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T3> parameterType3() {
+            return (Class<T3>) parameterArray[2];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T4> parameterType4() {
+            return (Class<T4>) parameterArray[3];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T5> parameterType5() {
+            return (Class<T5>) parameterArray[4];
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof Type) {
+                final Type<?, ?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?, ?>) o;
+                return this.hashCode() == that.hashCode()
+                        && this.returnType.equals(that.returnType)
+                        && Arrays.equals(this.parameterArray, that.parameterArray);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode.get();
+        }
+
+        @Override
+        public String toString() {
+            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
+                    + " -> "
+                    + returnType.getName();
         }
     }
 }

--- a/src-gen/main/java/javaslang/CheckedFunction5.java
+++ b/src-gen/main/java/javaslang/CheckedFunction5.java
@@ -9,15 +9,9 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import java.io.Serializable;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.SerializedLambda;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import javaslang.collection.List;
 import javaslang.control.Try;
 
 /**
@@ -107,7 +101,7 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends λ<R> {
      * @return true, if this function is applicable to the given objects, false otherwise.
      */
     default boolean isApplicableTo(Object o1, Object o2, Object o3, Object o4, Object o5) {
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 (o1 == null || paramTypes[0].isAssignableFrom(o1.getClass())) &&
                 (o2 == null || paramTypes[1].isAssignableFrom(o2.getClass())) &&
@@ -132,7 +126,7 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends λ<R> {
         Objects.requireNonNull(type3, "type3 is null");
         Objects.requireNonNull(type4, "type4 is null");
         Objects.requireNonNull(type5, "type5 is null");
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 paramTypes[0].isAssignableFrom(type1) &&
                 paramTypes[1].isAssignableFrom(type2) &&
@@ -238,7 +232,7 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, T4, T5, R> getType() {
-        return Type.of(this);
+        return new Type<>(this);
     }
 
     /**
@@ -252,105 +246,40 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends λ<R> {
      * @param <T4> the 4th parameter type of the function
      * @param <T5> the 5th parameter type of the function
      * @param <R> the return type of the function
+     * @since 2.0.0
      */
-    final class Type<T1, T2, T3, T4, T5, R> implements λ.Type<R>, Serializable {
+    final class Type<T1, T2, T3, T4, T5, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;
 
-        private final Class<R> returnType;
-        private final Class<?>[] parameterArray;
-
-        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
-                .map(c -> c.getName().hashCode())
-                .fold(1, (acc, i) -> acc * 31 + i)
-                * 31 + returnType().getName().hashCode()
-        );
-
-        private Type(Class<R> returnType, Class<?>[] parameterArray) {
-            this.returnType = returnType;
-            this.parameterArray = parameterArray;
-        }
-
-        @SuppressWarnings("unchecked")
-        private static <T1, T2, T3, T4, T5, R> Type<T1, T2, T3, T4, T5, R> of(CheckedFunction5<T1, T2, T3, T4, T5, R> f) {
-            final MethodType methodType = getLambdaSignature(f);
-            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
-        }
-
-        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
-        private static MethodType getLambdaSignature(Serializable lambda) {
-            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
-            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
-        }
-
-        private static SerializedLambda getSerializedLambda(Serializable lambda) {
-            return Try.of(() -> {
-                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
-                method.setAccessible(true);
-                return (SerializedLambda) method.invoke(lambda);
-            }).get();
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Class<R> returnType() {
-            return returnType;
-        }
-
-        @Override
-        public Class<?>[] parameterArray() {
-            return parameterArray;
+        @SuppressWarnings("deprecation")
+        private Type(CheckedFunction5<T1, T2, T3, T4, T5, R> λ) {
+            super(λ);
         }
 
         @SuppressWarnings("unchecked")
         public Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray[0];
+            return (Class<T1>) parameterTypes()[0];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray[1];
+            return (Class<T2>) parameterTypes()[1];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray[2];
+            return (Class<T3>) parameterTypes()[2];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray[3];
+            return (Class<T4>) parameterTypes()[3];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T5> parameterType5() {
-            return (Class<T5>) parameterArray[4];
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) {
-                return true;
-            } else if (o instanceof Type) {
-                final Type<?, ?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?, ?>) o;
-                return this.hashCode() == that.hashCode()
-                        && this.returnType.equals(that.returnType)
-                        && Arrays.equals(this.parameterArray, that.parameterArray);
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return hashCode.get();
-        }
-
-        @Override
-        public String toString() {
-            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
-                    + " -> "
-                    + returnType.getName();
+            return (Class<T5>) parameterTypes()[4];
         }
     }
 }

--- a/src-gen/main/java/javaslang/CheckedFunction6.java
+++ b/src-gen/main/java/javaslang/CheckedFunction6.java
@@ -272,6 +272,7 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
      * @param <R> the return type of the function
      * @since 2.0.0
      */
+    @SuppressWarnings("deprecation")
     final class Type<T1, T2, T3, T4, T5, T6, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;

--- a/src-gen/main/java/javaslang/CheckedFunction6.java
+++ b/src-gen/main/java/javaslang/CheckedFunction6.java
@@ -9,15 +9,9 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import java.io.Serializable;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.SerializedLambda;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import javaslang.collection.List;
 import javaslang.control.Try;
 
 /**
@@ -111,7 +105,7 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
      * @return true, if this function is applicable to the given objects, false otherwise.
      */
     default boolean isApplicableTo(Object o1, Object o2, Object o3, Object o4, Object o5, Object o6) {
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 (o1 == null || paramTypes[0].isAssignableFrom(o1.getClass())) &&
                 (o2 == null || paramTypes[1].isAssignableFrom(o2.getClass())) &&
@@ -139,7 +133,7 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
         Objects.requireNonNull(type4, "type4 is null");
         Objects.requireNonNull(type5, "type5 is null");
         Objects.requireNonNull(type6, "type6 is null");
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 paramTypes[0].isAssignableFrom(type1) &&
                 paramTypes[1].isAssignableFrom(type2) &&
@@ -261,7 +255,7 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, T4, T5, T6, R> getType() {
-        return Type.of(this);
+        return new Type<>(this);
     }
 
     /**
@@ -276,110 +270,45 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
      * @param <T5> the 5th parameter type of the function
      * @param <T6> the 6th parameter type of the function
      * @param <R> the return type of the function
+     * @since 2.0.0
      */
-    final class Type<T1, T2, T3, T4, T5, T6, R> implements λ.Type<R>, Serializable {
+    final class Type<T1, T2, T3, T4, T5, T6, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;
 
-        private final Class<R> returnType;
-        private final Class<?>[] parameterArray;
-
-        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
-                .map(c -> c.getName().hashCode())
-                .fold(1, (acc, i) -> acc * 31 + i)
-                * 31 + returnType().getName().hashCode()
-        );
-
-        private Type(Class<R> returnType, Class<?>[] parameterArray) {
-            this.returnType = returnType;
-            this.parameterArray = parameterArray;
-        }
-
-        @SuppressWarnings("unchecked")
-        private static <T1, T2, T3, T4, T5, T6, R> Type<T1, T2, T3, T4, T5, T6, R> of(CheckedFunction6<T1, T2, T3, T4, T5, T6, R> f) {
-            final MethodType methodType = getLambdaSignature(f);
-            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
-        }
-
-        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
-        private static MethodType getLambdaSignature(Serializable lambda) {
-            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
-            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
-        }
-
-        private static SerializedLambda getSerializedLambda(Serializable lambda) {
-            return Try.of(() -> {
-                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
-                method.setAccessible(true);
-                return (SerializedLambda) method.invoke(lambda);
-            }).get();
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Class<R> returnType() {
-            return returnType;
-        }
-
-        @Override
-        public Class<?>[] parameterArray() {
-            return parameterArray;
+        @SuppressWarnings("deprecation")
+        private Type(CheckedFunction6<T1, T2, T3, T4, T5, T6, R> λ) {
+            super(λ);
         }
 
         @SuppressWarnings("unchecked")
         public Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray[0];
+            return (Class<T1>) parameterTypes()[0];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray[1];
+            return (Class<T2>) parameterTypes()[1];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray[2];
+            return (Class<T3>) parameterTypes()[2];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray[3];
+            return (Class<T4>) parameterTypes()[3];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T5> parameterType5() {
-            return (Class<T5>) parameterArray[4];
+            return (Class<T5>) parameterTypes()[4];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T6> parameterType6() {
-            return (Class<T6>) parameterArray[5];
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) {
-                return true;
-            } else if (o instanceof Type) {
-                final Type<?, ?, ?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?, ?, ?>) o;
-                return this.hashCode() == that.hashCode()
-                        && this.returnType.equals(that.returnType)
-                        && Arrays.equals(this.parameterArray, that.parameterArray);
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return hashCode.get();
-        }
-
-        @Override
-        public String toString() {
-            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
-                    + " -> "
-                    + returnType.getName();
+            return (Class<T6>) parameterTypes()[5];
         }
     }
 }

--- a/src-gen/main/java/javaslang/CheckedFunction6.java
+++ b/src-gen/main/java/javaslang/CheckedFunction6.java
@@ -9,9 +9,15 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
+import java.io.Serializable;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import javaslang.collection.List;
 import javaslang.control.Try;
 
 /**
@@ -255,38 +261,7 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, T4, T5, T6, R> getType() {
-
-        final λ.Type<R> superType = λ.super.getType();
-
-        return new Type<T1, T2, T3, T4, T5, T6, R>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public Class<R> returnType() {
-                return superType.returnType();
-            }
-
-            @Override
-            public Class<?>[] parameterArray() {
-                return superType.parameterArray();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                return superType.equals(o);
-            }
-
-            @Override
-            public int hashCode() {
-                return superType.hashCode();
-            }
-
-            @Override
-            public String toString() {
-                return superType.toString();
-            }
-        };
+        return Type.of(this);
     }
 
     /**
@@ -302,38 +277,109 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
      * @param <T6> the 6th parameter type of the function
      * @param <R> the return type of the function
      */
-    interface Type<T1, T2, T3, T4, T5, T6, R> extends λ.Type<R> {
+    final class Type<T1, T2, T3, T4, T5, T6, R> implements λ.Type<R>, Serializable {
 
-        long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
-        @SuppressWarnings("unchecked")
-        default Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray()[0];
+        private final Class<R> returnType;
+        private final Class<?>[] parameterArray;
+
+        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
+                .map(c -> c.getName().hashCode())
+                .fold(1, (acc, i) -> acc * 31 + i)
+                * 31 + returnType().getName().hashCode()
+        );
+
+        private Type(Class<R> returnType, Class<?>[] parameterArray) {
+            this.returnType = returnType;
+            this.parameterArray = parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray()[1];
+        private static <T1, T2, T3, T4, T5, T6, R> Type<T1, T2, T3, T4, T5, T6, R> of(CheckedFunction6<T1, T2, T3, T4, T5, T6, R> f) {
+            final MethodType methodType = getLambdaSignature(f);
+            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
+        }
+
+        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
+        private static MethodType getLambdaSignature(Serializable lambda) {
+            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
+            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
+        }
+
+        private static SerializedLambda getSerializedLambda(Serializable lambda) {
+            return Try.of(() -> {
+                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+                method.setAccessible(true);
+                return (SerializedLambda) method.invoke(lambda);
+            }).get();
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray()[2];
+        @Override
+        public Class<R> returnType() {
+            return returnType;
+        }
+
+        @Override
+        public Class<?>[] parameterArray() {
+            return parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray()[3];
+        public Class<T1> parameterType1() {
+            return (Class<T1>) parameterArray[0];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T5> parameterType5() {
-            return (Class<T5>) parameterArray()[4];
+        public Class<T2> parameterType2() {
+            return (Class<T2>) parameterArray[1];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T6> parameterType6() {
-            return (Class<T6>) parameterArray()[5];
+        public Class<T3> parameterType3() {
+            return (Class<T3>) parameterArray[2];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T4> parameterType4() {
+            return (Class<T4>) parameterArray[3];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T5> parameterType5() {
+            return (Class<T5>) parameterArray[4];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T6> parameterType6() {
+            return (Class<T6>) parameterArray[5];
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof Type) {
+                final Type<?, ?, ?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?, ?, ?>) o;
+                return this.hashCode() == that.hashCode()
+                        && this.returnType.equals(that.returnType)
+                        && Arrays.equals(this.parameterArray, that.parameterArray);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode.get();
+        }
+
+        @Override
+        public String toString() {
+            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
+                    + " -> "
+                    + returnType.getName();
         }
     }
 }

--- a/src-gen/main/java/javaslang/CheckedFunction7.java
+++ b/src-gen/main/java/javaslang/CheckedFunction7.java
@@ -9,15 +9,9 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import java.io.Serializable;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.SerializedLambda;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import javaslang.collection.List;
 import javaslang.control.Try;
 
 /**
@@ -115,7 +109,7 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
      * @return true, if this function is applicable to the given objects, false otherwise.
      */
     default boolean isApplicableTo(Object o1, Object o2, Object o3, Object o4, Object o5, Object o6, Object o7) {
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 (o1 == null || paramTypes[0].isAssignableFrom(o1.getClass())) &&
                 (o2 == null || paramTypes[1].isAssignableFrom(o2.getClass())) &&
@@ -146,7 +140,7 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
         Objects.requireNonNull(type5, "type5 is null");
         Objects.requireNonNull(type6, "type6 is null");
         Objects.requireNonNull(type7, "type7 is null");
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 paramTypes[0].isAssignableFrom(type1) &&
                 paramTypes[1].isAssignableFrom(type2) &&
@@ -285,7 +279,7 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, T4, T5, T6, T7, R> getType() {
-        return Type.of(this);
+        return new Type<>(this);
     }
 
     /**
@@ -301,115 +295,50 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
      * @param <T6> the 6th parameter type of the function
      * @param <T7> the 7th parameter type of the function
      * @param <R> the return type of the function
+     * @since 2.0.0
      */
-    final class Type<T1, T2, T3, T4, T5, T6, T7, R> implements λ.Type<R>, Serializable {
+    final class Type<T1, T2, T3, T4, T5, T6, T7, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;
 
-        private final Class<R> returnType;
-        private final Class<?>[] parameterArray;
-
-        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
-                .map(c -> c.getName().hashCode())
-                .fold(1, (acc, i) -> acc * 31 + i)
-                * 31 + returnType().getName().hashCode()
-        );
-
-        private Type(Class<R> returnType, Class<?>[] parameterArray) {
-            this.returnType = returnType;
-            this.parameterArray = parameterArray;
-        }
-
-        @SuppressWarnings("unchecked")
-        private static <T1, T2, T3, T4, T5, T6, T7, R> Type<T1, T2, T3, T4, T5, T6, T7, R> of(CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> f) {
-            final MethodType methodType = getLambdaSignature(f);
-            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
-        }
-
-        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
-        private static MethodType getLambdaSignature(Serializable lambda) {
-            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
-            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
-        }
-
-        private static SerializedLambda getSerializedLambda(Serializable lambda) {
-            return Try.of(() -> {
-                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
-                method.setAccessible(true);
-                return (SerializedLambda) method.invoke(lambda);
-            }).get();
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Class<R> returnType() {
-            return returnType;
-        }
-
-        @Override
-        public Class<?>[] parameterArray() {
-            return parameterArray;
+        @SuppressWarnings("deprecation")
+        private Type(CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> λ) {
+            super(λ);
         }
 
         @SuppressWarnings("unchecked")
         public Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray[0];
+            return (Class<T1>) parameterTypes()[0];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray[1];
+            return (Class<T2>) parameterTypes()[1];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray[2];
+            return (Class<T3>) parameterTypes()[2];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray[3];
+            return (Class<T4>) parameterTypes()[3];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T5> parameterType5() {
-            return (Class<T5>) parameterArray[4];
+            return (Class<T5>) parameterTypes()[4];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T6> parameterType6() {
-            return (Class<T6>) parameterArray[5];
+            return (Class<T6>) parameterTypes()[5];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T7> parameterType7() {
-            return (Class<T7>) parameterArray[6];
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) {
-                return true;
-            } else if (o instanceof Type) {
-                final Type<?, ?, ?, ?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?, ?, ?, ?>) o;
-                return this.hashCode() == that.hashCode()
-                        && this.returnType.equals(that.returnType)
-                        && Arrays.equals(this.parameterArray, that.parameterArray);
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return hashCode.get();
-        }
-
-        @Override
-        public String toString() {
-            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
-                    + " -> "
-                    + returnType.getName();
+            return (Class<T7>) parameterTypes()[6];
         }
     }
 }

--- a/src-gen/main/java/javaslang/CheckedFunction7.java
+++ b/src-gen/main/java/javaslang/CheckedFunction7.java
@@ -297,6 +297,7 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
      * @param <R> the return type of the function
      * @since 2.0.0
      */
+    @SuppressWarnings("deprecation")
     final class Type<T1, T2, T3, T4, T5, T6, T7, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;

--- a/src-gen/main/java/javaslang/CheckedFunction7.java
+++ b/src-gen/main/java/javaslang/CheckedFunction7.java
@@ -9,9 +9,15 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
+import java.io.Serializable;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import javaslang.collection.List;
 import javaslang.control.Try;
 
 /**
@@ -279,38 +285,7 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, T4, T5, T6, T7, R> getType() {
-
-        final λ.Type<R> superType = λ.super.getType();
-
-        return new Type<T1, T2, T3, T4, T5, T6, T7, R>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public Class<R> returnType() {
-                return superType.returnType();
-            }
-
-            @Override
-            public Class<?>[] parameterArray() {
-                return superType.parameterArray();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                return superType.equals(o);
-            }
-
-            @Override
-            public int hashCode() {
-                return superType.hashCode();
-            }
-
-            @Override
-            public String toString() {
-                return superType.toString();
-            }
-        };
+        return Type.of(this);
     }
 
     /**
@@ -327,43 +302,114 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
      * @param <T7> the 7th parameter type of the function
      * @param <R> the return type of the function
      */
-    interface Type<T1, T2, T3, T4, T5, T6, T7, R> extends λ.Type<R> {
+    final class Type<T1, T2, T3, T4, T5, T6, T7, R> implements λ.Type<R>, Serializable {
 
-        long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
-        @SuppressWarnings("unchecked")
-        default Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray()[0];
+        private final Class<R> returnType;
+        private final Class<?>[] parameterArray;
+
+        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
+                .map(c -> c.getName().hashCode())
+                .fold(1, (acc, i) -> acc * 31 + i)
+                * 31 + returnType().getName().hashCode()
+        );
+
+        private Type(Class<R> returnType, Class<?>[] parameterArray) {
+            this.returnType = returnType;
+            this.parameterArray = parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray()[1];
+        private static <T1, T2, T3, T4, T5, T6, T7, R> Type<T1, T2, T3, T4, T5, T6, T7, R> of(CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> f) {
+            final MethodType methodType = getLambdaSignature(f);
+            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
+        }
+
+        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
+        private static MethodType getLambdaSignature(Serializable lambda) {
+            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
+            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
+        }
+
+        private static SerializedLambda getSerializedLambda(Serializable lambda) {
+            return Try.of(() -> {
+                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+                method.setAccessible(true);
+                return (SerializedLambda) method.invoke(lambda);
+            }).get();
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray()[2];
+        @Override
+        public Class<R> returnType() {
+            return returnType;
+        }
+
+        @Override
+        public Class<?>[] parameterArray() {
+            return parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray()[3];
+        public Class<T1> parameterType1() {
+            return (Class<T1>) parameterArray[0];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T5> parameterType5() {
-            return (Class<T5>) parameterArray()[4];
+        public Class<T2> parameterType2() {
+            return (Class<T2>) parameterArray[1];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T6> parameterType6() {
-            return (Class<T6>) parameterArray()[5];
+        public Class<T3> parameterType3() {
+            return (Class<T3>) parameterArray[2];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T7> parameterType7() {
-            return (Class<T7>) parameterArray()[6];
+        public Class<T4> parameterType4() {
+            return (Class<T4>) parameterArray[3];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T5> parameterType5() {
+            return (Class<T5>) parameterArray[4];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T6> parameterType6() {
+            return (Class<T6>) parameterArray[5];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T7> parameterType7() {
+            return (Class<T7>) parameterArray[6];
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof Type) {
+                final Type<?, ?, ?, ?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?, ?, ?, ?>) o;
+                return this.hashCode() == that.hashCode()
+                        && this.returnType.equals(that.returnType)
+                        && Arrays.equals(this.parameterArray, that.parameterArray);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode.get();
+        }
+
+        @Override
+        public String toString() {
+            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
+                    + " -> "
+                    + returnType.getName();
         }
     }
 }

--- a/src-gen/main/java/javaslang/CheckedFunction8.java
+++ b/src-gen/main/java/javaslang/CheckedFunction8.java
@@ -323,6 +323,7 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<
      * @param <R> the return type of the function
      * @since 2.0.0
      */
+    @SuppressWarnings("deprecation")
     final class Type<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;

--- a/src-gen/main/java/javaslang/CheckedFunction8.java
+++ b/src-gen/main/java/javaslang/CheckedFunction8.java
@@ -9,15 +9,9 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import java.io.Serializable;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.SerializedLambda;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import javaslang.collection.List;
 import javaslang.control.Try;
 
 /**
@@ -119,7 +113,7 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<
      * @return true, if this function is applicable to the given objects, false otherwise.
      */
     default boolean isApplicableTo(Object o1, Object o2, Object o3, Object o4, Object o5, Object o6, Object o7, Object o8) {
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 (o1 == null || paramTypes[0].isAssignableFrom(o1.getClass())) &&
                 (o2 == null || paramTypes[1].isAssignableFrom(o2.getClass())) &&
@@ -153,7 +147,7 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<
         Objects.requireNonNull(type6, "type6 is null");
         Objects.requireNonNull(type7, "type7 is null");
         Objects.requireNonNull(type8, "type8 is null");
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 paramTypes[0].isAssignableFrom(type1) &&
                 paramTypes[1].isAssignableFrom(type2) &&
@@ -310,7 +304,7 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<
 
     @Override
     default Type<T1, T2, T3, T4, T5, T6, T7, T8, R> getType() {
-        return Type.of(this);
+        return new Type<>(this);
     }
 
     /**
@@ -327,120 +321,55 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<
      * @param <T7> the 7th parameter type of the function
      * @param <T8> the 8th parameter type of the function
      * @param <R> the return type of the function
+     * @since 2.0.0
      */
-    final class Type<T1, T2, T3, T4, T5, T6, T7, T8, R> implements λ.Type<R>, Serializable {
+    final class Type<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;
 
-        private final Class<R> returnType;
-        private final Class<?>[] parameterArray;
-
-        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
-                .map(c -> c.getName().hashCode())
-                .fold(1, (acc, i) -> acc * 31 + i)
-                * 31 + returnType().getName().hashCode()
-        );
-
-        private Type(Class<R> returnType, Class<?>[] parameterArray) {
-            this.returnType = returnType;
-            this.parameterArray = parameterArray;
-        }
-
-        @SuppressWarnings("unchecked")
-        private static <T1, T2, T3, T4, T5, T6, T7, T8, R> Type<T1, T2, T3, T4, T5, T6, T7, T8, R> of(CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> f) {
-            final MethodType methodType = getLambdaSignature(f);
-            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
-        }
-
-        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
-        private static MethodType getLambdaSignature(Serializable lambda) {
-            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
-            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
-        }
-
-        private static SerializedLambda getSerializedLambda(Serializable lambda) {
-            return Try.of(() -> {
-                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
-                method.setAccessible(true);
-                return (SerializedLambda) method.invoke(lambda);
-            }).get();
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Class<R> returnType() {
-            return returnType;
-        }
-
-        @Override
-        public Class<?>[] parameterArray() {
-            return parameterArray;
+        @SuppressWarnings("deprecation")
+        private Type(CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> λ) {
+            super(λ);
         }
 
         @SuppressWarnings("unchecked")
         public Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray[0];
+            return (Class<T1>) parameterTypes()[0];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray[1];
+            return (Class<T2>) parameterTypes()[1];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray[2];
+            return (Class<T3>) parameterTypes()[2];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray[3];
+            return (Class<T4>) parameterTypes()[3];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T5> parameterType5() {
-            return (Class<T5>) parameterArray[4];
+            return (Class<T5>) parameterTypes()[4];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T6> parameterType6() {
-            return (Class<T6>) parameterArray[5];
+            return (Class<T6>) parameterTypes()[5];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T7> parameterType7() {
-            return (Class<T7>) parameterArray[6];
+            return (Class<T7>) parameterTypes()[6];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T8> parameterType8() {
-            return (Class<T8>) parameterArray[7];
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) {
-                return true;
-            } else if (o instanceof Type) {
-                final Type<?, ?, ?, ?, ?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?, ?, ?, ?, ?>) o;
-                return this.hashCode() == that.hashCode()
-                        && this.returnType.equals(that.returnType)
-                        && Arrays.equals(this.parameterArray, that.parameterArray);
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return hashCode.get();
-        }
-
-        @Override
-        public String toString() {
-            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
-                    + " -> "
-                    + returnType.getName();
+            return (Class<T8>) parameterTypes()[7];
         }
     }
 }

--- a/src-gen/main/java/javaslang/CheckedFunction8.java
+++ b/src-gen/main/java/javaslang/CheckedFunction8.java
@@ -9,9 +9,15 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
+import java.io.Serializable;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import javaslang.collection.List;
 import javaslang.control.Try;
 
 /**
@@ -304,38 +310,7 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<
 
     @Override
     default Type<T1, T2, T3, T4, T5, T6, T7, T8, R> getType() {
-
-        final λ.Type<R> superType = λ.super.getType();
-
-        return new Type<T1, T2, T3, T4, T5, T6, T7, T8, R>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public Class<R> returnType() {
-                return superType.returnType();
-            }
-
-            @Override
-            public Class<?>[] parameterArray() {
-                return superType.parameterArray();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                return superType.equals(o);
-            }
-
-            @Override
-            public int hashCode() {
-                return superType.hashCode();
-            }
-
-            @Override
-            public String toString() {
-                return superType.toString();
-            }
-        };
+        return Type.of(this);
     }
 
     /**
@@ -353,48 +328,119 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<
      * @param <T8> the 8th parameter type of the function
      * @param <R> the return type of the function
      */
-    interface Type<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ.Type<R> {
+    final class Type<T1, T2, T3, T4, T5, T6, T7, T8, R> implements λ.Type<R>, Serializable {
 
-        long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
-        @SuppressWarnings("unchecked")
-        default Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray()[0];
+        private final Class<R> returnType;
+        private final Class<?>[] parameterArray;
+
+        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
+                .map(c -> c.getName().hashCode())
+                .fold(1, (acc, i) -> acc * 31 + i)
+                * 31 + returnType().getName().hashCode()
+        );
+
+        private Type(Class<R> returnType, Class<?>[] parameterArray) {
+            this.returnType = returnType;
+            this.parameterArray = parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray()[1];
+        private static <T1, T2, T3, T4, T5, T6, T7, T8, R> Type<T1, T2, T3, T4, T5, T6, T7, T8, R> of(CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> f) {
+            final MethodType methodType = getLambdaSignature(f);
+            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
+        }
+
+        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
+        private static MethodType getLambdaSignature(Serializable lambda) {
+            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
+            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
+        }
+
+        private static SerializedLambda getSerializedLambda(Serializable lambda) {
+            return Try.of(() -> {
+                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+                method.setAccessible(true);
+                return (SerializedLambda) method.invoke(lambda);
+            }).get();
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray()[2];
+        @Override
+        public Class<R> returnType() {
+            return returnType;
+        }
+
+        @Override
+        public Class<?>[] parameterArray() {
+            return parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray()[3];
+        public Class<T1> parameterType1() {
+            return (Class<T1>) parameterArray[0];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T5> parameterType5() {
-            return (Class<T5>) parameterArray()[4];
+        public Class<T2> parameterType2() {
+            return (Class<T2>) parameterArray[1];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T6> parameterType6() {
-            return (Class<T6>) parameterArray()[5];
+        public Class<T3> parameterType3() {
+            return (Class<T3>) parameterArray[2];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T7> parameterType7() {
-            return (Class<T7>) parameterArray()[6];
+        public Class<T4> parameterType4() {
+            return (Class<T4>) parameterArray[3];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T8> parameterType8() {
-            return (Class<T8>) parameterArray()[7];
+        public Class<T5> parameterType5() {
+            return (Class<T5>) parameterArray[4];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T6> parameterType6() {
+            return (Class<T6>) parameterArray[5];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T7> parameterType7() {
+            return (Class<T7>) parameterArray[6];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T8> parameterType8() {
+            return (Class<T8>) parameterArray[7];
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof Type) {
+                final Type<?, ?, ?, ?, ?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?, ?, ?, ?, ?>) o;
+                return this.hashCode() == that.hashCode()
+                        && this.returnType.equals(that.returnType)
+                        && Arrays.equals(this.parameterArray, that.parameterArray);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode.get();
+        }
+
+        @Override
+        public String toString() {
+            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
+                    + " -> "
+                    + returnType.getName();
         }
     }
 }

--- a/src-gen/main/java/javaslang/Function0.java
+++ b/src-gen/main/java/javaslang/Function0.java
@@ -136,6 +136,7 @@ public interface Function0<R> extends λ<R>, Supplier<R> {
      * @param <R> the return type of the function
      * @since 2.0.0
      */
+    @SuppressWarnings("deprecation")
     final class Type<R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;

--- a/src-gen/main/java/javaslang/Function0.java
+++ b/src-gen/main/java/javaslang/Function0.java
@@ -9,8 +9,15 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
+import java.io.Serializable;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Supplier;
+import javaslang.collection.List;
+import javaslang.control.Try;
 
 /**
  * Represents a function with no arguments.
@@ -125,38 +132,7 @@ public interface Function0<R> extends λ<R>, Supplier<R> {
 
     @Override
     default Type<R> getType() {
-
-        final λ.Type<R> superType = λ.super.getType();
-
-        return new Type<R>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public Class<R> returnType() {
-                return superType.returnType();
-            }
-
-            @Override
-            public Class<?>[] parameterArray() {
-                return superType.parameterArray();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                return superType.equals(o);
-            }
-
-            @Override
-            public int hashCode() {
-                return superType.hashCode();
-            }
-
-            @Override
-            public String toString() {
-                return superType.toString();
-            }
-        };
+        return Type.of(this);
     }
 
     /**
@@ -166,9 +142,79 @@ public interface Function0<R> extends λ<R>, Supplier<R> {
      *
      * @param <R> the return type of the function
      */
-    interface Type<R> extends λ.Type<R> {
+    final class Type<R> implements λ.Type<R>, Serializable {
 
-        long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
+        private final Class<R> returnType;
+        private final Class<?>[] parameterArray;
+
+        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
+                .map(c -> c.getName().hashCode())
+                .fold(1, (acc, i) -> acc * 31 + i)
+                * 31 + returnType().getName().hashCode()
+        );
+
+        private Type(Class<R> returnType, Class<?>[] parameterArray) {
+            this.returnType = returnType;
+            this.parameterArray = parameterArray;
+        }
+
+        @SuppressWarnings("unchecked")
+        private static <R> Type<R> of(Function0<R> f) {
+            final MethodType methodType = getLambdaSignature(f);
+            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
+        }
+
+        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
+        private static MethodType getLambdaSignature(Serializable lambda) {
+            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
+            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
+        }
+
+        private static SerializedLambda getSerializedLambda(Serializable lambda) {
+            return Try.of(() -> {
+                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+                method.setAccessible(true);
+                return (SerializedLambda) method.invoke(lambda);
+            }).get();
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public Class<R> returnType() {
+            return returnType;
+        }
+
+        @Override
+        public Class<?>[] parameterArray() {
+            return parameterArray;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof Type) {
+                final Type<?> that = (Type<?>) o;
+                return this.hashCode() == that.hashCode()
+                        && this.returnType.equals(that.returnType)
+                        && Arrays.equals(this.parameterArray, that.parameterArray);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode.get();
+        }
+
+        @Override
+        public String toString() {
+            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
+                    + " -> "
+                    + returnType.getName();
+        }
     }
 }

--- a/src-gen/main/java/javaslang/Function1.java
+++ b/src-gen/main/java/javaslang/Function1.java
@@ -186,6 +186,7 @@ public interface Function1<T1, R> extends λ<R>, Function<T1, R> {
      * @param <R> the return type of the function
      * @since 2.0.0
      */
+    @SuppressWarnings("deprecation")
     final class Type<T1, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;

--- a/src-gen/main/java/javaslang/Function1.java
+++ b/src-gen/main/java/javaslang/Function1.java
@@ -9,10 +9,17 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
+import java.io.Serializable;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import javaslang.collection.List;
+import javaslang.control.Try;
 
 /**
  * Represents a function with one argument.
@@ -174,38 +181,7 @@ public interface Function1<T1, R> extends λ<R>, Function<T1, R> {
 
     @Override
     default Type<T1, R> getType() {
-
-        final λ.Type<R> superType = λ.super.getType();
-
-        return new Type<T1, R>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public Class<R> returnType() {
-                return superType.returnType();
-            }
-
-            @Override
-            public Class<?>[] parameterArray() {
-                return superType.parameterArray();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                return superType.equals(o);
-            }
-
-            @Override
-            public int hashCode() {
-                return superType.hashCode();
-            }
-
-            @Override
-            public String toString() {
-                return superType.toString();
-            }
-        };
+        return Type.of(this);
     }
 
     /**
@@ -216,13 +192,84 @@ public interface Function1<T1, R> extends λ<R>, Function<T1, R> {
      * @param <T1> the 1st parameter type of the function
      * @param <R> the return type of the function
      */
-    interface Type<T1, R> extends λ.Type<R> {
+    final class Type<T1, R> implements λ.Type<R>, Serializable {
 
-        long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
+
+        private final Class<R> returnType;
+        private final Class<?>[] parameterArray;
+
+        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
+                .map(c -> c.getName().hashCode())
+                .fold(1, (acc, i) -> acc * 31 + i)
+                * 31 + returnType().getName().hashCode()
+        );
+
+        private Type(Class<R> returnType, Class<?>[] parameterArray) {
+            this.returnType = returnType;
+            this.parameterArray = parameterArray;
+        }
 
         @SuppressWarnings("unchecked")
-        default Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray()[0];
+        private static <T1, R> Type<T1, R> of(Function1<T1, R> f) {
+            final MethodType methodType = getLambdaSignature(f);
+            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
+        }
+
+        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
+        private static MethodType getLambdaSignature(Serializable lambda) {
+            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
+            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
+        }
+
+        private static SerializedLambda getSerializedLambda(Serializable lambda) {
+            return Try.of(() -> {
+                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+                method.setAccessible(true);
+                return (SerializedLambda) method.invoke(lambda);
+            }).get();
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public Class<R> returnType() {
+            return returnType;
+        }
+
+        @Override
+        public Class<?>[] parameterArray() {
+            return parameterArray;
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T1> parameterType1() {
+            return (Class<T1>) parameterArray[0];
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof Type) {
+                final Type<?, ?> that = (Type<?, ?>) o;
+                return this.hashCode() == that.hashCode()
+                        && this.returnType.equals(that.returnType)
+                        && Arrays.equals(this.parameterArray, that.parameterArray);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode.get();
+        }
+
+        @Override
+        public String toString() {
+            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
+                    + " -> "
+                    + returnType.getName();
         }
     }
 }

--- a/src-gen/main/java/javaslang/Function1.java
+++ b/src-gen/main/java/javaslang/Function1.java
@@ -9,17 +9,10 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import java.io.Serializable;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.SerializedLambda;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
-import javaslang.collection.List;
-import javaslang.control.Try;
 
 /**
  * Represents a function with one argument.
@@ -102,7 +95,7 @@ public interface Function1<T1, R> extends λ<R>, Function<T1, R> {
      * @return true, if this function is applicable to the given objects, false otherwise.
      */
     default boolean isApplicableTo(Object o1) {
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 (o1 == null || paramTypes[0].isAssignableFrom(o1.getClass()));
     }
@@ -115,7 +108,7 @@ public interface Function1<T1, R> extends λ<R>, Function<T1, R> {
      */
     default boolean isApplicableToType(Class<?> type1) {
         Objects.requireNonNull(type1, "type1 is null");
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 paramTypes[0].isAssignableFrom(type1);
     }
@@ -181,7 +174,7 @@ public interface Function1<T1, R> extends λ<R>, Function<T1, R> {
 
     @Override
     default Type<T1, R> getType() {
-        return Type.of(this);
+        return new Type<>(this);
     }
 
     /**
@@ -191,85 +184,20 @@ public interface Function1<T1, R> extends λ<R>, Function<T1, R> {
      *
      * @param <T1> the 1st parameter type of the function
      * @param <R> the return type of the function
+     * @since 2.0.0
      */
-    final class Type<T1, R> implements λ.Type<R>, Serializable {
+    final class Type<T1, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;
 
-        private final Class<R> returnType;
-        private final Class<?>[] parameterArray;
-
-        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
-                .map(c -> c.getName().hashCode())
-                .fold(1, (acc, i) -> acc * 31 + i)
-                * 31 + returnType().getName().hashCode()
-        );
-
-        private Type(Class<R> returnType, Class<?>[] parameterArray) {
-            this.returnType = returnType;
-            this.parameterArray = parameterArray;
-        }
-
-        @SuppressWarnings("unchecked")
-        private static <T1, R> Type<T1, R> of(Function1<T1, R> f) {
-            final MethodType methodType = getLambdaSignature(f);
-            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
-        }
-
-        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
-        private static MethodType getLambdaSignature(Serializable lambda) {
-            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
-            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
-        }
-
-        private static SerializedLambda getSerializedLambda(Serializable lambda) {
-            return Try.of(() -> {
-                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
-                method.setAccessible(true);
-                return (SerializedLambda) method.invoke(lambda);
-            }).get();
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Class<R> returnType() {
-            return returnType;
-        }
-
-        @Override
-        public Class<?>[] parameterArray() {
-            return parameterArray;
+        @SuppressWarnings("deprecation")
+        private Type(Function1<T1, R> λ) {
+            super(λ);
         }
 
         @SuppressWarnings("unchecked")
         public Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray[0];
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) {
-                return true;
-            } else if (o instanceof Type) {
-                final Type<?, ?> that = (Type<?, ?>) o;
-                return this.hashCode() == that.hashCode()
-                        && this.returnType.equals(that.returnType)
-                        && Arrays.equals(this.parameterArray, that.parameterArray);
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return hashCode.get();
-        }
-
-        @Override
-        public String toString() {
-            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
-                    + " -> "
-                    + returnType.getName();
+            return (Class<T1>) parameterTypes()[0];
         }
     }
 }

--- a/src-gen/main/java/javaslang/Function2.java
+++ b/src-gen/main/java/javaslang/Function2.java
@@ -182,6 +182,7 @@ public interface Function2<T1, T2, R> extends λ<R>, BiFunction<T1, T2, R> {
      * @param <R> the return type of the function
      * @since 2.0.0
      */
+    @SuppressWarnings("deprecation")
     final class Type<T1, T2, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;

--- a/src-gen/main/java/javaslang/Function2.java
+++ b/src-gen/main/java/javaslang/Function2.java
@@ -9,10 +9,17 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
+import java.io.Serializable;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
+import javaslang.collection.List;
+import javaslang.control.Try;
 
 /**
  * Represents a function with two arguments.
@@ -169,38 +176,7 @@ public interface Function2<T1, T2, R> extends λ<R>, BiFunction<T1, T2, R> {
 
     @Override
     default Type<T1, T2, R> getType() {
-
-        final λ.Type<R> superType = λ.super.getType();
-
-        return new Type<T1, T2, R>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public Class<R> returnType() {
-                return superType.returnType();
-            }
-
-            @Override
-            public Class<?>[] parameterArray() {
-                return superType.parameterArray();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                return superType.equals(o);
-            }
-
-            @Override
-            public int hashCode() {
-                return superType.hashCode();
-            }
-
-            @Override
-            public String toString() {
-                return superType.toString();
-            }
-        };
+        return Type.of(this);
     }
 
     /**
@@ -212,18 +188,89 @@ public interface Function2<T1, T2, R> extends λ<R>, BiFunction<T1, T2, R> {
      * @param <T2> the 2nd parameter type of the function
      * @param <R> the return type of the function
      */
-    interface Type<T1, T2, R> extends λ.Type<R> {
+    final class Type<T1, T2, R> implements λ.Type<R>, Serializable {
 
-        long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
-        @SuppressWarnings("unchecked")
-        default Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray()[0];
+        private final Class<R> returnType;
+        private final Class<?>[] parameterArray;
+
+        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
+                .map(c -> c.getName().hashCode())
+                .fold(1, (acc, i) -> acc * 31 + i)
+                * 31 + returnType().getName().hashCode()
+        );
+
+        private Type(Class<R> returnType, Class<?>[] parameterArray) {
+            this.returnType = returnType;
+            this.parameterArray = parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray()[1];
+        private static <T1, T2, R> Type<T1, T2, R> of(Function2<T1, T2, R> f) {
+            final MethodType methodType = getLambdaSignature(f);
+            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
+        }
+
+        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
+        private static MethodType getLambdaSignature(Serializable lambda) {
+            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
+            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
+        }
+
+        private static SerializedLambda getSerializedLambda(Serializable lambda) {
+            return Try.of(() -> {
+                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+                method.setAccessible(true);
+                return (SerializedLambda) method.invoke(lambda);
+            }).get();
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public Class<R> returnType() {
+            return returnType;
+        }
+
+        @Override
+        public Class<?>[] parameterArray() {
+            return parameterArray;
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T1> parameterType1() {
+            return (Class<T1>) parameterArray[0];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T2> parameterType2() {
+            return (Class<T2>) parameterArray[1];
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof Type) {
+                final Type<?, ?, ?> that = (Type<?, ?, ?>) o;
+                return this.hashCode() == that.hashCode()
+                        && this.returnType.equals(that.returnType)
+                        && Arrays.equals(this.parameterArray, that.parameterArray);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode.get();
+        }
+
+        @Override
+        public String toString() {
+            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
+                    + " -> "
+                    + returnType.getName();
         }
     }
 }

--- a/src-gen/main/java/javaslang/Function3.java
+++ b/src-gen/main/java/javaslang/Function3.java
@@ -9,9 +9,16 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
+import java.io.Serializable;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import javaslang.collection.List;
+import javaslang.control.Try;
 
 /**
  * Represents a function with three arguments.
@@ -188,38 +195,7 @@ public interface Function3<T1, T2, T3, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, R> getType() {
-
-        final λ.Type<R> superType = λ.super.getType();
-
-        return new Type<T1, T2, T3, R>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public Class<R> returnType() {
-                return superType.returnType();
-            }
-
-            @Override
-            public Class<?>[] parameterArray() {
-                return superType.parameterArray();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                return superType.equals(o);
-            }
-
-            @Override
-            public int hashCode() {
-                return superType.hashCode();
-            }
-
-            @Override
-            public String toString() {
-                return superType.toString();
-            }
-        };
+        return Type.of(this);
     }
 
     /**
@@ -232,23 +208,94 @@ public interface Function3<T1, T2, T3, R> extends λ<R> {
      * @param <T3> the 3rd parameter type of the function
      * @param <R> the return type of the function
      */
-    interface Type<T1, T2, T3, R> extends λ.Type<R> {
+    final class Type<T1, T2, T3, R> implements λ.Type<R>, Serializable {
 
-        long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
-        @SuppressWarnings("unchecked")
-        default Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray()[0];
+        private final Class<R> returnType;
+        private final Class<?>[] parameterArray;
+
+        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
+                .map(c -> c.getName().hashCode())
+                .fold(1, (acc, i) -> acc * 31 + i)
+                * 31 + returnType().getName().hashCode()
+        );
+
+        private Type(Class<R> returnType, Class<?>[] parameterArray) {
+            this.returnType = returnType;
+            this.parameterArray = parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray()[1];
+        private static <T1, T2, T3, R> Type<T1, T2, T3, R> of(Function3<T1, T2, T3, R> f) {
+            final MethodType methodType = getLambdaSignature(f);
+            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
+        }
+
+        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
+        private static MethodType getLambdaSignature(Serializable lambda) {
+            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
+            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
+        }
+
+        private static SerializedLambda getSerializedLambda(Serializable lambda) {
+            return Try.of(() -> {
+                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+                method.setAccessible(true);
+                return (SerializedLambda) method.invoke(lambda);
+            }).get();
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray()[2];
+        @Override
+        public Class<R> returnType() {
+            return returnType;
+        }
+
+        @Override
+        public Class<?>[] parameterArray() {
+            return parameterArray;
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T1> parameterType1() {
+            return (Class<T1>) parameterArray[0];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T2> parameterType2() {
+            return (Class<T2>) parameterArray[1];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T3> parameterType3() {
+            return (Class<T3>) parameterArray[2];
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof Type) {
+                final Type<?, ?, ?, ?> that = (Type<?, ?, ?, ?>) o;
+                return this.hashCode() == that.hashCode()
+                        && this.returnType.equals(that.returnType)
+                        && Arrays.equals(this.parameterArray, that.parameterArray);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode.get();
+        }
+
+        @Override
+        public String toString() {
+            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
+                    + " -> "
+                    + returnType.getName();
         }
     }
 }

--- a/src-gen/main/java/javaslang/Function3.java
+++ b/src-gen/main/java/javaslang/Function3.java
@@ -9,16 +9,9 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import java.io.Serializable;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.SerializedLambda;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import javaslang.collection.List;
-import javaslang.control.Try;
 
 /**
  * Represents a function with three arguments.
@@ -99,7 +92,7 @@ public interface Function3<T1, T2, T3, R> extends λ<R> {
      * @return true, if this function is applicable to the given objects, false otherwise.
      */
     default boolean isApplicableTo(Object o1, Object o2, Object o3) {
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 (o1 == null || paramTypes[0].isAssignableFrom(o1.getClass())) &&
                 (o2 == null || paramTypes[1].isAssignableFrom(o2.getClass())) &&
@@ -118,7 +111,7 @@ public interface Function3<T1, T2, T3, R> extends λ<R> {
         Objects.requireNonNull(type1, "type1 is null");
         Objects.requireNonNull(type2, "type2 is null");
         Objects.requireNonNull(type3, "type3 is null");
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 paramTypes[0].isAssignableFrom(type1) &&
                 paramTypes[1].isAssignableFrom(type2) &&
@@ -195,7 +188,7 @@ public interface Function3<T1, T2, T3, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, R> getType() {
-        return Type.of(this);
+        return new Type<>(this);
     }
 
     /**
@@ -207,95 +200,30 @@ public interface Function3<T1, T2, T3, R> extends λ<R> {
      * @param <T2> the 2nd parameter type of the function
      * @param <T3> the 3rd parameter type of the function
      * @param <R> the return type of the function
+     * @since 2.0.0
      */
-    final class Type<T1, T2, T3, R> implements λ.Type<R>, Serializable {
+    final class Type<T1, T2, T3, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;
 
-        private final Class<R> returnType;
-        private final Class<?>[] parameterArray;
-
-        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
-                .map(c -> c.getName().hashCode())
-                .fold(1, (acc, i) -> acc * 31 + i)
-                * 31 + returnType().getName().hashCode()
-        );
-
-        private Type(Class<R> returnType, Class<?>[] parameterArray) {
-            this.returnType = returnType;
-            this.parameterArray = parameterArray;
-        }
-
-        @SuppressWarnings("unchecked")
-        private static <T1, T2, T3, R> Type<T1, T2, T3, R> of(Function3<T1, T2, T3, R> f) {
-            final MethodType methodType = getLambdaSignature(f);
-            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
-        }
-
-        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
-        private static MethodType getLambdaSignature(Serializable lambda) {
-            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
-            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
-        }
-
-        private static SerializedLambda getSerializedLambda(Serializable lambda) {
-            return Try.of(() -> {
-                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
-                method.setAccessible(true);
-                return (SerializedLambda) method.invoke(lambda);
-            }).get();
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Class<R> returnType() {
-            return returnType;
-        }
-
-        @Override
-        public Class<?>[] parameterArray() {
-            return parameterArray;
+        @SuppressWarnings("deprecation")
+        private Type(Function3<T1, T2, T3, R> λ) {
+            super(λ);
         }
 
         @SuppressWarnings("unchecked")
         public Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray[0];
+            return (Class<T1>) parameterTypes()[0];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray[1];
+            return (Class<T2>) parameterTypes()[1];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray[2];
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) {
-                return true;
-            } else if (o instanceof Type) {
-                final Type<?, ?, ?, ?> that = (Type<?, ?, ?, ?>) o;
-                return this.hashCode() == that.hashCode()
-                        && this.returnType.equals(that.returnType)
-                        && Arrays.equals(this.parameterArray, that.parameterArray);
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return hashCode.get();
-        }
-
-        @Override
-        public String toString() {
-            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
-                    + " -> "
-                    + returnType.getName();
+            return (Class<T3>) parameterTypes()[2];
         }
     }
 }

--- a/src-gen/main/java/javaslang/Function3.java
+++ b/src-gen/main/java/javaslang/Function3.java
@@ -202,6 +202,7 @@ public interface Function3<T1, T2, T3, R> extends λ<R> {
      * @param <R> the return type of the function
      * @since 2.0.0
      */
+    @SuppressWarnings("deprecation")
     final class Type<T1, T2, T3, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;

--- a/src-gen/main/java/javaslang/Function4.java
+++ b/src-gen/main/java/javaslang/Function4.java
@@ -9,9 +9,16 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
+import java.io.Serializable;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import javaslang.collection.List;
+import javaslang.control.Try;
 
 /**
  * Represents a function with 4 arguments.
@@ -209,38 +216,7 @@ public interface Function4<T1, T2, T3, T4, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, T4, R> getType() {
-
-        final λ.Type<R> superType = λ.super.getType();
-
-        return new Type<T1, T2, T3, T4, R>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public Class<R> returnType() {
-                return superType.returnType();
-            }
-
-            @Override
-            public Class<?>[] parameterArray() {
-                return superType.parameterArray();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                return superType.equals(o);
-            }
-
-            @Override
-            public int hashCode() {
-                return superType.hashCode();
-            }
-
-            @Override
-            public String toString() {
-                return superType.toString();
-            }
-        };
+        return Type.of(this);
     }
 
     /**
@@ -254,28 +230,99 @@ public interface Function4<T1, T2, T3, T4, R> extends λ<R> {
      * @param <T4> the 4th parameter type of the function
      * @param <R> the return type of the function
      */
-    interface Type<T1, T2, T3, T4, R> extends λ.Type<R> {
+    final class Type<T1, T2, T3, T4, R> implements λ.Type<R>, Serializable {
 
-        long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
-        @SuppressWarnings("unchecked")
-        default Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray()[0];
+        private final Class<R> returnType;
+        private final Class<?>[] parameterArray;
+
+        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
+                .map(c -> c.getName().hashCode())
+                .fold(1, (acc, i) -> acc * 31 + i)
+                * 31 + returnType().getName().hashCode()
+        );
+
+        private Type(Class<R> returnType, Class<?>[] parameterArray) {
+            this.returnType = returnType;
+            this.parameterArray = parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray()[1];
+        private static <T1, T2, T3, T4, R> Type<T1, T2, T3, T4, R> of(Function4<T1, T2, T3, T4, R> f) {
+            final MethodType methodType = getLambdaSignature(f);
+            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
+        }
+
+        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
+        private static MethodType getLambdaSignature(Serializable lambda) {
+            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
+            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
+        }
+
+        private static SerializedLambda getSerializedLambda(Serializable lambda) {
+            return Try.of(() -> {
+                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+                method.setAccessible(true);
+                return (SerializedLambda) method.invoke(lambda);
+            }).get();
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray()[2];
+        @Override
+        public Class<R> returnType() {
+            return returnType;
+        }
+
+        @Override
+        public Class<?>[] parameterArray() {
+            return parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray()[3];
+        public Class<T1> parameterType1() {
+            return (Class<T1>) parameterArray[0];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T2> parameterType2() {
+            return (Class<T2>) parameterArray[1];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T3> parameterType3() {
+            return (Class<T3>) parameterArray[2];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T4> parameterType4() {
+            return (Class<T4>) parameterArray[3];
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof Type) {
+                final Type<?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?>) o;
+                return this.hashCode() == that.hashCode()
+                        && this.returnType.equals(that.returnType)
+                        && Arrays.equals(this.parameterArray, that.parameterArray);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode.get();
+        }
+
+        @Override
+        public String toString() {
+            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
+                    + " -> "
+                    + returnType.getName();
         }
     }
 }

--- a/src-gen/main/java/javaslang/Function4.java
+++ b/src-gen/main/java/javaslang/Function4.java
@@ -9,16 +9,9 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import java.io.Serializable;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.SerializedLambda;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import javaslang.collection.List;
-import javaslang.control.Try;
 
 /**
  * Represents a function with 4 arguments.
@@ -103,7 +96,7 @@ public interface Function4<T1, T2, T3, T4, R> extends λ<R> {
      * @return true, if this function is applicable to the given objects, false otherwise.
      */
     default boolean isApplicableTo(Object o1, Object o2, Object o3, Object o4) {
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 (o1 == null || paramTypes[0].isAssignableFrom(o1.getClass())) &&
                 (o2 == null || paramTypes[1].isAssignableFrom(o2.getClass())) &&
@@ -125,7 +118,7 @@ public interface Function4<T1, T2, T3, T4, R> extends λ<R> {
         Objects.requireNonNull(type2, "type2 is null");
         Objects.requireNonNull(type3, "type3 is null");
         Objects.requireNonNull(type4, "type4 is null");
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 paramTypes[0].isAssignableFrom(type1) &&
                 paramTypes[1].isAssignableFrom(type2) &&
@@ -216,7 +209,7 @@ public interface Function4<T1, T2, T3, T4, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, T4, R> getType() {
-        return Type.of(this);
+        return new Type<>(this);
     }
 
     /**
@@ -229,100 +222,35 @@ public interface Function4<T1, T2, T3, T4, R> extends λ<R> {
      * @param <T3> the 3rd parameter type of the function
      * @param <T4> the 4th parameter type of the function
      * @param <R> the return type of the function
+     * @since 2.0.0
      */
-    final class Type<T1, T2, T3, T4, R> implements λ.Type<R>, Serializable {
+    final class Type<T1, T2, T3, T4, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;
 
-        private final Class<R> returnType;
-        private final Class<?>[] parameterArray;
-
-        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
-                .map(c -> c.getName().hashCode())
-                .fold(1, (acc, i) -> acc * 31 + i)
-                * 31 + returnType().getName().hashCode()
-        );
-
-        private Type(Class<R> returnType, Class<?>[] parameterArray) {
-            this.returnType = returnType;
-            this.parameterArray = parameterArray;
-        }
-
-        @SuppressWarnings("unchecked")
-        private static <T1, T2, T3, T4, R> Type<T1, T2, T3, T4, R> of(Function4<T1, T2, T3, T4, R> f) {
-            final MethodType methodType = getLambdaSignature(f);
-            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
-        }
-
-        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
-        private static MethodType getLambdaSignature(Serializable lambda) {
-            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
-            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
-        }
-
-        private static SerializedLambda getSerializedLambda(Serializable lambda) {
-            return Try.of(() -> {
-                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
-                method.setAccessible(true);
-                return (SerializedLambda) method.invoke(lambda);
-            }).get();
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Class<R> returnType() {
-            return returnType;
-        }
-
-        @Override
-        public Class<?>[] parameterArray() {
-            return parameterArray;
+        @SuppressWarnings("deprecation")
+        private Type(Function4<T1, T2, T3, T4, R> λ) {
+            super(λ);
         }
 
         @SuppressWarnings("unchecked")
         public Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray[0];
+            return (Class<T1>) parameterTypes()[0];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray[1];
+            return (Class<T2>) parameterTypes()[1];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray[2];
+            return (Class<T3>) parameterTypes()[2];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray[3];
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) {
-                return true;
-            } else if (o instanceof Type) {
-                final Type<?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?>) o;
-                return this.hashCode() == that.hashCode()
-                        && this.returnType.equals(that.returnType)
-                        && Arrays.equals(this.parameterArray, that.parameterArray);
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return hashCode.get();
-        }
-
-        @Override
-        public String toString() {
-            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
-                    + " -> "
-                    + returnType.getName();
+            return (Class<T4>) parameterTypes()[3];
         }
     }
 }

--- a/src-gen/main/java/javaslang/Function4.java
+++ b/src-gen/main/java/javaslang/Function4.java
@@ -224,6 +224,7 @@ public interface Function4<T1, T2, T3, T4, R> extends λ<R> {
      * @param <R> the return type of the function
      * @since 2.0.0
      */
+    @SuppressWarnings("deprecation")
     final class Type<T1, T2, T3, T4, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;

--- a/src-gen/main/java/javaslang/Function5.java
+++ b/src-gen/main/java/javaslang/Function5.java
@@ -9,9 +9,16 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
+import java.io.Serializable;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import javaslang.collection.List;
+import javaslang.control.Try;
 
 /**
  * Represents a function with 5 arguments.
@@ -231,38 +238,7 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, T4, T5, R> getType() {
-
-        final λ.Type<R> superType = λ.super.getType();
-
-        return new Type<T1, T2, T3, T4, T5, R>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public Class<R> returnType() {
-                return superType.returnType();
-            }
-
-            @Override
-            public Class<?>[] parameterArray() {
-                return superType.parameterArray();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                return superType.equals(o);
-            }
-
-            @Override
-            public int hashCode() {
-                return superType.hashCode();
-            }
-
-            @Override
-            public String toString() {
-                return superType.toString();
-            }
-        };
+        return Type.of(this);
     }
 
     /**
@@ -277,33 +253,104 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends λ<R> {
      * @param <T5> the 5th parameter type of the function
      * @param <R> the return type of the function
      */
-    interface Type<T1, T2, T3, T4, T5, R> extends λ.Type<R> {
+    final class Type<T1, T2, T3, T4, T5, R> implements λ.Type<R>, Serializable {
 
-        long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
-        @SuppressWarnings("unchecked")
-        default Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray()[0];
+        private final Class<R> returnType;
+        private final Class<?>[] parameterArray;
+
+        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
+                .map(c -> c.getName().hashCode())
+                .fold(1, (acc, i) -> acc * 31 + i)
+                * 31 + returnType().getName().hashCode()
+        );
+
+        private Type(Class<R> returnType, Class<?>[] parameterArray) {
+            this.returnType = returnType;
+            this.parameterArray = parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray()[1];
+        private static <T1, T2, T3, T4, T5, R> Type<T1, T2, T3, T4, T5, R> of(Function5<T1, T2, T3, T4, T5, R> f) {
+            final MethodType methodType = getLambdaSignature(f);
+            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
+        }
+
+        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
+        private static MethodType getLambdaSignature(Serializable lambda) {
+            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
+            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
+        }
+
+        private static SerializedLambda getSerializedLambda(Serializable lambda) {
+            return Try.of(() -> {
+                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+                method.setAccessible(true);
+                return (SerializedLambda) method.invoke(lambda);
+            }).get();
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray()[2];
+        @Override
+        public Class<R> returnType() {
+            return returnType;
+        }
+
+        @Override
+        public Class<?>[] parameterArray() {
+            return parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray()[3];
+        public Class<T1> parameterType1() {
+            return (Class<T1>) parameterArray[0];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T5> parameterType5() {
-            return (Class<T5>) parameterArray()[4];
+        public Class<T2> parameterType2() {
+            return (Class<T2>) parameterArray[1];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T3> parameterType3() {
+            return (Class<T3>) parameterArray[2];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T4> parameterType4() {
+            return (Class<T4>) parameterArray[3];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T5> parameterType5() {
+            return (Class<T5>) parameterArray[4];
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof Type) {
+                final Type<?, ?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?, ?>) o;
+                return this.hashCode() == that.hashCode()
+                        && this.returnType.equals(that.returnType)
+                        && Arrays.equals(this.parameterArray, that.parameterArray);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode.get();
+        }
+
+        @Override
+        public String toString() {
+            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
+                    + " -> "
+                    + returnType.getName();
         }
     }
 }

--- a/src-gen/main/java/javaslang/Function5.java
+++ b/src-gen/main/java/javaslang/Function5.java
@@ -9,16 +9,9 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import java.io.Serializable;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.SerializedLambda;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import javaslang.collection.List;
-import javaslang.control.Try;
 
 /**
  * Represents a function with 5 arguments.
@@ -107,7 +100,7 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends λ<R> {
      * @return true, if this function is applicable to the given objects, false otherwise.
      */
     default boolean isApplicableTo(Object o1, Object o2, Object o3, Object o4, Object o5) {
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 (o1 == null || paramTypes[0].isAssignableFrom(o1.getClass())) &&
                 (o2 == null || paramTypes[1].isAssignableFrom(o2.getClass())) &&
@@ -132,7 +125,7 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends λ<R> {
         Objects.requireNonNull(type3, "type3 is null");
         Objects.requireNonNull(type4, "type4 is null");
         Objects.requireNonNull(type5, "type5 is null");
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 paramTypes[0].isAssignableFrom(type1) &&
                 paramTypes[1].isAssignableFrom(type2) &&
@@ -238,7 +231,7 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, T4, T5, R> getType() {
-        return Type.of(this);
+        return new Type<>(this);
     }
 
     /**
@@ -252,105 +245,40 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends λ<R> {
      * @param <T4> the 4th parameter type of the function
      * @param <T5> the 5th parameter type of the function
      * @param <R> the return type of the function
+     * @since 2.0.0
      */
-    final class Type<T1, T2, T3, T4, T5, R> implements λ.Type<R>, Serializable {
+    final class Type<T1, T2, T3, T4, T5, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;
 
-        private final Class<R> returnType;
-        private final Class<?>[] parameterArray;
-
-        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
-                .map(c -> c.getName().hashCode())
-                .fold(1, (acc, i) -> acc * 31 + i)
-                * 31 + returnType().getName().hashCode()
-        );
-
-        private Type(Class<R> returnType, Class<?>[] parameterArray) {
-            this.returnType = returnType;
-            this.parameterArray = parameterArray;
-        }
-
-        @SuppressWarnings("unchecked")
-        private static <T1, T2, T3, T4, T5, R> Type<T1, T2, T3, T4, T5, R> of(Function5<T1, T2, T3, T4, T5, R> f) {
-            final MethodType methodType = getLambdaSignature(f);
-            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
-        }
-
-        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
-        private static MethodType getLambdaSignature(Serializable lambda) {
-            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
-            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
-        }
-
-        private static SerializedLambda getSerializedLambda(Serializable lambda) {
-            return Try.of(() -> {
-                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
-                method.setAccessible(true);
-                return (SerializedLambda) method.invoke(lambda);
-            }).get();
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Class<R> returnType() {
-            return returnType;
-        }
-
-        @Override
-        public Class<?>[] parameterArray() {
-            return parameterArray;
+        @SuppressWarnings("deprecation")
+        private Type(Function5<T1, T2, T3, T4, T5, R> λ) {
+            super(λ);
         }
 
         @SuppressWarnings("unchecked")
         public Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray[0];
+            return (Class<T1>) parameterTypes()[0];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray[1];
+            return (Class<T2>) parameterTypes()[1];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray[2];
+            return (Class<T3>) parameterTypes()[2];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray[3];
+            return (Class<T4>) parameterTypes()[3];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T5> parameterType5() {
-            return (Class<T5>) parameterArray[4];
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) {
-                return true;
-            } else if (o instanceof Type) {
-                final Type<?, ?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?, ?>) o;
-                return this.hashCode() == that.hashCode()
-                        && this.returnType.equals(that.returnType)
-                        && Arrays.equals(this.parameterArray, that.parameterArray);
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return hashCode.get();
-        }
-
-        @Override
-        public String toString() {
-            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
-                    + " -> "
-                    + returnType.getName();
+            return (Class<T5>) parameterTypes()[4];
         }
     }
 }

--- a/src-gen/main/java/javaslang/Function5.java
+++ b/src-gen/main/java/javaslang/Function5.java
@@ -247,6 +247,7 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends λ<R> {
      * @param <R> the return type of the function
      * @since 2.0.0
      */
+    @SuppressWarnings("deprecation")
     final class Type<T1, T2, T3, T4, T5, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;

--- a/src-gen/main/java/javaslang/Function6.java
+++ b/src-gen/main/java/javaslang/Function6.java
@@ -9,9 +9,16 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
+import java.io.Serializable;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import javaslang.collection.List;
+import javaslang.control.Try;
 
 /**
  * Represents a function with 6 arguments.
@@ -254,38 +261,7 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, T4, T5, T6, R> getType() {
-
-        final λ.Type<R> superType = λ.super.getType();
-
-        return new Type<T1, T2, T3, T4, T5, T6, R>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public Class<R> returnType() {
-                return superType.returnType();
-            }
-
-            @Override
-            public Class<?>[] parameterArray() {
-                return superType.parameterArray();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                return superType.equals(o);
-            }
-
-            @Override
-            public int hashCode() {
-                return superType.hashCode();
-            }
-
-            @Override
-            public String toString() {
-                return superType.toString();
-            }
-        };
+        return Type.of(this);
     }
 
     /**
@@ -301,38 +277,109 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
      * @param <T6> the 6th parameter type of the function
      * @param <R> the return type of the function
      */
-    interface Type<T1, T2, T3, T4, T5, T6, R> extends λ.Type<R> {
+    final class Type<T1, T2, T3, T4, T5, T6, R> implements λ.Type<R>, Serializable {
 
-        long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
-        @SuppressWarnings("unchecked")
-        default Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray()[0];
+        private final Class<R> returnType;
+        private final Class<?>[] parameterArray;
+
+        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
+                .map(c -> c.getName().hashCode())
+                .fold(1, (acc, i) -> acc * 31 + i)
+                * 31 + returnType().getName().hashCode()
+        );
+
+        private Type(Class<R> returnType, Class<?>[] parameterArray) {
+            this.returnType = returnType;
+            this.parameterArray = parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray()[1];
+        private static <T1, T2, T3, T4, T5, T6, R> Type<T1, T2, T3, T4, T5, T6, R> of(Function6<T1, T2, T3, T4, T5, T6, R> f) {
+            final MethodType methodType = getLambdaSignature(f);
+            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
+        }
+
+        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
+        private static MethodType getLambdaSignature(Serializable lambda) {
+            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
+            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
+        }
+
+        private static SerializedLambda getSerializedLambda(Serializable lambda) {
+            return Try.of(() -> {
+                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+                method.setAccessible(true);
+                return (SerializedLambda) method.invoke(lambda);
+            }).get();
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray()[2];
+        @Override
+        public Class<R> returnType() {
+            return returnType;
+        }
+
+        @Override
+        public Class<?>[] parameterArray() {
+            return parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray()[3];
+        public Class<T1> parameterType1() {
+            return (Class<T1>) parameterArray[0];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T5> parameterType5() {
-            return (Class<T5>) parameterArray()[4];
+        public Class<T2> parameterType2() {
+            return (Class<T2>) parameterArray[1];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T6> parameterType6() {
-            return (Class<T6>) parameterArray()[5];
+        public Class<T3> parameterType3() {
+            return (Class<T3>) parameterArray[2];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T4> parameterType4() {
+            return (Class<T4>) parameterArray[3];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T5> parameterType5() {
+            return (Class<T5>) parameterArray[4];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T6> parameterType6() {
+            return (Class<T6>) parameterArray[5];
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof Type) {
+                final Type<?, ?, ?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?, ?, ?>) o;
+                return this.hashCode() == that.hashCode()
+                        && this.returnType.equals(that.returnType)
+                        && Arrays.equals(this.parameterArray, that.parameterArray);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode.get();
+        }
+
+        @Override
+        public String toString() {
+            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
+                    + " -> "
+                    + returnType.getName();
         }
     }
 }

--- a/src-gen/main/java/javaslang/Function6.java
+++ b/src-gen/main/java/javaslang/Function6.java
@@ -271,6 +271,7 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
      * @param <R> the return type of the function
      * @since 2.0.0
      */
+    @SuppressWarnings("deprecation")
     final class Type<T1, T2, T3, T4, T5, T6, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;

--- a/src-gen/main/java/javaslang/Function6.java
+++ b/src-gen/main/java/javaslang/Function6.java
@@ -9,16 +9,9 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import java.io.Serializable;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.SerializedLambda;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import javaslang.collection.List;
-import javaslang.control.Try;
 
 /**
  * Represents a function with 6 arguments.
@@ -111,7 +104,7 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
      * @return true, if this function is applicable to the given objects, false otherwise.
      */
     default boolean isApplicableTo(Object o1, Object o2, Object o3, Object o4, Object o5, Object o6) {
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 (o1 == null || paramTypes[0].isAssignableFrom(o1.getClass())) &&
                 (o2 == null || paramTypes[1].isAssignableFrom(o2.getClass())) &&
@@ -139,7 +132,7 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
         Objects.requireNonNull(type4, "type4 is null");
         Objects.requireNonNull(type5, "type5 is null");
         Objects.requireNonNull(type6, "type6 is null");
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 paramTypes[0].isAssignableFrom(type1) &&
                 paramTypes[1].isAssignableFrom(type2) &&
@@ -261,7 +254,7 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, T4, T5, T6, R> getType() {
-        return Type.of(this);
+        return new Type<>(this);
     }
 
     /**
@@ -276,110 +269,45 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
      * @param <T5> the 5th parameter type of the function
      * @param <T6> the 6th parameter type of the function
      * @param <R> the return type of the function
+     * @since 2.0.0
      */
-    final class Type<T1, T2, T3, T4, T5, T6, R> implements λ.Type<R>, Serializable {
+    final class Type<T1, T2, T3, T4, T5, T6, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;
 
-        private final Class<R> returnType;
-        private final Class<?>[] parameterArray;
-
-        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
-                .map(c -> c.getName().hashCode())
-                .fold(1, (acc, i) -> acc * 31 + i)
-                * 31 + returnType().getName().hashCode()
-        );
-
-        private Type(Class<R> returnType, Class<?>[] parameterArray) {
-            this.returnType = returnType;
-            this.parameterArray = parameterArray;
-        }
-
-        @SuppressWarnings("unchecked")
-        private static <T1, T2, T3, T4, T5, T6, R> Type<T1, T2, T3, T4, T5, T6, R> of(Function6<T1, T2, T3, T4, T5, T6, R> f) {
-            final MethodType methodType = getLambdaSignature(f);
-            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
-        }
-
-        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
-        private static MethodType getLambdaSignature(Serializable lambda) {
-            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
-            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
-        }
-
-        private static SerializedLambda getSerializedLambda(Serializable lambda) {
-            return Try.of(() -> {
-                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
-                method.setAccessible(true);
-                return (SerializedLambda) method.invoke(lambda);
-            }).get();
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Class<R> returnType() {
-            return returnType;
-        }
-
-        @Override
-        public Class<?>[] parameterArray() {
-            return parameterArray;
+        @SuppressWarnings("deprecation")
+        private Type(Function6<T1, T2, T3, T4, T5, T6, R> λ) {
+            super(λ);
         }
 
         @SuppressWarnings("unchecked")
         public Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray[0];
+            return (Class<T1>) parameterTypes()[0];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray[1];
+            return (Class<T2>) parameterTypes()[1];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray[2];
+            return (Class<T3>) parameterTypes()[2];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray[3];
+            return (Class<T4>) parameterTypes()[3];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T5> parameterType5() {
-            return (Class<T5>) parameterArray[4];
+            return (Class<T5>) parameterTypes()[4];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T6> parameterType6() {
-            return (Class<T6>) parameterArray[5];
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) {
-                return true;
-            } else if (o instanceof Type) {
-                final Type<?, ?, ?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?, ?, ?>) o;
-                return this.hashCode() == that.hashCode()
-                        && this.returnType.equals(that.returnType)
-                        && Arrays.equals(this.parameterArray, that.parameterArray);
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return hashCode.get();
-        }
-
-        @Override
-        public String toString() {
-            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
-                    + " -> "
-                    + returnType.getName();
+            return (Class<T6>) parameterTypes()[5];
         }
     }
 }

--- a/src-gen/main/java/javaslang/Function7.java
+++ b/src-gen/main/java/javaslang/Function7.java
@@ -9,9 +9,16 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
+import java.io.Serializable;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import javaslang.collection.List;
+import javaslang.control.Try;
 
 /**
  * Represents a function with 7 arguments.
@@ -278,38 +285,7 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, T4, T5, T6, T7, R> getType() {
-
-        final λ.Type<R> superType = λ.super.getType();
-
-        return new Type<T1, T2, T3, T4, T5, T6, T7, R>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public Class<R> returnType() {
-                return superType.returnType();
-            }
-
-            @Override
-            public Class<?>[] parameterArray() {
-                return superType.parameterArray();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                return superType.equals(o);
-            }
-
-            @Override
-            public int hashCode() {
-                return superType.hashCode();
-            }
-
-            @Override
-            public String toString() {
-                return superType.toString();
-            }
-        };
+        return Type.of(this);
     }
 
     /**
@@ -326,43 +302,114 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
      * @param <T7> the 7th parameter type of the function
      * @param <R> the return type of the function
      */
-    interface Type<T1, T2, T3, T4, T5, T6, T7, R> extends λ.Type<R> {
+    final class Type<T1, T2, T3, T4, T5, T6, T7, R> implements λ.Type<R>, Serializable {
 
-        long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
-        @SuppressWarnings("unchecked")
-        default Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray()[0];
+        private final Class<R> returnType;
+        private final Class<?>[] parameterArray;
+
+        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
+                .map(c -> c.getName().hashCode())
+                .fold(1, (acc, i) -> acc * 31 + i)
+                * 31 + returnType().getName().hashCode()
+        );
+
+        private Type(Class<R> returnType, Class<?>[] parameterArray) {
+            this.returnType = returnType;
+            this.parameterArray = parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray()[1];
+        private static <T1, T2, T3, T4, T5, T6, T7, R> Type<T1, T2, T3, T4, T5, T6, T7, R> of(Function7<T1, T2, T3, T4, T5, T6, T7, R> f) {
+            final MethodType methodType = getLambdaSignature(f);
+            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
+        }
+
+        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
+        private static MethodType getLambdaSignature(Serializable lambda) {
+            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
+            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
+        }
+
+        private static SerializedLambda getSerializedLambda(Serializable lambda) {
+            return Try.of(() -> {
+                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+                method.setAccessible(true);
+                return (SerializedLambda) method.invoke(lambda);
+            }).get();
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray()[2];
+        @Override
+        public Class<R> returnType() {
+            return returnType;
+        }
+
+        @Override
+        public Class<?>[] parameterArray() {
+            return parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray()[3];
+        public Class<T1> parameterType1() {
+            return (Class<T1>) parameterArray[0];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T5> parameterType5() {
-            return (Class<T5>) parameterArray()[4];
+        public Class<T2> parameterType2() {
+            return (Class<T2>) parameterArray[1];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T6> parameterType6() {
-            return (Class<T6>) parameterArray()[5];
+        public Class<T3> parameterType3() {
+            return (Class<T3>) parameterArray[2];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T7> parameterType7() {
-            return (Class<T7>) parameterArray()[6];
+        public Class<T4> parameterType4() {
+            return (Class<T4>) parameterArray[3];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T5> parameterType5() {
+            return (Class<T5>) parameterArray[4];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T6> parameterType6() {
+            return (Class<T6>) parameterArray[5];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T7> parameterType7() {
+            return (Class<T7>) parameterArray[6];
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof Type) {
+                final Type<?, ?, ?, ?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?, ?, ?, ?>) o;
+                return this.hashCode() == that.hashCode()
+                        && this.returnType.equals(that.returnType)
+                        && Arrays.equals(this.parameterArray, that.parameterArray);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode.get();
+        }
+
+        @Override
+        public String toString() {
+            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
+                    + " -> "
+                    + returnType.getName();
         }
     }
 }

--- a/src-gen/main/java/javaslang/Function7.java
+++ b/src-gen/main/java/javaslang/Function7.java
@@ -9,16 +9,9 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import java.io.Serializable;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.SerializedLambda;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import javaslang.collection.List;
-import javaslang.control.Try;
 
 /**
  * Represents a function with 7 arguments.
@@ -115,7 +108,7 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
      * @return true, if this function is applicable to the given objects, false otherwise.
      */
     default boolean isApplicableTo(Object o1, Object o2, Object o3, Object o4, Object o5, Object o6, Object o7) {
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 (o1 == null || paramTypes[0].isAssignableFrom(o1.getClass())) &&
                 (o2 == null || paramTypes[1].isAssignableFrom(o2.getClass())) &&
@@ -146,7 +139,7 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
         Objects.requireNonNull(type5, "type5 is null");
         Objects.requireNonNull(type6, "type6 is null");
         Objects.requireNonNull(type7, "type7 is null");
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 paramTypes[0].isAssignableFrom(type1) &&
                 paramTypes[1].isAssignableFrom(type2) &&
@@ -285,7 +278,7 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, T4, T5, T6, T7, R> getType() {
-        return Type.of(this);
+        return new Type<>(this);
     }
 
     /**
@@ -301,115 +294,50 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
      * @param <T6> the 6th parameter type of the function
      * @param <T7> the 7th parameter type of the function
      * @param <R> the return type of the function
+     * @since 2.0.0
      */
-    final class Type<T1, T2, T3, T4, T5, T6, T7, R> implements λ.Type<R>, Serializable {
+    final class Type<T1, T2, T3, T4, T5, T6, T7, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;
 
-        private final Class<R> returnType;
-        private final Class<?>[] parameterArray;
-
-        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
-                .map(c -> c.getName().hashCode())
-                .fold(1, (acc, i) -> acc * 31 + i)
-                * 31 + returnType().getName().hashCode()
-        );
-
-        private Type(Class<R> returnType, Class<?>[] parameterArray) {
-            this.returnType = returnType;
-            this.parameterArray = parameterArray;
-        }
-
-        @SuppressWarnings("unchecked")
-        private static <T1, T2, T3, T4, T5, T6, T7, R> Type<T1, T2, T3, T4, T5, T6, T7, R> of(Function7<T1, T2, T3, T4, T5, T6, T7, R> f) {
-            final MethodType methodType = getLambdaSignature(f);
-            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
-        }
-
-        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
-        private static MethodType getLambdaSignature(Serializable lambda) {
-            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
-            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
-        }
-
-        private static SerializedLambda getSerializedLambda(Serializable lambda) {
-            return Try.of(() -> {
-                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
-                method.setAccessible(true);
-                return (SerializedLambda) method.invoke(lambda);
-            }).get();
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Class<R> returnType() {
-            return returnType;
-        }
-
-        @Override
-        public Class<?>[] parameterArray() {
-            return parameterArray;
+        @SuppressWarnings("deprecation")
+        private Type(Function7<T1, T2, T3, T4, T5, T6, T7, R> λ) {
+            super(λ);
         }
 
         @SuppressWarnings("unchecked")
         public Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray[0];
+            return (Class<T1>) parameterTypes()[0];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray[1];
+            return (Class<T2>) parameterTypes()[1];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray[2];
+            return (Class<T3>) parameterTypes()[2];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray[3];
+            return (Class<T4>) parameterTypes()[3];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T5> parameterType5() {
-            return (Class<T5>) parameterArray[4];
+            return (Class<T5>) parameterTypes()[4];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T6> parameterType6() {
-            return (Class<T6>) parameterArray[5];
+            return (Class<T6>) parameterTypes()[5];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T7> parameterType7() {
-            return (Class<T7>) parameterArray[6];
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) {
-                return true;
-            } else if (o instanceof Type) {
-                final Type<?, ?, ?, ?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?, ?, ?, ?>) o;
-                return this.hashCode() == that.hashCode()
-                        && this.returnType.equals(that.returnType)
-                        && Arrays.equals(this.parameterArray, that.parameterArray);
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return hashCode.get();
-        }
-
-        @Override
-        public String toString() {
-            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
-                    + " -> "
-                    + returnType.getName();
+            return (Class<T7>) parameterTypes()[6];
         }
     }
 }

--- a/src-gen/main/java/javaslang/Function7.java
+++ b/src-gen/main/java/javaslang/Function7.java
@@ -296,6 +296,7 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
      * @param <R> the return type of the function
      * @since 2.0.0
      */
+    @SuppressWarnings("deprecation")
     final class Type<T1, T2, T3, T4, T5, T6, T7, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;

--- a/src-gen/main/java/javaslang/Function8.java
+++ b/src-gen/main/java/javaslang/Function8.java
@@ -9,9 +9,16 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
+import java.io.Serializable;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import javaslang.collection.List;
+import javaslang.control.Try;
 
 /**
  * Represents a function with 8 arguments.
@@ -303,38 +310,7 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, T4, T5, T6, T7, T8, R> getType() {
-
-        final λ.Type<R> superType = λ.super.getType();
-
-        return new Type<T1, T2, T3, T4, T5, T6, T7, T8, R>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public Class<R> returnType() {
-                return superType.returnType();
-            }
-
-            @Override
-            public Class<?>[] parameterArray() {
-                return superType.parameterArray();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                return superType.equals(o);
-            }
-
-            @Override
-            public int hashCode() {
-                return superType.hashCode();
-            }
-
-            @Override
-            public String toString() {
-                return superType.toString();
-            }
-        };
+        return Type.of(this);
     }
 
     /**
@@ -352,48 +328,119 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<R> {
      * @param <T8> the 8th parameter type of the function
      * @param <R> the return type of the function
      */
-    interface Type<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ.Type<R> {
+    final class Type<T1, T2, T3, T4, T5, T6, T7, T8, R> implements λ.Type<R>, Serializable {
 
-        long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
-        @SuppressWarnings("unchecked")
-        default Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray()[0];
+        private final Class<R> returnType;
+        private final Class<?>[] parameterArray;
+
+        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
+                .map(c -> c.getName().hashCode())
+                .fold(1, (acc, i) -> acc * 31 + i)
+                * 31 + returnType().getName().hashCode()
+        );
+
+        private Type(Class<R> returnType, Class<?>[] parameterArray) {
+            this.returnType = returnType;
+            this.parameterArray = parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray()[1];
+        private static <T1, T2, T3, T4, T5, T6, T7, T8, R> Type<T1, T2, T3, T4, T5, T6, T7, T8, R> of(Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> f) {
+            final MethodType methodType = getLambdaSignature(f);
+            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
+        }
+
+        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
+        private static MethodType getLambdaSignature(Serializable lambda) {
+            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
+            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
+        }
+
+        private static SerializedLambda getSerializedLambda(Serializable lambda) {
+            return Try.of(() -> {
+                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+                method.setAccessible(true);
+                return (SerializedLambda) method.invoke(lambda);
+            }).get();
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray()[2];
+        @Override
+        public Class<R> returnType() {
+            return returnType;
+        }
+
+        @Override
+        public Class<?>[] parameterArray() {
+            return parameterArray;
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray()[3];
+        public Class<T1> parameterType1() {
+            return (Class<T1>) parameterArray[0];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T5> parameterType5() {
-            return (Class<T5>) parameterArray()[4];
+        public Class<T2> parameterType2() {
+            return (Class<T2>) parameterArray[1];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T6> parameterType6() {
-            return (Class<T6>) parameterArray()[5];
+        public Class<T3> parameterType3() {
+            return (Class<T3>) parameterArray[2];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T7> parameterType7() {
-            return (Class<T7>) parameterArray()[6];
+        public Class<T4> parameterType4() {
+            return (Class<T4>) parameterArray[3];
         }
 
         @SuppressWarnings("unchecked")
-        default Class<T8> parameterType8() {
-            return (Class<T8>) parameterArray()[7];
+        public Class<T5> parameterType5() {
+            return (Class<T5>) parameterArray[4];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T6> parameterType6() {
+            return (Class<T6>) parameterArray[5];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T7> parameterType7() {
+            return (Class<T7>) parameterArray[6];
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<T8> parameterType8() {
+            return (Class<T8>) parameterArray[7];
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof Type) {
+                final Type<?, ?, ?, ?, ?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?, ?, ?, ?, ?>) o;
+                return this.hashCode() == that.hashCode()
+                        && this.returnType.equals(that.returnType)
+                        && Arrays.equals(this.parameterArray, that.parameterArray);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode.get();
+        }
+
+        @Override
+        public String toString() {
+            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
+                    + " -> "
+                    + returnType.getName();
         }
     }
 }

--- a/src-gen/main/java/javaslang/Function8.java
+++ b/src-gen/main/java/javaslang/Function8.java
@@ -9,16 +9,9 @@ package javaslang;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import java.io.Serializable;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.SerializedLambda;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import javaslang.collection.List;
-import javaslang.control.Try;
 
 /**
  * Represents a function with 8 arguments.
@@ -119,7 +112,7 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<R> {
      * @return true, if this function is applicable to the given objects, false otherwise.
      */
     default boolean isApplicableTo(Object o1, Object o2, Object o3, Object o4, Object o5, Object o6, Object o7, Object o8) {
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 (o1 == null || paramTypes[0].isAssignableFrom(o1.getClass())) &&
                 (o2 == null || paramTypes[1].isAssignableFrom(o2.getClass())) &&
@@ -153,7 +146,7 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<R> {
         Objects.requireNonNull(type6, "type6 is null");
         Objects.requireNonNull(type7, "type7 is null");
         Objects.requireNonNull(type8, "type8 is null");
-        final Class<?>[] paramTypes = getType().parameterArray();
+        final Class<?>[] paramTypes = getType().parameterTypes();
         return
                 paramTypes[0].isAssignableFrom(type1) &&
                 paramTypes[1].isAssignableFrom(type2) &&
@@ -310,7 +303,7 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<R> {
 
     @Override
     default Type<T1, T2, T3, T4, T5, T6, T7, T8, R> getType() {
-        return Type.of(this);
+        return new Type<>(this);
     }
 
     /**
@@ -327,120 +320,55 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<R> {
      * @param <T7> the 7th parameter type of the function
      * @param <T8> the 8th parameter type of the function
      * @param <R> the return type of the function
+     * @since 2.0.0
      */
-    final class Type<T1, T2, T3, T4, T5, T6, T7, T8, R> implements λ.Type<R>, Serializable {
+    final class Type<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;
 
-        private final Class<R> returnType;
-        private final Class<?>[] parameterArray;
-
-        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterArray())
-                .map(c -> c.getName().hashCode())
-                .fold(1, (acc, i) -> acc * 31 + i)
-                * 31 + returnType().getName().hashCode()
-        );
-
-        private Type(Class<R> returnType, Class<?>[] parameterArray) {
-            this.returnType = returnType;
-            this.parameterArray = parameterArray;
-        }
-
-        @SuppressWarnings("unchecked")
-        private static <T1, T2, T3, T4, T5, T6, T7, T8, R> Type<T1, T2, T3, T4, T5, T6, T7, T8, R> of(Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> f) {
-            final MethodType methodType = getLambdaSignature(f);
-            return new Type<>((Class<R>) methodType.returnType(), methodType.parameterArray());
-        }
-
-        // TODO: get rid of this repitition in every Function*.Type (with Java 9?)
-        private static MethodType getLambdaSignature(Serializable lambda) {
-            final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
-            return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
-        }
-
-        private static SerializedLambda getSerializedLambda(Serializable lambda) {
-            return Try.of(() -> {
-                final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
-                method.setAccessible(true);
-                return (SerializedLambda) method.invoke(lambda);
-            }).get();
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Class<R> returnType() {
-            return returnType;
-        }
-
-        @Override
-        public Class<?>[] parameterArray() {
-            return parameterArray;
+        @SuppressWarnings("deprecation")
+        private Type(Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> λ) {
+            super(λ);
         }
 
         @SuppressWarnings("unchecked")
         public Class<T1> parameterType1() {
-            return (Class<T1>) parameterArray[0];
+            return (Class<T1>) parameterTypes()[0];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T2> parameterType2() {
-            return (Class<T2>) parameterArray[1];
+            return (Class<T2>) parameterTypes()[1];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T3> parameterType3() {
-            return (Class<T3>) parameterArray[2];
+            return (Class<T3>) parameterTypes()[2];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T4> parameterType4() {
-            return (Class<T4>) parameterArray[3];
+            return (Class<T4>) parameterTypes()[3];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T5> parameterType5() {
-            return (Class<T5>) parameterArray[4];
+            return (Class<T5>) parameterTypes()[4];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T6> parameterType6() {
-            return (Class<T6>) parameterArray[5];
+            return (Class<T6>) parameterTypes()[5];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T7> parameterType7() {
-            return (Class<T7>) parameterArray[6];
+            return (Class<T7>) parameterTypes()[6];
         }
 
         @SuppressWarnings("unchecked")
         public Class<T8> parameterType8() {
-            return (Class<T8>) parameterArray[7];
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) {
-                return true;
-            } else if (o instanceof Type) {
-                final Type<?, ?, ?, ?, ?, ?, ?, ?, ?> that = (Type<?, ?, ?, ?, ?, ?, ?, ?, ?>) o;
-                return this.hashCode() == that.hashCode()
-                        && this.returnType.equals(that.returnType)
-                        && Arrays.equals(this.parameterArray, that.parameterArray);
-            } else {
-                return false;
-            }
-        }
-
-        @Override
-        public int hashCode() {
-            return hashCode.get();
-        }
-
-        @Override
-        public String toString() {
-            return List.of(parameterArray).map(Class::getName).join(", ", "(", ")")
-                    + " -> "
-                    + returnType.getName();
+            return (Class<T8>) parameterTypes()[7];
         }
     }
 }

--- a/src-gen/main/java/javaslang/Function8.java
+++ b/src-gen/main/java/javaslang/Function8.java
@@ -322,6 +322,7 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<R> {
      * @param <R> the return type of the function
      * @since 2.0.0
      */
+    @SuppressWarnings("deprecation")
     final class Type<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ.AbstractType<R> {
 
         private static final long serialVersionUID = 1L;

--- a/src/main/java/javaslang/collection/BinaryTree.java
+++ b/src/main/java/javaslang/collection/BinaryTree.java
@@ -537,7 +537,9 @@ public interface BinaryTree<T> extends Tree<T> {
      *
      * @param <T> value type of the binary tree
      * @since 1.1.0
+     * @deprecated Internal API, not intended to be used. This class will disappear from public API as soon as possible.
      */
+    @Deprecated
     abstract class AbstractBinaryTree<T> implements BinaryTree<T> {
 
         /**

--- a/src/main/java/javaslang/collection/BinaryTree.java
+++ b/src/main/java/javaslang/collection/BinaryTree.java
@@ -540,6 +540,12 @@ public interface BinaryTree<T> extends Tree<T> {
      */
     abstract class AbstractBinaryTree<T> implements BinaryTree<T> {
 
+        /**
+         * This class is not public API (but currently cannot be hidden as of Java 8).
+         */
+        protected AbstractBinaryTree() {
+        }
+
         @Override
         public boolean equals(Object o) {
             if (o == this) {

--- a/src/main/java/javaslang/collection/List.java
+++ b/src/main/java/javaslang/collection/List.java
@@ -1537,7 +1537,9 @@ public interface List<T> extends Seq<T>, Stack<T> {
      *
      * @param <T> Component type of the List.
      * @since 1.1.0
+     * @deprecated Internal API, not intended to be used. This class will disappear from public API as soon as possible.
      */
+    @Deprecated
     abstract class AbstractList<T> implements List<T> {
 
         /**

--- a/src/main/java/javaslang/collection/List.java
+++ b/src/main/java/javaslang/collection/List.java
@@ -1529,10 +1529,9 @@ public interface List<T> extends Seq<T>, Stack<T> {
     }
 
     /**
-     * <p>
      * This class is needed because the interface {@link List} cannot use default methods to override Object's non-final
      * methods equals, hashCode and toString.
-     * </p>
+     * <p>
      * See <a href="http://mail.openjdk.java.net/pipermail/lambda-dev/2013-March/008435.html">Allow default methods to
      * override Object's methods</a>.
      *
@@ -1540,6 +1539,12 @@ public interface List<T> extends Seq<T>, Stack<T> {
      * @since 1.1.0
      */
     abstract class AbstractList<T> implements List<T> {
+
+        /**
+         * This class is not public API (but currently cannot be hidden as of Java 8).
+         */
+        protected AbstractList() {
+        }
 
         @Override
         public boolean equals(Object o) {

--- a/src/main/java/javaslang/collection/RoseTree.java
+++ b/src/main/java/javaslang/collection/RoseTree.java
@@ -374,7 +374,9 @@ public interface RoseTree<T> extends Tree<T> {
      *
      * @param <T> value type of the rose tree
      * @since 1.1.0
+     * @deprecated Internal API, not intended to be used. This class will disappear from public API as soon as possible.
      */
+    @Deprecated
     abstract class AbstractRoseTree<T> implements RoseTree<T> {
 
         /**

--- a/src/main/java/javaslang/collection/RoseTree.java
+++ b/src/main/java/javaslang/collection/RoseTree.java
@@ -377,6 +377,12 @@ public interface RoseTree<T> extends Tree<T> {
      */
     abstract class AbstractRoseTree<T> implements RoseTree<T> {
 
+        /**
+         * This class is not public API (but currently cannot be hidden as of Java 8).
+         */
+        protected AbstractRoseTree() {
+        }
+
         @Override
         public boolean equals(Object o) {
             if (o == this) {

--- a/src/main/java/javaslang/collection/Stream.java
+++ b/src/main/java/javaslang/collection/Stream.java
@@ -1660,6 +1660,12 @@ public interface Stream<T> extends Seq<T> {
      */
     abstract class AbstractStream<T> implements Stream<T> {
 
+        /**
+         * This class is not public API (but currently cannot be hidden as of Java 8).
+         */
+        protected AbstractStream() {
+        }
+
         @Override
         public boolean equals(Object o) {
             if (o == this) {

--- a/src/main/java/javaslang/collection/Stream.java
+++ b/src/main/java/javaslang/collection/Stream.java
@@ -1657,7 +1657,9 @@ public interface Stream<T> extends Seq<T> {
      *
      * @param <T> Component type of the Stream.
      * @since 1.1.0
+     * @deprecated Internal API, not intended to be used. This class will disappear from public API as soon as possible.
      */
+    @Deprecated
     abstract class AbstractStream<T> implements Stream<T> {
 
         /**

--- a/src/main/java/javaslang/control/Failure.java
+++ b/src/main/java/javaslang/control/Failure.java
@@ -197,6 +197,7 @@ public final class Failure<T> implements Try<T>, Serializable {
 
         private static final long serialVersionUID = 1L;
 
+        // DEV-NOTE: need to be protected because of serialization
         protected Cause(Throwable cause) {
             super(cause);
         }
@@ -247,7 +248,12 @@ public final class Failure<T> implements Try<T>, Serializable {
 
         private static final long serialVersionUID = 1L;
 
-        public Fatal(Throwable cause) {
+        /**
+         * Use {@link Cause#of(Throwable)} to get an instance of this class.
+         *
+         * @param cause A cause
+         */
+        private Fatal(Throwable cause) {
             super(cause);
         }
 
@@ -264,7 +270,12 @@ public final class Failure<T> implements Try<T>, Serializable {
 
         private static final long serialVersionUID = 1L;
 
-        public NonFatal(Throwable cause) {
+        /**
+         * Use {@link Cause#of(Throwable)} to get an instance of this class.
+         *
+         * @param cause A cause
+         */
+        private NonFatal(Throwable cause) {
             super(cause);
         }
 

--- a/src/main/java/javaslang/control/Failure.java
+++ b/src/main/java/javaslang/control/Failure.java
@@ -197,7 +197,7 @@ public final class Failure<T> implements Try<T>, Serializable {
 
         private static final long serialVersionUID = 1L;
 
-        Cause(Throwable cause) {
+        protected Cause(Throwable cause) {
             super(cause);
         }
 
@@ -247,7 +247,7 @@ public final class Failure<T> implements Try<T>, Serializable {
 
         private static final long serialVersionUID = 1L;
 
-        Fatal(Throwable cause) {
+        public Fatal(Throwable cause) {
             super(cause);
         }
 
@@ -264,7 +264,7 @@ public final class Failure<T> implements Try<T>, Serializable {
 
         private static final long serialVersionUID = 1L;
 
-        NonFatal(Throwable cause) {
+        public NonFatal(Throwable cause) {
             super(cause);
         }
 

--- a/src/main/java/javaslang/λ.java
+++ b/src/main/java/javaslang/λ.java
@@ -117,7 +117,9 @@ public interface λ<R> extends Serializable {
      *
      * @param <R> Result type of the function
      * @since 2.0.0
+     * @deprecated Internal API, not intended to be used. This class will disappear from public API as soon as possible.
      */
+    @Deprecated
     abstract class AbstractType<R> implements Type<R>, Serializable {
 
         private static final long serialVersionUID = 1L;

--- a/src/main/java/javaslang/λ.java
+++ b/src/main/java/javaslang/λ.java
@@ -5,7 +5,14 @@
  */
 package javaslang;
 
+import javaslang.collection.List;
+import javaslang.control.Try;
+
 import java.io.Serializable;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 
 /**
  * This is a general definition of a (checked/unchecked) function of unknown parameters and a return type R.
@@ -82,6 +89,7 @@ public interface λ<R> extends Serializable {
      * Represents the type of a function which consists of <em>parameter types</em> and a <em>return type</em>.
      *
      * @param <R> the return type of the function
+     * @since 2.0.0
      */
     interface Type<R> {
 
@@ -97,7 +105,101 @@ public interface λ<R> extends Serializable {
          *
          * @return the parameter types
          */
-        Class<?>[] parameterArray();
+        Class<?>[] parameterTypes();
+    }
+
+    /**
+     * This class is needed because the interface {@link Type} cannot use default methods to override Object's non-final
+     * methods equals, hashCode and toString.
+     * <p>
+     * See <a href="http://mail.openjdk.java.net/pipermail/lambda-dev/2013-March/008435.html">Allow default methods to
+     * override Object's methods</a>.
+     *
+     * @param <R> Result type of the function
+     * @since 2.0.0
+     */
+    abstract class AbstractType<R> implements Type<R>, Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final Class<R> returnType;
+        private final Class<?>[] parameterTypes;
+
+        private transient final Lazy<Integer> hashCode = Lazy.of(() -> List.of(parameterTypes())
+                        .map(c -> c.getName().hashCode())
+                        .fold(1, (acc, i) -> acc * 31 + i)
+                        * 31 + returnType().getName().hashCode()
+        );
+
+        /**
+         * Internal constructor.
+         *
+         * @param λ the outer function instance of this type
+         * @deprecated There should be a constructor {@code AbstractType(Class<R> returnType, Class<?>[] parameterArray)} but because of implementation details this one is needed. It will disappear as soon as possible.
+         */
+        @SuppressWarnings("unchecked")
+        @Deprecated
+        protected AbstractType(λ<R> λ) {
+
+            // hiding this functionality
+            final class ReflectionUtil {
+
+                MethodType getLambdaSignature(Serializable lambda) {
+                    final String signature = getSerializedLambda(lambda).getInstantiatedMethodType();
+                    return MethodType.fromMethodDescriptorString(signature, lambda.getClass().getClassLoader());
+                }
+
+                private SerializedLambda getSerializedLambda(Serializable lambda) {
+                    return Try.of(() -> {
+                        final Method method = lambda.getClass().getDeclaredMethod("writeReplace");
+                        method.setAccessible(true);
+                        return (SerializedLambda) method.invoke(lambda);
+                    }).get();
+                }
+            }
+
+            final MethodType methodType = new ReflectionUtil().getLambdaSignature(λ);
+
+            this.returnType = (Class<R>) methodType.returnType();
+            this.parameterTypes = methodType.parameterArray();
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public Class<R> returnType() {
+            return returnType;
+        }
+
+        @Override
+        public Class<?>[] parameterTypes() {
+            return parameterTypes;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof AbstractType) {
+                final AbstractType<?> that = (AbstractType<?>) o;
+                return this.hashCode() == that.hashCode()
+                        && this.returnType().equals(that.returnType)
+                        && Arrays.equals(this.parameterTypes, that.parameterTypes);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode.get();
+        }
+
+        @Override
+        public String toString() {
+            return List.of(parameterTypes).map(Class::getName).join(", ", "(", ")")
+                    + " -> "
+                    + returnType.getName();
+        }
     }
 
     /**


### PR DESCRIPTION
We traded the hiding of Lambda serialization for code repetition (see Function*.Type). It is ok for now, the repetitive code is generated automatically and defined only once within `Generator.scala`.

However, I added a TODO to find a better solution.