### PR TITLE
re-enabled type consistency checks

### DIFF
--- a/src/main/java/javaslang/collection/HashMap.java
+++ b/src/main/java/javaslang/collection/HashMap.java
@@ -314,6 +314,16 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
     }
 
     @Override
+    public HashMap<K, V> put(Entry<? extends K, ? extends V> entry) {
+        return put(entry.key, entry.value);
+    }
+
+    @Override
+    public HashMap<K, V> put(Tuple2<? extends K, ? extends V> entry) {
+        return put(entry._1, entry._2);
+    }
+
+    @Override
     public Entry<K, V> reduceRight(BiFunction<? super Entry<K, V>, ? super Entry<K, V>, ? extends Entry<K, V>> op) {
         throw new UnsupportedOperationException("TODO");
     }

--- a/src/main/java/javaslang/collection/Map.java
+++ b/src/main/java/javaslang/collection/Map.java
@@ -49,9 +49,7 @@ public interface Map<K, V> extends Traversable<Map.Entry<K, V>>, Function<K, V> 
      * @param entry A Map.Entry
      * @return A new Map containing these elements and that entry.
      */
-    default Map<K, V> put(Entry<? extends K, ? extends V> entry) {
-        return put(entry.key, entry.value);
-    }
+    Map<K, V> put(Entry<? extends K, ? extends V> entry);
 
     /**
      * Convenience method for {@code put(entry._1, entry._2)}.
@@ -59,9 +57,7 @@ public interface Map<K, V> extends Traversable<Map.Entry<K, V>>, Function<K, V> 
      * @param entry A Map.Entry
      * @return A new Map containing these elements and that entry.
      */
-    default Map<K, V> put(Tuple2<? extends K, ? extends V> entry) {
-        return put(entry._1, entry._2);
-    }
+    Map<K, V> put(Tuple2<? extends K, ? extends V> entry);
 
     Map<K, V> remove(K key);
 

--- a/src/main/java/javaslang/collection/SortedMap.java
+++ b/src/main/java/javaslang/collection/SortedMap.java
@@ -100,6 +100,12 @@ public interface SortedMap<K, V> extends Map<K, V> {
     SortedMap<K, V> put(K key, V value);
 
     @Override
+    SortedMap<K, V> put(Entry<? extends K, ? extends V> entry);
+
+    @Override
+    SortedMap<K, V> put(Tuple2<? extends K, ? extends V> entry);
+
+    @Override
     SortedMap<K, V> remove(K key);
 
     @Override


### PR DESCRIPTION
Now checks are performed, if a method overrides another (instead checking for equality).

Fixes #478