### PR TITLE
Vector performance improved #560 #568

### DIFF
--- a/src/main/java/javaslang/collection/Vector.java
+++ b/src/main/java/javaslang/collection/Vector.java
@@ -675,18 +675,17 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
     @Override
     public Iterator<T> iterator() {
         return new Iterator<T>() {
-            private int index = 0;
+            private int index = indexShift;
+            private final int size = trie.size() + indexShift;
 
             @Override
             public boolean hasNext() {
-                return index < trie.size();
+                return index < size;
             }
 
             @Override
             public T next() {
-                final int trieIndex = index + indexShift;
-                index++;
-                return trie.get(trieIndex).get();
+                return trie.get(index++).get();
             }
         };
     }
@@ -782,8 +781,8 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
         List<T> list = List.ofAll(elements);
         final int newIndexShift = indexShift - list.length();
         HashArrayMappedTrie<Integer, T> newTrie = trie;
-        for (int i = 0; !list.isEmpty(); i++) {
-            newTrie = newTrie.put(newIndexShift + i, list.head());
+        for (int i = newIndexShift; !list.isEmpty(); i++) {
+            newTrie = newTrie.put(i, list.head());
             list = list.tail();
         }
         return new Vector<>(newIndexShift, newTrie);

--- a/src/main/java/javaslang/collection/Vector.java
+++ b/src/main/java/javaslang/collection/Vector.java
@@ -29,10 +29,16 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
     private static final Vector<?> EMPTY = new Vector<>(HashArrayMappedTrie.empty());
 
     private final HashArrayMappedTrie<Integer, T> trie;
+    private final int indexShift;
     private final transient Lazy<Integer> hashCode = Lazy.of(() -> Traversable.hash(this));
 
     private Vector(HashArrayMappedTrie<Integer, T> trie) {
+        this(0, trie);
+    }
+
+    private Vector(int indexShift, HashArrayMappedTrie<Integer, T> trie) {
         this.trie = trie;
+        this.indexShift = indexShift;
     }
 
     /**
@@ -394,16 +400,16 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
 
     @Override
     public Vector<T> append(T element) {
-        return new Vector<>(trie.put(trie.size(), element));
+        return new Vector<>(indexShift, trie.put(length() + indexShift, element));
     }
 
     @Override
     public Vector<T> appendAll(java.lang.Iterable<? extends T> elements) {
         HashArrayMappedTrie<Integer, T> result = trie;
         for (T element : elements) {
-            result = result.put(result.size(), element);
+            result = result.put(result.size() + indexShift, element);
         }
-        return new Vector<>(result);
+        return new Vector<>(indexShift, result);
     }
 
     @Override
@@ -543,7 +549,7 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
         if (index < 0 || index >= length()) {
             throw new IndexOutOfBoundsException("get(" + index + ")");
         }
-        return trie.get(index).get();
+        return trie.get(index + indexShift).get();
     }
 
     @Override
@@ -590,7 +596,7 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
         if (isEmpty()) {
             throw new UnsupportedOperationException("init of empty vector");
         }
-        return new Vector<>(trie.remove(length() - 1));
+        return new Vector<>(indexShift, trie.remove(length() + indexShift - 1));
     }
 
     @Override
@@ -678,7 +684,9 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
 
             @Override
             public T next() {
-                return trie.get(index++).get();
+                final int trieIndex = index + indexShift;
+                index++;
+                return trie.get(trieIndex).get();
             }
         };
     }
@@ -765,12 +773,20 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
 
     @Override
     public Vector<T> prepend(T element) {
-        return insert(0, element);
+        final int newIndexShift = indexShift - 1;
+        return new Vector<>(newIndexShift, trie.put(newIndexShift, element));
     }
 
     @Override
     public Vector<T> prependAll(java.lang.Iterable<? extends T> elements) {
-        return insertAll(0, elements);
+        List<T> list = List.ofAll(elements);
+        final int newIndexShift = indexShift - list.length();
+        HashArrayMappedTrie<Integer, T> newTrie = trie;
+        for (int i = 0; !list.isEmpty(); i++) {
+            newTrie = newTrie.put(newIndexShift + i, list.head());
+            list = list.tail();
+        }
+        return new Vector<>(newIndexShift, newTrie);
     }
 
     @Override
@@ -1025,11 +1041,12 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
         if (isEmpty()) {
             throw new UnsupportedOperationException("tail of empty vector");
         }
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        for (int i = 1; i < length(); i++) {
-            trie = trie.put(i - 1, get(i));
+        if(length() == 1) {
+            return empty();
+        } else {
+            final int newIndexShift = indexShift + 1;
+            return new Vector<>(newIndexShift, trie.remove(indexShift));
         }
-        return trie.isEmpty() ? empty() : new Vector<>(trie);
     }
 
     @Override
@@ -1037,11 +1054,11 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
         if (isEmpty()) {
             return None.instance();
         }
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        for (int i = 1; i < length(); i++) {
-            trie = trie.put(i - 1, get(i));
+        if(length() == 1) {
+            return new Some<>(empty());
+        } else {
+            return new Some<>(tail());
         }
-        return new Some<>(trie.isEmpty() ? empty() : new Vector<>(trie));
     }
 
     @Override
@@ -1115,7 +1132,7 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
         if (index >= length()) {
             throw new IndexOutOfBoundsException("update(" + index + ")");
         }
-        return new Vector<>(trie.put(index, element));
+        return new Vector<>(indexShift, trie.put(index + indexShift, element));
     }
 
     @Override

--- a/src/main/java/javaslang/collection/package-info.java
+++ b/src/main/java/javaslang/collection/package-info.java
@@ -23,7 +23,7 @@
  *         <tr><td>{@linkplain javaslang.collection.List}</td><td><small>const</small></td><td><small>const</small></td><td><small>linear</small></td><td><small>linear</small></td><td><small>const</small></td><td><small>linear</small></td><td><small>linear</small></td></tr>
  *         <tr><td>{@linkplain javaslang.collection.Queue}</td><td><small>const</small></td><td><small>const<sup>a</sup></small></td><td><small>linear</small></td><td><small>linear</small></td><td><small>const</small></td><td><small>const</small></td><td><small>linear</small></td></tr>
  *         <tr><td>{@linkplain javaslang.collection.Stream}</td><td><small>const</small></td><td><small>const</small></td><td><small>linear</small></td><td><small>linear</small></td><td><small>const<sup>lazy</sup></small></td><td><small>const<sup>lazy</sup></small></td><td><small>linear</small></td></tr>
- *         <tr><td>{@linkplain javaslang.collection.Vector}</td><td><small>const<sup>eff</sup></small></td><td><small>linear</small></td><td><small>const<sup>eff</sup></small></td><td><small>const<sup>eff</sup></small></td><td><small>linear</small></td><td><small>const<sup>eff</sup></small></td><td><small>linear</small></td></tr>
+ *         <tr><td>{@linkplain javaslang.collection.Vector}</td><td><small>const<sup>eff</sup></small></td><td><small>const<sup>eff</sup></small></td><td><small>const<sup>eff</sup></small></td><td><small>const<sup>eff</sup></small></td><td><small>const<sup>eff</sup></small></td><td><small>const<sup>eff</sup></small></td><td><small>linear</small></td></tr>
  *     </tbody>
  * </table>
  * <br>


### PR DESCRIPTION
First of all,  table of Scala performance characteristics says nothing about <code>Vector.insert()</code>. Maybe it is not exists? :)

Now about <code>Vector.prepend()</code> and <code>Vector.tail()</code>
Let's define additional parameter <code>indexShift</code>. It shows difference between index in vector and corresponding index in HAMT. With it both operations can be implemented in O(1) (because all HAMT operations is O(1), see code).

Please review it carefully. This trick has come out of my head directly and it need to be verified.