### PR TITLE
Performance improvement of RedBlackTree.insert

### DIFF
--- a/src/main/java/javaslang/collection/RedBlackTree.java
+++ b/src/main/java/javaslang/collection/RedBlackTree.java
@@ -670,11 +670,8 @@ interface RedBlackTreeModule {
                     return (newRight == node.right) ? node : Node.balanceRight(node.color, node.blackHeight, node.left, node.value, newRight, node.empty);
                 } else {
                     // DEV-NOTE: Even if there is no _comparison_ difference, the object may not be _equal_.
-                    if (Objects.equals(node.value, value)) {
-                        return node;
-                    } else {
-                        return new Node<>(node.color, node.blackHeight, node.left, value, node.right, node.empty);
-                    }
+                    //           To save an equals() call, which may be expensive, we return a new instance.
+                    return new Node<>(node.color, node.blackHeight, node.left, value, node.right, node.empty);
                 }
             }
         }


### PR DESCRIPTION
We trade here a new instance creation against an equals() call. We know nothing about the complexity of equals - it may be very expensive. But we know that insertion is O(log n). Therefore creating a new node is reasonable, even if it is equal.

Amendment to #665 