### PR TITLE
Removed TraversableOnce.forAll(Predicate) because it was the same as …

### DIFF
--- a/src/main/java/javaslang/collection/Array.java
+++ b/src/main/java/javaslang/collection/Array.java
@@ -125,11 +125,6 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
     }
 
     @Override
-    public Array<T> findAll(Predicate<? super T> predicate) {
-        throw new UnsupportedOperationException("TODO");
-    }
-
-    @Override
     public <U> Array<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         throw new UnsupportedOperationException("TODO");
     }

--- a/src/main/java/javaslang/collection/CharSeq.java
+++ b/src/main/java/javaslang/collection/CharSeq.java
@@ -247,12 +247,6 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
     }
 
     @Override
-    public CharSeq findAll(Predicate<? super Character> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
-        return filter(predicate);
-    }
-
-    @Override
     public <U> Vector<U> flatMap(Function<? super Character, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (isEmpty()) {

--- a/src/main/java/javaslang/collection/HashMap.java
+++ b/src/main/java/javaslang/collection/HashMap.java
@@ -160,12 +160,6 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
     }
 
     @Override
-    public HashMap<K, V> findAll(Predicate<? super Entry<K, V>> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
-        return filter(predicate);
-    }
-
-    @Override
     public Option<Entry<K, V>> findLast(Predicate<? super Entry<K, V>> predicate) {
         throw new UnsupportedOperationException("TODO");
     }

--- a/src/main/java/javaslang/collection/HashSet.java
+++ b/src/main/java/javaslang/collection/HashSet.java
@@ -186,12 +186,6 @@ public final class HashSet<T> implements Set<T>, Serializable {
     }
 
     @Override
-    public HashSet<T> findAll(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
-        return filter(predicate);
-    }
-
-    @Override
     public Option<T> findLast(Predicate<? super T> predicate) {
         throw new UnsupportedOperationException("TODO");
     }

--- a/src/main/java/javaslang/collection/IndexedSeq.java
+++ b/src/main/java/javaslang/collection/IndexedSeq.java
@@ -70,9 +70,6 @@ public interface IndexedSeq<T> extends Seq<T> {
     IndexedSeq<T> filter(Predicate<? super T> predicate);
 
     @Override
-    IndexedSeq<T> findAll(Predicate<? super T> predicate);
-
-    @Override
     <U> IndexedSeq<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper);
 
     @Override

--- a/src/main/java/javaslang/collection/Iterator.java
+++ b/src/main/java/javaslang/collection/Iterator.java
@@ -413,12 +413,6 @@ public interface Iterator<T> extends java.util.Iterator<T>, TraversableOnce<T> {
     }
 
     @Override
-    default Iterator<T> findAll(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
-        return filter(predicate);
-    }
-
-    @Override
     default Option<T> findLast(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         T last = null;

--- a/src/main/java/javaslang/collection/LinearSeq.java
+++ b/src/main/java/javaslang/collection/LinearSeq.java
@@ -70,9 +70,6 @@ public interface LinearSeq<T> extends Seq<T> {
     LinearSeq<T> filter(Predicate<? super T> predicate);
 
     @Override
-    LinearSeq<T> findAll(Predicate<? super T> predicate);
-
-    @Override
     <U> LinearSeq<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper);
 
     @Override

--- a/src/main/java/javaslang/collection/List.java
+++ b/src/main/java/javaslang/collection/List.java
@@ -706,12 +706,6 @@ public interface List<T> extends LinearSeq<T>, Stack<T> {
     }
 
     @Override
-    default List<T> findAll(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
-        return filter(predicate);
-    }
-
-    @Override
     default <U> List<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (isEmpty()) {

--- a/src/main/java/javaslang/collection/Map.java
+++ b/src/main/java/javaslang/collection/Map.java
@@ -107,9 +107,6 @@ public interface Map<K, V> extends Traversable<Map.Entry<K, V>>, Function<K, V> 
     Map<K, V> filter(Predicate<? super Entry<K, V>> predicate);
 
     @Override
-    Map<K, V> findAll(Predicate<? super Entry<K, V>> predicate);
-
-    @Override
     <U> Set<U> flatMap(Function<? super Entry<K, V>, ? extends Iterable<? extends U>> mapper);
 
     @Override

--- a/src/main/java/javaslang/collection/Queue.java
+++ b/src/main/java/javaslang/collection/Queue.java
@@ -603,12 +603,6 @@ public class Queue<T> implements LinearSeq<T>, Serializable {
     }
 
     @Override
-    public Queue<T> findAll(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
-        return toList().findAll(predicate).toQueue();
-    }
-
-    @Override
     public <U> Queue<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return new Queue<>(front.flatMap(mapper), rear.flatMap(mapper));

--- a/src/main/java/javaslang/collection/Seq.java
+++ b/src/main/java/javaslang/collection/Seq.java
@@ -675,9 +675,6 @@ public interface Seq<T> extends Traversable<T>, IntFunction<T> {
     Seq<T> filter(Predicate<? super T> predicate);
 
     @Override
-    Seq<T> findAll(Predicate<? super T> predicate);
-
-    @Override
     default Option<T> findLast(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return reverse().findFirst(predicate);

--- a/src/main/java/javaslang/collection/Set.java
+++ b/src/main/java/javaslang/collection/Set.java
@@ -71,9 +71,6 @@ public interface Set<T> extends Traversable<T> {
     Set<T> filter(Predicate<? super T> predicate);
 
     @Override
-    Set<T> findAll(Predicate<? super T> predicate);
-
-    @Override
     <U> Set<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper);
 
     @Override

--- a/src/main/java/javaslang/collection/SortedMap.java
+++ b/src/main/java/javaslang/collection/SortedMap.java
@@ -49,9 +49,6 @@ public interface SortedMap<K, V> extends Map<K, V> {
     SortedMap<K, V> filter(Predicate<? super Entry<K, V>> predicate);
 
     @Override
-    SortedMap<K, V> findAll(Predicate<? super Entry<K, V>> predicate);
-
-    @Override
     <U> Set<U> flatMap(Function<? super Entry<K, V>, ? extends Iterable<? extends U>> mapper);
 
     @Override

--- a/src/main/java/javaslang/collection/SortedSet.java
+++ b/src/main/java/javaslang/collection/SortedSet.java
@@ -55,9 +55,6 @@ public interface SortedSet<T> extends Set<T> {
     SortedSet<T> filter(Predicate<? super T> predicate);
 
     @Override
-    SortedSet<T> findAll(Predicate<? super T> predicate);
-
-    @Override
     <U> SortedSet<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper);
 
     @Override

--- a/src/main/java/javaslang/collection/Stack.java
+++ b/src/main/java/javaslang/collection/Stack.java
@@ -505,9 +505,6 @@ public interface Stack<T> extends LinearSeq<T> {
     Stack<T> filter(Predicate<? super T> predicate);
 
     @Override
-    Stack<T> findAll(Predicate<? super T> predicate);
-
-    @Override
     <U> Stack<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper);
 
     @Override

--- a/src/main/java/javaslang/collection/Stream.java
+++ b/src/main/java/javaslang/collection/Stream.java
@@ -824,11 +824,6 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> findAll(Predicate<? super T> predicate) {
-        return filter(predicate);
-    }
-
-    @Override
     default <U> Stream<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return isEmpty() ? Nil.instance() : Stream.ofAll(() -> new Iterator<U>() {

--- a/src/main/java/javaslang/collection/Traversable.java
+++ b/src/main/java/javaslang/collection/Traversable.java
@@ -129,9 +129,6 @@ public interface Traversable<T> extends TraversableOnce<T> {
     Traversable<T> filter(Predicate<? super T> predicate);
 
     @Override
-    Traversable<T> findAll(Predicate<? super T> predicate);
-
-    @Override
     <U> Traversable<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper);
 
     @Override

--- a/src/main/java/javaslang/collection/TraversableOnce.java
+++ b/src/main/java/javaslang/collection/TraversableOnce.java
@@ -83,7 +83,6 @@ import java.util.function.*;
  * <li>{@link #drop(int)}</li>
  * <li>{@link #dropRight(int)}</li>
  * <li>{@link #dropWhile(Predicate)}</li>
- * <li>{@link #findAll(Predicate)}</li>
  * <li>{@link #findFirst(Predicate)}</li>
  * <li>{@link #findLast(Predicate)}</li>
  * <li>{@link #take(int)}</li>
@@ -295,16 +294,6 @@ public interface TraversableOnce<T> extends Value<T> {
      */
     @Override
     TraversableOnce<T> filter(Predicate<? super T> predicate);
-
-    /**
-     * Essentially the same as {@link #filter(Predicate)} but the result type may differ,
-     * i.e. tree.findAll() may be a List.
-     *
-     * @param predicate A predicate.
-     * @return all elements of this which satisfy the given predicate.
-     * @throws NullPointerException if {@code predicate} is null
-     */
-    TraversableOnce<T> findAll(Predicate<? super T> predicate);
 
     /**
      * Returns the first element of this which satisfies the given predicate.

--- a/src/main/java/javaslang/collection/Tree.java
+++ b/src/main/java/javaslang/collection/Tree.java
@@ -201,9 +201,6 @@ public interface Tree<T> extends Traversable<T> {
     List<T> filter(Predicate<? super T> predicate);
 
     @Override
-    List<T> findAll(Predicate<? super T> predicate);
-
-    @Override
     default <U> Tree<U> flatMapVal(Function<? super T, ? extends Value<? extends U>> mapper) {
         return flatMap(mapper);
     }
@@ -359,11 +356,6 @@ public interface Tree<T> extends Traversable<T> {
         @Override
         public List<T> filter(Predicate<? super T> predicate) {
             return traverse().filter(predicate);
-        }
-
-        @Override
-        public List<T> findAll(Predicate<? super T> predicate) {
-            return traverse().findAll(predicate);
         }
 
         @Override
@@ -820,11 +812,6 @@ public interface Tree<T> extends Traversable<T> {
 
         @Override
         public List.Nil<T> filter(Predicate<? super T> predicate) {
-            return List.Nil.instance();
-        }
-
-        @Override
-        public List.Nil<T> findAll(Predicate<? super T> predicate) {
             return List.Nil.instance();
         }
 

--- a/src/main/java/javaslang/collection/TreeSet.java
+++ b/src/main/java/javaslang/collection/TreeSet.java
@@ -556,11 +556,6 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
     }
 
     @Override
-    public TreeSet<T> findAll(Predicate<? super T> predicate) {
-        throw new UnsupportedOperationException("TODO");
-    }
-
-    @Override
     public Option<T> findLast(Predicate<? super T> predicate) {
         throw new UnsupportedOperationException("TODO");
     }

--- a/src/main/java/javaslang/collection/Vector.java
+++ b/src/main/java/javaslang/collection/Vector.java
@@ -685,12 +685,6 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
     }
 
     @Override
-    public Vector<T> findAll(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
-        return filter(predicate);
-    }
-
-    @Override
     public <U> Vector<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (isEmpty()) {

--- a/src/test/java/javaslang/collection/AbstractTraversableTest.java
+++ b/src/test/java/javaslang/collection/AbstractTraversableTest.java
@@ -310,18 +310,6 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         }
     }
 
-    // -- findAll
-
-    @Test
-    public void shouldFindAllOfNil() {
-        assertThat(empty().findAll(ignored -> true)).isEqualTo(empty());
-    }
-
-    @Test
-    public void shouldFindAllOfNonNil() {
-        assertThat(of(1, 2, 3, 4).findAll(i -> i % 2 == 0)).isEqualTo(of(2, 4));
-    }
-
     // -- findFirst
 
     @Test

--- a/src/test/java/javaslang/collection/CharSeqTest.java
+++ b/src/test/java/javaslang/collection/CharSeqTest.java
@@ -317,18 +317,6 @@ public class CharSeqTest {
         }
     }
 
-    // -- findAll
-
-    @Test
-    public void shouldFindAllOfNil() {
-        assertThat(empty().findAll(ignored -> true)).isEqualTo(empty());
-    }
-
-    @Test
-    public void shouldFindAllOfNonNil() {
-        assertThat(CharSeq.of('1', '2', '3', '4').findAll(i -> i % 2 == 0)).isEqualTo(CharSeq.of('2', '4'));
-    }
-
     // -- findFirst
 
     @Test


### PR DESCRIPTION
…filter(Predicate).