### PR TITLE
Simplified Try and Failure.NonFatal.

### DIFF
--- a/src/main/java/javaslang/control/Failure.java
+++ b/src/main/java/javaslang/control/Failure.java
@@ -48,11 +48,6 @@ public final class Failure<T> implements Try<T>, Serializable {
     }
 
     @Override
-    public boolean isFailure() {
-        return true;
-    }
-
-    @Override
     public boolean isSuccess() {
         return false;
     }
@@ -64,23 +59,8 @@ public final class Failure<T> implements Try<T>, Serializable {
     }
 
     @Override
-    public T orElse(T other) {
-        return other;
-    }
-
-    @Override
-    public T orElseGet(Function<? super Throwable, ? extends T> other) {
-        return other.apply(cause.getCause());
-    }
-
-    @Override
-    public void orElseRun(Consumer<? super Throwable> action) {
-        action.accept(cause.getCause());
-    }
-
-    @Override
-    public <X extends Throwable> T orElseThrow(Function<? super Throwable, X> exceptionProvider) throws X {
-        throw exceptionProvider.apply(cause.getCause());
+    public NonFatal getCause() {
+        return cause;
     }
 
     @Override
@@ -105,21 +85,6 @@ public final class Failure<T> implements Try<T>, Serializable {
         } catch (Throwable t) {
             return new Failure<>(t);
         }
-    }
-
-    @Override
-    public None<T> toOption() {
-        return None.instance();
-    }
-
-    @Override
-    public Optional<T> toJavaOptional() {
-        return Optional.empty();
-    }
-
-    @Override
-    public Left<Throwable, T> toEither() {
-        return new Left<>(cause.getCause());
     }
 
     @Override
