### PR TITLE
Implement HashMap.map, fix HashSet.equals

### DIFF
--- a/src/main/java/javaslang/collection/HashMap.java
+++ b/src/main/java/javaslang/collection/HashMap.java
@@ -258,10 +258,10 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
     public <U, W> Map<U, W> map(BiFunction<? super K, ? super V, ? extends Entry<? extends U, ? extends W>> mapper) {
         return null;
     }
-
     @Override
     public <U> Set<U> map(Function<? super Entry<K, V>, ? extends U> mapper) {
-        return null;
+        Objects.requireNonNull(mapper, "mapper is null");
+        return foldLeft(HashSet.empty(), (acc, entry) -> acc.add(mapper.apply(entry)));
     }
 
     @Override

--- a/src/main/java/javaslang/collection/HashSet.java
+++ b/src/main/java/javaslang/collection/HashSet.java
@@ -480,14 +480,14 @@ public final class HashSet<T> implements Set<T>, Serializable {
         return hash.get();
     }
 
-    @Override
     @SuppressWarnings("unchecked")
+    @Override
     public boolean equals(Object o) {
         if (o == this) {
             return true;
         } else if (o instanceof HashSet) {
-            final HashSet<T> that = (HashSet<T>) o;
-            return this.iterator().equals(that.iterator());
+            final HashSet<?> that = (HashSet<?>) o;
+            return this.length() == that.length() && ((HashSet<Object>) this).containsAll(that);
         } else {
             return false;
         }

--- a/src/main/java/javaslang/collection/HashSet.java
+++ b/src/main/java/javaslang/collection/HashSet.java
@@ -481,11 +481,12 @@ public final class HashSet<T> implements Set<T>, Serializable {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public boolean equals(Object o) {
         if (o == this) {
             return true;
         } else if (o instanceof HashSet) {
-            final HashSet<?> that = (HashSet<?>) o;
+            final HashSet<T> that = (HashSet<T>) o;
             return this.iterator().equals(that.iterator());
         } else {
             return false;

--- a/src/test/java/javaslang/collection/HashMapTest.java
+++ b/src/test/java/javaslang/collection/HashMapTest.java
@@ -1,0 +1,36 @@
+/*     / \____  _    ______   _____ / \____   ____  _____
+ *    /  \__  \/ \  / \__  \ /  __//  \__  \ /    \/ __  \   Javaslang
+ *  _/  // _\  \  \/  / _\  \\_  \/  // _\  \  /\  \__/  /   Copyright 2014-2015 Daniel Dietrich
+ * /___/ \_____/\____/\_____/____/\___\_____/_/  \_/____/    Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.StrictAssertions.assertThat;
+
+public class HashMapTest {
+
+    // -- map
+
+    @Test
+    public void shouldMapEmpty() {
+        final Set<Integer> expected = HashSet.empty();
+
+        final Set<Integer> actual = HashMap.<Integer,Integer>empty().map(entry -> entry.key);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldMapNonEmpty() {
+        final Set<Integer> expected = HashSet.<Integer>of(1, 2);
+        final Set<Integer> actual =
+                HashMap.<Integer, String>of(
+                    Map.Entry.of(1, "1"),
+                    Map.Entry.of(2, "2"))
+                .map(entry -> entry.key);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/src/test/java/javaslang/collection/HashSetTest.java
+++ b/src/test/java/javaslang/collection/HashSetTest.java
@@ -6,10 +6,13 @@
 package javaslang.collection;
 
 import org.assertj.core.api.*;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.NoSuchElementException;
 import java.util.stream.Collector;
+
+import static org.junit.Assert.assertTrue;
 
 public class HashSetTest extends AbstractTraversableTest {
 
@@ -292,6 +295,11 @@ public class HashSetTest extends AbstractTraversableTest {
     @Override
     public void shouldSlideNonNilBySize2() {
 // TODO
+    }
+
+    @Test
+    public void shouldBeEqual() {
+        assertTrue(HashSet.of(1).equals(HashSet.of(1)));
     }
 
     boolean isThisLazyCollection() {

--- a/src/test/java/javaslang/collection/StreamTest.java
+++ b/src/test/java/javaslang/collection/StreamTest.java
@@ -8,13 +8,17 @@ package javaslang.collection;
 import javaslang.Serializables;
 import javaslang.collection.Stream.Cons;
 import javaslang.collection.Stream.Nil;
+import org.assertj.core.data.MapEntry;
 import org.junit.Test;
 
 import java.io.InvalidObjectException;
+import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.function.Function;
 import java.util.stream.Collector;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.StrictAssertions.entry;
 
 public class StreamTest extends AbstractSeqTest {
 
@@ -285,8 +289,8 @@ public class StreamTest extends AbstractSeqTest {
     @Test
     public void shouldGroupByAndMapProperly() {
         assertThat(Stream.of(1)
-                .groupBy(n -> n)
-                .map(longStreamEntry -> longStreamEntry.key)
+                .groupBy(Function.identity())
+                .map(entry -> entry.key)
                 .toList()).isEqualTo(List.of(1));
     }
 

--- a/src/test/java/javaslang/collection/StreamTest.java
+++ b/src/test/java/javaslang/collection/StreamTest.java
@@ -282,6 +282,14 @@ public class StreamTest extends AbstractSeqTest {
         assertThat(stream.toString()).isEqualTo("Stream(1, 2, ?)");
     }
 
+    @Test
+    public void shouldGroupByAndMapProperly() {
+        assertThat(Stream.of(1)
+                .groupBy(n -> n)
+                .map(longStreamEntry -> longStreamEntry.key)
+                .toList()).isEqualTo(List.of(1));
+    }
+
     // -- Serializable
 
     @Test(expected = InvalidObjectException.class)


### PR DESCRIPTION
As a "side effect" of running tests for `HashMap.map`,
a problem with `HashSet.equals` was identified and fixed.

Fixes #503 and #504.