@@ -169,12 +134,6 @@ public final class Failure<T> implements Try<T>, Serializable {
 
     @Override
     public Failure<T> peek(Consumer<? super T> action) {
-        return this;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public Failure<T> andThen(CheckedConsumer<? super T> f) {
         return this;
     }
 

--- a/src/main/java/javaslang/control/Failure.java
+++ b/src/main/java/javaslang/control/Failure.java
@@ -5,14 +5,8 @@
  */
 package javaslang.control;
 
-import javaslang.CheckedFunction1;
-
 import java.io.Serializable;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Predicate;
 
 /**
  * A failed Try.
@@ -29,27 +23,13 @@ public final class Failure<T> implements Try<T>, Serializable {
     /**
      * Constructs a Failure.
      *
-     * @param t A cause of type Throwable, may not be null.
-     * @throws NullPointerException if t is null
+     * @param exception A cause of type Throwable, may not be null.
+     * @throws NullPointerException if exception is null
+     * @throws Error                if the given exception if fatal, i.e. non-recoverable
      */
-    public Failure(Throwable t) {
-        Objects.requireNonNull(t, "Throwable is null");
-        final Cause cause = Cause.of(t);
-        if (cause.isFatal()) {
-            throw cause;
-        } else {
-            this.cause = (NonFatal) cause;
-        }
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return true;
-    }
-
-    @Override
-    public boolean isSuccess() {
-        return false;
+    public Failure(Throwable exception) {
+        Objects.requireNonNull(exception, "exception is null");
+        cause = NonFatal.of(exception);
     }
 
     // Throws NonFatal instead of Throwable because it is a RuntimeException which does not need to be checked.
@@ -64,77 +44,8 @@ public final class Failure<T> implements Try<T>, Serializable {
     }
 
     @Override
-    public Try<T> recover(Function<Throwable, ? extends T> f) {
-        return Try.of(() -> f.apply(cause.getCause()));
-    }
-
-    @Override
-    public Try<T> recoverWith(Function<Throwable, Try<T>> f) {
-        try {
-            return f.apply(cause.getCause());
-        } catch (Throwable t) {
-            return new Failure<>(t);
-        }
-    }
-
-    @Override
-    public Failure<T> onFailure(Consumer<Throwable> f) {
-        try {
-            f.accept(cause.getCause());
-            return this;
-        } catch (Throwable t) {
-            return new Failure<>(t);
-        }
-    }
-
-    @Override
-    public Success<Throwable> failed() {
-        return new Success<>(cause.getCause());
-    }
-
-    @Override
-    public Failure<T> filter(Predicate<? super T> predicate) {
-        return this;
-    }
-
-    @Override
-    public Failure<T> filterTry(CheckedPredicate<? super T> predicate) {
-        return this;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <U> Failure<U> flatMap(Function<? super T, ? extends java.lang.Iterable<? extends U>> mapper) {
-        return (Failure<U>) this;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <U> Failure<U> flatMapTry(CheckedFunction<? super T, ? extends java.lang.Iterable<? extends U>> mapper) {
-        return (Failure<U>) this;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public Failure<Object> flatten() {
-        return (Failure<Object>) this;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <U> Failure<U> map(Function<? super T, ? extends U> mapper) {
-        return (Failure<U>) this;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <U> Failure<U> mapTry(CheckedFunction1<? super T, ? extends U> f) {
-        return (Failure<U>) this;
-    }
-
-    @Override
-    public Failure<T> peek(Consumer<? super T> action) {
-        return this;
+    public boolean isFailure() {
+        return true;
     }
 
     @Override
@@ -161,104 +72,47 @@ public final class Failure<T> implements Try<T>, Serializable {
     }
 
     /**
-     * Causes wrap Throwables. They are unchecked, i.e. RuntimeExceptions, which are either fatal (represented by
-     * the subclass {@link Fatal}) or non-fatal (represented by the subclass {@link NonFatal}). Fatal causes are
-     * considered to be non-recoverable.
+     * An unchecked wrapper for non-fatal/recoverable exceptions. The underlying exception can
+     * be accessed via {@link #getCause()}.
      * <p>
-     * Use {@link Cause#of(Throwable)} to get an instance of Cause. The instance returned is either of type
-     * {@link Fatal} or {@link NonFatal}.
-     * <p>
-     * {@link #isFatal()} states, if this Cause is considered to be non-recoverable.
+     * The following exceptions are considered as fatal/non-recoverable:
+     * <ul>
+     * <li>LinkageError</li>
+     * <li>ThreadDeath</li>
+     * <li>VirtualMachineError (i.e. OutOfMemoryError or StackOverflowError)</li>
+     * </ul>
      */
-    public static abstract class Cause extends RuntimeException implements Serializable {
+    public static final class NonFatal extends RuntimeException implements Serializable {
 
         private static final long serialVersionUID = 1L;
 
-        // DEV-NOTE: need to be protected because of serialization
-        protected Cause(Throwable cause) {
-            super(cause);
+        private NonFatal(Throwable exception) {
+            super(exception);
         }
 
         /**
-         * Returns true, if this is Fatal, i.e. if the cause is fatal. See {@link Cause#of(Throwable)} for the
-         * definition on when a Throwable is fatal.
+         * Wraps the given exception in a {@code NonFatal} or throws an {@link Error} if the given exception is fatal.
+         * <p>
+         * Note: InterruptedException is not considered to be fatal. It should be handled explicitly but we cannot
+         * throw it directly because it is not an Error. If we would wrap it in an Error, we couldn't handle it
+         * directly. Therefore it is not thrown as fatal exception.
          *
-         * @return true, if this instance is Fatal, false otherwise.
+         * @param exception A Throwable
+         * @return A new {@code NonFatal} if the given exception is recoverable
+         * @throws Error if the given exception is fatal, i.e. not recoverable
          */
-        public abstract boolean isFatal();
-
-        /**
-         * Wraps t in a Cause which is either a {@link Fatal} or a {@link NonFatal}. The given Throwable t is
-         * wrapped in a Fatal, i.e. considered as a non-recoverable, if t is an instance of one of the following
-         * classes:
-         *
-         * <ul>
-         * <li>InterruptedException</li>
-         * <li>LinkageError</li>
-         * <li>ThreadDeath</li>
-         * <li>VirtualMachineError (i.e. OutOfMemoryError or StackOverflowError)</li>
-         * </ul>
-         *
-         * However, StackOverflowError is considered as a non-fatal.
-         *
-         * @param t A Throwable
-         * @return A {@link Fatal}, if t is fatal, a {@link NonFatal} otherwise.
-         * @throws java.lang.NullPointerException if t is null
-         */
-        public static Cause of(Throwable t) {
-            Objects.requireNonNull(t, "Throwable is null");
-            if (t instanceof Cause) {
-                return (Cause) t;
+        static NonFatal of(Throwable exception) {
+            if (exception instanceof NonFatal) {
+                return (NonFatal) exception;
             }
-            final boolean isFatal = t instanceof VirtualMachineError
-                    || t instanceof ThreadDeath
-                    || t instanceof InterruptedException
-                    || t instanceof LinkageError;
-            return isFatal ? new Fatal(t) : new NonFatal(t);
-        }
-    }
-
-    /**
-     * Use {@link Cause#of(Throwable)} to create instances of {@link Fatal} and {@link NonFatal}.
-     */
-    public static final class Fatal extends Cause {
-
-        private static final long serialVersionUID = 1L;
-
-        /**
-         * Use {@link Cause#of(Throwable)} to get an instance of this class.
-         *
-         * @param cause A cause
-         */
-        private Fatal(Throwable cause) {
-            super(cause);
-        }
-
-        @Override
-        public boolean isFatal() {
-            return true;
-        }
-    }
-
-    /**
-     * Use {@link Cause#of(Throwable)} to create instances of {@link Fatal} and {@link NonFatal}.
-     */
-    public static final class NonFatal extends Cause {
-
-        private static final long serialVersionUID = 1L;
-
-        /**
-         * Use {@link Cause#of(Throwable)} to get an instance of this class.
-         *
-         * @param cause A cause
-         */
-        private NonFatal(Throwable cause) {
-            super(cause);
-        }
-
-        @Override
-        public boolean isFatal() {
-            return false;
+            final boolean isFatal = exception instanceof VirtualMachineError
+                    || exception instanceof ThreadDeath
+                    || exception instanceof LinkageError;
+            if (isFatal) {
+                throw (Error) exception;
+            } else {
+                return new NonFatal(exception);
+            }
         }
     }
 }

--- a/src/main/java/javaslang/control/Success.java
+++ b/src/main/java/javaslang/control/Success.java
@@ -11,7 +11,6 @@ import javaslang.Value;
 import java.io.Serializable;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -38,16 +37,6 @@ public final class Success<T> implements Try<T>, Serializable {
     }
 
     @Override
-    public boolean isEmpty() {
-        return false;
-    }
-
-    @Override
-    public boolean isSuccess() {
-        return true;
-    }
-
-    @Override
     public T get() {
         return value;
     }
@@ -58,91 +47,8 @@ public final class Success<T> implements Try<T>, Serializable {
     }
 
     @Override
-    public Success<T> recover(Function<Throwable, ? extends T> f) {
-        return this;
-    }
-
-    @Override
-    public Success<T> recoverWith(Function<Throwable, Try<T>> f) {
-        return this;
-    }
-
-    @Override
-    public Success<T> onFailure(Consumer<Throwable> f) {
-        return this;
-    }
-
-    @Override
-    public Failure<Throwable> failed() {
-        return new Failure<>(new UnsupportedOperationException("Success.failed()"));
-    }
-
-    @Override
-    public Try<T> filter(Predicate<? super T> predicate) {
-        try {
-            if (predicate.test(value)) {
-                return this;
-            } else {
-                return new Failure<>(new NoSuchElementException("Predicate does not hold for " + value));
-            }
-        } catch (Throwable t) {
-            return new Failure<>(t);
-        }
-    }
-
-    @Override
-    public Try<T> filterTry(CheckedPredicate<? super T> predicate) {
-        return Try.of(() -> predicate.test(value)).flatMap(b -> filter(ignored -> b));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <U> Try<U> flatMap(Function<? super T, ? extends java.lang.Iterable<? extends U>> mapper) {
-        return flatMapTry((CheckedFunction<T, java.lang.Iterable<? extends U>>) mapper::apply);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <U> Try<U> flatMapTry(CheckedFunction<? super T, ? extends java.lang.Iterable<? extends U>> mapper) {
-        try {
-            final Iterable<? extends U> iterable = mapper.apply(value);
-            if (iterable instanceof Value) {
-                return ((Value<U>) iterable).toTry();
-            } else {
-                return Try.of(() -> Value.get(iterable));
-            }
-        } catch (Throwable t) {
-            return new Failure<>(t);
-        }
-    }
-
-    @Override
-    public Try<Object> flatten() {
-        return flatMap(value -> (value instanceof Try) ? ((Try<?>) value).flatten() : this);
-    }
-
-    @Override
-    public <U> Try<U> map(Function<? super T, ? extends U> mapper) {
-        try {
-            return new Success<>(mapper.apply(value));
-        } catch (Throwable t) {
-            return new Failure<>(t);
-        }
-    }
-
-    @Override
-    public <U> Try<U> mapTry(CheckedFunction1<? super T, ? extends U> f) {
-        return Try.of(() -> f.apply(value));
-    }
-
-    @Override
-    public Try<T> peek(Consumer<? super T> action) {
-        try {
-            action.accept(value);
-            return this;
-        } catch (Throwable t) {
-            return new Failure<>(t);
-        }
+    public boolean isFailure() {
+        return false;
     }
 
     @Override

--- a/src/main/java/javaslang/control/Success.java
+++ b/src/main/java/javaslang/control/Success.java
@@ -43,11 +43,6 @@ public final class Success<T> implements Try<T>, Serializable {
     }
 
     @Override
-    public boolean isFailure() {
-        return false;
-    }
-
-    @Override
     public boolean isSuccess() {
         return true;
     }
@@ -58,23 +53,8 @@ public final class Success<T> implements Try<T>, Serializable {
     }
 
     @Override
-    public T orElse(T other) {
-        return value;
-    }
-
-    @Override
-    public T orElseGet(Function<? super Throwable, ? extends T> other) {
-        return value;
-    }
-
-    @Override
-    public void orElseRun(Consumer<? super Throwable> action) {
-        // nothing to do
-    }
-
-    @Override
-    public <X extends Throwable> T orElseThrow(Function<? super Throwable, X> exceptionProvider) throws X {
-        return value;
+    public Failure.NonFatal getCause() {
+        throw new UnsupportedOperationException("getCause on Success");
     }
 
     @Override
@@ -163,27 +143,6 @@ public final class Success<T> implements Try<T>, Serializable {
         } catch (Throwable t) {
             return new Failure<>(t);
         }
-    }
-
-    @Override
-    public Some<T> toOption() {
-        return new Some<>(value);
-    }
-
-    @Override
-    public Right<Throwable, T> toEither() {
-        return new Right<>(value);
-    }
-
-    @Override
-    public Optional<T> toJavaOptional() {
-        return Optional.ofNullable(value);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public Try<T> andThen(CheckedConsumer<? super T> consumer) {
-        return Try.run(() -> consumer.accept(value)).flatMap(ignored -> this);
     }
 
     @Override

--- a/src/main/java/javaslang/control/Try.java
+++ b/src/main/java/javaslang/control/Try.java
@@ -8,7 +8,9 @@ package javaslang.control;
 import javaslang.CheckedFunction1;
 import javaslang.Value;
 import javaslang.collection.Iterator;
+import javaslang.control.Failure.NonFatal;
 
+import java.util.NoSuchElementException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -53,159 +55,31 @@ public interface Try<T> extends Value<T> {
     }
 
     /**
-     * Checks if this is a Failure.
-     *
-     * @return true, if this is a Failure, otherwise false, if this is a Success
-     */
-    default boolean isFailure() {
-        return !isSuccess();
-    }
-
-    /**
-     * Checks if this is a Success.
-     *
-     * @return true, if this is a Success, otherwise false, if this is a Failure
-     */
-    boolean isSuccess();
-
-    Failure.NonFatal getCause();
-
-    default T orElseGet(Function<? super Throwable, ? extends T> other) {
-        if (isEmpty()) {
-            return other.apply(getCause().getCause());
-        } else {
-            return get();
-        }
-    }
-
-    default void orElseRun(Consumer<? super Throwable> action) {
-        if (isEmpty()) {
-            action.accept(getCause().getCause());
-        }
-    }
-
-    default <X extends Throwable> T orElseThrow(Function<? super Throwable, X> exceptionProvider) throws X {
-        if (isEmpty()) {
-            throw exceptionProvider.apply(getCause().getCause());
-        } else {
-            return get();
-        }
-    }
-
-    /**
-     * Returns {@code this}, if this is a {@code Success}, otherwise tries to recover the exception of the failure with {@code f},
-     * i.e. calling {@code Try.of(() -> f.apply(throwable))}.
-     *
-     * @param f A recovery function taking a Throwable
-     * @return a new Try
-     */
-    Try<T> recover(Function<Throwable, ? extends T> f);
-
-    /**
-     * Returns {@code this}, if this is a Success, otherwise tries to recover the exception of the failure with {@code f},
-     * i.e. calling {@code f.apply(cause.getCause())}. If an error occurs recovering a Failure, then the new Failure is
-     * returned.
-     *
-     * @param f A recovery function taking a Throwable
-     * @return a new Try
-     */
-    Try<T> recoverWith(Function<Throwable, Try<T>> f);
-
-    /**
-     * Returns {@code Success(throwable)} if this is a {@code Failure(throwable)}, otherwise
-     * a {@code Failure(new UnsupportedOperationException("Success.failed()"))} if this is a Success.
-     *
-     * @return a new Try
-     */
-    Try<Throwable> failed();
-
-    /**
-     * Consumes the throwable if this is a Failure, otherwise returns this Success.
-     *
-     * @param f A Consumer
-     * @return a new Failure, if this is a Failure and the consumer throws, otherwise this, which may be a Success or
-     * a Failure.
-     */
-    Try<T> onFailure(Consumer<Throwable> f);
-
-    default Either<Throwable, T> toEither() {
-        if (isEmpty()) {
-            return new Left<>(getCause().getCause());
-        } else {
-            return new Right<>(get());
-        }
-    }
-
-    /**
-     * <p>Returns {@code this} if this is a Failure or this is a Success and the value satisfies the predicate.</p>
-     * <p>Returns a new Failure, if this is a Success and the value does not satisfy the Predicate or an exception
-     * occurs testing the predicate.</p>
-     *
-     * @param predicate A predicate
-     * @return a new Try
-     */
-    @Override
-    Try<T> filter(Predicate<? super T> predicate);
-
-    Try<T> filterTry(CheckedPredicate<? super T> predicate);
-
-    /**
-     * FlatMaps the value of a Success or returns a Failure.
-     *
-     * @param mapper A mapper
-     * @param <U>    The new component type
-     * @return a new Try
-     */
-    @Override
-    <U> Try<U> flatMap(Function<? super T, ? extends java.lang.Iterable<? extends U>> mapper);
-
-    <U> Try<U> flatMapTry(CheckedFunction<? super T, ? extends java.lang.Iterable<? extends U>> mapper);
-
-    @Override
-    Try<Object> flatten();
-
-    /**
-     * Maps the value of a Success or returns a Failure.
-     *
-     * @param <U>    The new component type
-     * @param mapper A mapper
-     * @return a new Try
-     */
-    <U> Try<U> map(Function<? super T, ? extends U> mapper);
-
-    /**
-     * Runs the given checked function if this is a {@code Success},
+     * Runs the given checked consumer if this is a {@code Success},
      * passing the result of the current expression to it.
      * If this expression is a {@code Failure} then it'll return a new
-     * {@code Failure} of type R with the original exception.
+     * {@code Failure} of type T with the original exception.
      *
      * The main use case is chaining checked functions using method references:
      *
      * <pre>
      * <code>
-     * Try.of(() -&gt; 0)
-     *    .mapTry(x -&gt; 1 / x); // division by zero
+     * Try.of(() -&gt; 100)
+     *    .andThen(i -&gt; System.out.println(i));
+     *
      * </code>
      * </pre>
      *
-     * @param <U>    The new component type
-     * @param mapper A checked function
+     * @param consumer A checked consumer taking a single argument.
      * @return a new {@code Try}
      */
-    <U> Try<U> mapTry(CheckedFunction1<? super T, ? extends U> mapper);
-
-    /**
-     * Applies the action to the value of a Success or does nothing in the case of a Failure.
-     *
-     * @param action A Consumer
-     * @return this Try
-     */
-    @Override
-    Try<T> peek(Consumer<? super T> action);
-
-    @Override
-    default Iterator<T> iterator() {
-        return isSuccess() ? Iterator.of(get()) : Iterator.empty();
+    @SuppressWarnings("unchecked")
+    default Try<T> andThen(CheckedConsumer<? super T> consumer) {
+        if (isFailure()) {
+            return this;
+        } else {
+            return Try.run(() -> consumer.accept(get())).flatMap(ignored -> this);
+        }
     }
 
     /**
@@ -243,30 +117,290 @@ public interface Try<T> extends Value<T> {
     }
 
     /**
-     * Runs the given checked consumer if this is a {@code Success},
+     * Returns {@code Success(throwable)} if this is a {@code Failure(throwable)}, otherwise
+     * a {@code Failure(new UnsupportedOperationException("Success.failed()"))} if this is a Success.
+     *
+     * @return a new Try
+     */
+    default Try<Throwable> failed() {
+        if (isSuccess()) {
+            return new Failure<>(new UnsupportedOperationException("Success.failed()"));
+        } else {
+            return new Success<>(getCause().getCause());
+        }
+    }
+
+    /**
+     * <p>Returns {@code this} if this is a Failure or this is a Success and the value satisfies the predicate.</p>
+     * <p>Returns a new Failure, if this is a Success and the value does not satisfy the Predicate or an exception
+     * occurs testing the predicate.</p>
+     *
+     * @param predicate A predicate
+     * @return a new Try
+     */
+    default Try<T> filter(Predicate<? super T> predicate) {
+        if (isFailure()) {
+            return this;
+        } else {
+            try {
+                if (predicate.test(get())) {
+                    return this;
+                } else {
+                    return new Failure<>(new NoSuchElementException("Predicate does not hold for " + get()));
+                }
+            } catch (Throwable t) {
+                return new Failure<>(t);
+            }
+        }
+    }
+
+    default Try<T> filterTry(CheckedPredicate<? super T> predicate) {
+        if (isFailure()) {
+            return this;
+        } else {
+            return Try.of(() -> predicate.test(get())).flatMap(b -> filter(ignored -> b));
+        }
+    }
+
+    /**
+     * FlatMaps the value of a Success or returns a Failure.
+     *
+     * @param mapper A mapper
+     * @param <U>    The new component type
+     * @return a new Try
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    default <U> Try<U> flatMap(Function<? super T, ? extends java.lang.Iterable<? extends U>> mapper) {
+        if (isFailure()) {
+            return (Failure<U>) this;
+        } else {
+            return flatMapTry((CheckedFunction<T, java.lang.Iterable<? extends U>>) mapper::apply);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    default <U> Try<U> flatMapTry(CheckedFunction<? super T, ? extends java.lang.Iterable<? extends U>> mapper) {
+        if (isFailure()) {
+            return (Failure<U>) this;
+        } else {
+            try {
+                final Iterable<? extends U> iterable = mapper.apply(get());
+                if (iterable instanceof Value) {
+                    return ((Value<U>) iterable).toTry();
+                } else {
+                    return Try.of(() -> Value.get(iterable));
+                }
+            } catch (Throwable t) {
+                return new Failure<>(t);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    default Try<Object> flatten() {
+        if (isFailure()) {
+            return (Failure<Object>) this;
+        } else {
+            return flatMap(value -> (value instanceof Try) ? ((Try<?>) get()).flatten() : this);
+        }
+    }
+
+    /**
+     * Gets the result of this Try if this is a Success or throws if this is a Failure.
+     *
+     * @return The result of this Try.
+     * @throws NonFatal if this is a Failure
+     */
+    @Override
+    T get();
+
+    /**
+     * Gets the cause if this is a Failure or throws if this is a Success.
+     *
+     * @return The cause if this is a Failure
+     * @throws UnsupportedOperationException if this is a Success
+     */
+    NonFatal getCause();
+
+    /**
+     * Checks whether this Try has no result, i.e. is a Failure.
+     *
+     * @return true if this is a Failure, returns false if this is a Success.
+     */
+    @Override
+    default boolean isEmpty() {
+        return isFailure();
+    }
+
+    /**
+     * Checks if this is a Failure.
+     *
+     * @return true, if this is a Failure, otherwise false, if this is a Success
+     */
+    boolean isFailure();
+
+    /**
+     * Checks if this is a Success.
+     *
+     * @return true, if this is a Success, otherwise false, if this is a Failure
+     */
+    default boolean isSuccess() {
+        return !isFailure();
+    }
+
+    @Override
+    default Iterator<T> iterator() {
+        return isSuccess() ? Iterator.of(get()) : Iterator.empty();
+    }
+
+    /**
+     * Maps the value of a Success or returns a Failure.
+     *
+     * @param <U>    The new component type
+     * @param mapper A mapper
+     * @return a new Try
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    default <U> Try<U> map(Function<? super T, ? extends U> mapper) {
+        if (isFailure()) {
+            return (Failure<U>) this;
+        } else {
+            try {
+                return new Success<>(mapper.apply(get()));
+            } catch (Throwable t) {
+                return new Failure<>(t);
+            }
+        }
+    }
+
+    /**
+     * Runs the given checked function if this is a {@code Success},
      * passing the result of the current expression to it.
      * If this expression is a {@code Failure} then it'll return a new
-     * {@code Failure} of type T with the original exception.
+     * {@code Failure} of type R with the original exception.
      *
      * The main use case is chaining checked functions using method references:
      *
      * <pre>
      * <code>
-     * Try.of(() -&gt; 100)
-     *    .andThen(i -&gt; System.out.println(i));
-     *
+     * Try.of(() -&gt; 0)
+     *    .mapTry(x -&gt; 1 / x); // division by zero
      * </code>
      * </pre>
      *
-     * @param consumer A checked consumer taking a single argument.
+     * @param <U>    The new component type
+     * @param mapper A checked function
      * @return a new {@code Try}
      */
     @SuppressWarnings("unchecked")
-    default Try<T> andThen(CheckedConsumer<? super T> consumer) {
+    default <U> Try<U> mapTry(CheckedFunction1<? super T, ? extends U> mapper) {
         if (isFailure()) {
-            return this;
+            return (Failure<U>) this;
         } else {
-            return Try.run(() -> consumer.accept(get())).flatMap(ignored -> this);
+            return Try.of(() -> mapper.apply(get()));
+        }
+    }
+
+    /**
+     * Consumes the throwable if this is a Failure, otherwise returns this Success.
+     *
+     * @param f A Consumer
+     * @return a new Failure, if this is a Failure and the consumer throws, otherwise this, which may be a Success or
+     * a Failure.
+     */
+    default Try<T> onFailure(Consumer<Throwable> f) {
+        if (isFailure()) {
+            try {
+                f.accept(getCause().getCause());
+                return this;
+            } catch (Throwable t) {
+                return new Failure<>(t);
+            }
+        } else {
+            return this;
+        }
+    }
+
+    default T orElseGet(Function<? super Throwable, ? extends T> other) {
+        if (isFailure()) {
+            return other.apply(getCause().getCause());
+        } else {
+            return get();
+        }
+    }
+
+    default void orElseRun(Consumer<? super Throwable> action) {
+        if (isFailure()) {
+            action.accept(getCause().getCause());
+        }
+    }
+
+    default <X extends Throwable> T orElseThrow(Function<? super Throwable, X> exceptionProvider) throws X {
+        if (isFailure()) {
+            throw exceptionProvider.apply(getCause().getCause());
+        } else {
+            return get();
+        }
+    }
+
+    /**
+     * Applies the action to the value of a Success or does nothing in the case of a Failure.
+     *
+     * @param action A Consumer
+     * @return this Try
+     */
+    @Override
+    default Try<T> peek(Consumer<? super T> action) {
+        if (isSuccess()) {
+            action.accept(get());
+        }
+        return this;
+    }
+
+    /**
+     * Returns {@code this}, if this is a {@code Success}, otherwise tries to recover the exception of the failure with {@code f},
+     * i.e. calling {@code Try.of(() -> f.apply(throwable))}.
+     *
+     * @param f A recovery function taking a Throwable
+     * @return a new Try
+     */
+    default Try<T> recover(Function<Throwable, ? extends T> f) {
+        if (isFailure()) {
+            return Try.of(() -> f.apply(getCause().getCause()));
+        } else {
+            return this;
+        }
+    }
+
+    /**
+     * Returns {@code this}, if this is a Success, otherwise tries to recover the exception of the failure with {@code f},
+     * i.e. calling {@code f.apply(cause.getCause())}. If an error occurs recovering a Failure, then the new Failure is
+     * returned.
+     *
+     * @param f A recovery function taking a Throwable
+     * @return a new Try
+     */
+    default Try<T> recoverWith(Function<Throwable, Try<T>> f) {
+        if (isFailure()) {
+            try {
+                return f.apply(getCause().getCause());
+            } catch (Throwable t) {
+                return new Failure<>(t);
+            }
+
+        } else {
+            return this;
+        }
+    }
+
+    default Either<Throwable, T> toEither() {
+        if (isFailure()) {
+            return new Left<>(getCause().getCause());
+        } else {
+            return new Right<>(get());
         }
     }
 


### PR DESCRIPTION
Towards #593

Changed the behavior of `Try.peek(Consumer)` in the following way:

**Before:** If Consumer threw, the current Success was converted to a Failure. That is not correct according to the common peek() behavior. Peek is no transformation.

**After:** If Consumer throws, peek() throws also.