### PR TITLE
(Re-)Unified return types of zip* and unzip.

### DIFF
--- a/src/main/java/javaslang/collection/HashMap.java
+++ b/src/main/java/javaslang/collection/HashMap.java
@@ -528,45 +528,8 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
     }
 
     @Override
-    public <K1, V1, K2, V2> Tuple2<HashMap<K1, V1>, HashMap<K2, V2>> unzip(Function<? super Entry<? super K, ? super V>, Tuple2<? extends Entry<? extends K1, ? extends V1>, ? extends Entry<? extends K2, ? extends V2>>> unzipper) {
-        Objects.requireNonNull(unzipper, "unzipper is null");
-        HashArrayMappedTrie<K1, V1> trie1 = HashArrayMappedTrie.empty();
-        HashArrayMappedTrie<K2, V2> trie2 = HashArrayMappedTrie.empty();
-        for (Entry<K, V> entry : this) {
-            final Tuple2<? extends Entry<? extends K1, ? extends V1>, ? extends Entry<? extends K2, ? extends V2>> t = unzipper.apply(entry);
-            trie1 = trie1.put(t._1.key, t._1.value);
-            trie2 = trie2.put(t._2.key, t._2.value);
-        }
-        return Tuple.of(HashMap.of(trie1), HashMap.of(trie2));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <K1, V1, K2, V2> Tuple2<HashMap<K1, V1>, HashMap<K2, V2>> unzip(BiFunction<? super K, ? super V, Tuple2<? extends Entry<? extends K1, ? extends V1>, ? extends Entry<? extends K2, ? extends V2>>> unzipper) {
-        Objects.requireNonNull(unzipper, "unzipper is null");
-        return unzip(entry -> unzipper.apply((K) entry.key, (V) entry.value));
-    }
-
-    @Override
     public Seq<V> values() {
         return map(Entry::value).toStream();
-    }
-
-    @Override
-    public <U> HashMap<Tuple2<K, V>, U> zip(java.lang.Iterable<U> that) {
-        Objects.requireNonNull(that, "that is null");
-        return HashMap.ofAll(iterator().zip(that).map(t -> Entry.of(Tuple.of(t._1.key, t._1.value), t._2)));
-    }
-
-    @Override
-    public <U> HashMap<Tuple2<K, V>, U> zipAll(java.lang.Iterable<U> that, Entry<K, V> thisElem, U thatElem) {
-        Objects.requireNonNull(that, "that is null");
-        return HashMap.ofAll(iterator().zipAll(that, thisElem, thatElem).map(t -> Entry.of(t._1 == null ? null : Tuple.of(t._1.key, t._1.value), t._2)));
-    }
-
-    @Override
-    public HashMap<Tuple2<K, V>, Integer> zipWithIndex() {
-        return HashMap.ofAll(iterator().zipWithIndex().map(t -> Entry.of(Tuple.of(t._1.key, t._1.value), t._2)));
     }
 
     @Override

--- a/src/main/java/javaslang/collection/List.java
+++ b/src/main/java/javaslang/collection/List.java
@@ -1227,8 +1227,7 @@ public interface List<T> extends LinearSeq<T>, Stack<T> {
     }
 
     @Override
-    default <T1, T2> Tuple2<List<T1>, List<T2>> unzip(
-            Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
+    default <T1, T2> Tuple2<List<T1>, List<T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
         List<T1> xs = Nil.instance();
         List<T2> ys = Nil.instance();

--- a/src/main/java/javaslang/collection/Map.java
+++ b/src/main/java/javaslang/collection/Map.java
@@ -66,17 +66,12 @@ public interface Map<K, V> extends Traversable<Map.Entry<K, V>>, Function<K, V> 
 
     int size();
 
-    <K1, V1, K2, V2> Tuple2<? extends Map<K1, V1>, ? extends Map<K2, V2>> unzip(Function<? super Entry<? super K, ? super V>, Tuple2<? extends Entry<? extends K1, ? extends V1>, ? extends Entry<? extends K2, ? extends V2>>> unzipper);
-
-    <K1, V1, K2, V2> Tuple2<? extends Map<K1, V1>, ? extends Map<K2, V2>> unzip(BiFunction<? super K, ? super V, Tuple2<? extends Entry<? extends K1, ? extends V1>, ? extends Entry<? extends K2, ? extends V2>>> unzipper);
+    default <T1, T2> Tuple2<Seq<T1>, Seq<T2>> unzip(BiFunction<? super K, ? super V, Tuple2<? extends T1, ? extends T2>> unzipper) {
+        Objects.requireNonNull(unzipper, "unzipper is null");
+        return unzip(entry -> unzipper.apply(entry.key, entry.value));
+    }
 
     Seq<V> values();
-
-    <U> Map<Tuple2<K, V>, U> zip(java.lang.Iterable<U> that);
-
-    <U> Map<Tuple2<K, V>, U> zipAll(java.lang.Iterable<U> that, Entry<K, V> thisElem, U thatElem);
-
-    Map<Tuple2<K, V>, Integer> zipWithIndex();
 
     // -- Adjusted return types of Traversable methods
 
@@ -200,6 +195,29 @@ public interface Map<K, V> extends Traversable<Map.Entry<K, V>>, Function<K, V> 
 
     @Override
     Map<K, V> takeWhile(Predicate<? super Entry<K, V>> predicate);
+
+    @Override
+    default <T1, T2> Tuple2<Seq<T1>, Seq<T2>> unzip(Function<? super Entry<K, V>, Tuple2<? extends T1, ? extends T2>> unzipper) {
+        Objects.requireNonNull(unzipper, "unzipper is null");
+        return iterator().unzip(unzipper).map(Stream::ofAll, Stream::ofAll);
+    }
+
+    @Override
+    default <U> Seq<Tuple2<Entry<K, V>, U>> zip(java.lang.Iterable<U> that) {
+        Objects.requireNonNull(that, "that is null");
+        return Stream.ofAll(iterator().zip(that));
+    }
+
+    @Override
+    default <U> Seq<Tuple2<Entry<K, V>, U>> zipAll(java.lang.Iterable<U> that, Entry<K, V> thisElem, U thatElem) {
+        Objects.requireNonNull(that, "that is null");
+        return Stream.ofAll(iterator().zipAll(that, thisElem, thatElem));
+    }
+
+    @Override
+    default Seq<Tuple2<Entry<K, V>, Integer>> zipWithIndex() {
+        return Stream.ofAll(iterator().zipWithIndex());
+    }
 
     /**
      * Representation of a Map entry.

--- a/src/main/java/javaslang/collection/Seq.java
+++ b/src/main/java/javaslang/collection/Seq.java
@@ -702,18 +702,6 @@ public interface Seq<T> extends Traversable<T>, IntFunction<T> {
     <U> Seq<U> unit(java.lang.Iterable<? extends U> iterable);
 
     /**
-     * Unzips this elements by mapping this elements to pairs which are subsequentially split into two distinct
-     * traversables.
-     *
-     * @param unzipper a function which converts elements of this to pairs
-     * @param <T1>     1st element type of a pair returned by unzipper
-     * @param <T2>     2nd element type of a pair returned by unzipper
-     * @return A pair of traversables containing elements split by unzipper
-     * @throws NullPointerException if {@code unzipper} is null
-     */
-    <T1, T2> Tuple2<? extends Seq<T1>, ? extends Seq<T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper);
-
-    /**
      * Updates the given element at the specified index.
      *
      * @param index   an index
@@ -722,45 +710,6 @@ public interface Seq<T> extends Traversable<T>, IntFunction<T> {
      * @throws IndexOutOfBoundsException if this is empty, index &lt; 0 or index &gt;= length()
      */
     Seq<T> update(int index, T element);
-
-    /**
-     * Returns a Seq formed from this Seq and another java.lang.Iterable collection by combining corresponding elements
-     * in pairs. If one of the two sequences is longer than the other, its remaining elements are ignored.
-     * <p>
-     * The length of the returned collection is the minimum of the lengths of this Seq and that.
-     *
-     * @param <U>  The type of the second half of the returned pairs.
-     * @param that The java.lang.Iterable providing the second half of each result pair.
-     * @return a new Seq containing pairs consisting of corresponding elements of this seq and that.
-     * @throws NullPointerException if {@code that} is null
-     */
-    <U> Seq<Tuple2<T, U>> zip(java.lang.Iterable<U> that);
-
-    /**
-     * Returns a Traversable formed from this Traversable and another java.lang.Iterable by combining corresponding elements in
-     * pairs. If one of the two collections is shorter than the other, placeholder elements are used to extend the
-     * shorter collection to the length of the longer.
-     * <p>
-     * The length of the returned Traversable is the maximum of the lengths of this Traversable and that.
-     * <p>
-     * If this Traversable is shorter than that, thisElem values are used to fill the result.
-     * If that is shorter than this Traversable, thatElem values are used to fill the result.
-     *
-     * @param <U>      The type of the second half of the returned pairs.
-     * @param that     The java.lang.Iterable providing the second half of each result pair.
-     * @param thisElem The element to be used to fill up the result if this Traversable is shorter than that.
-     * @param thatElem The element to be used to fill up the result if that is shorter than this Traversable.
-     * @return A new Traversable containing pairs consisting of corresponding elements of this Traversable and that.
-     * @throws NullPointerException if {@code that} is null
-     */
-    <U> Seq<Tuple2<T, U>> zipAll(java.lang.Iterable<U> that, T thisElem, U thatElem);
-
-    /**
-     * Zips this seq with its indices.
-     *
-     * @return A new seq containing all elements of this seq paired with their index, starting with 0.
-     */
-    Seq<Tuple2<T, Integer>> zipWithIndex();
 
     // -- Adjusted return types of Traversable methods
 
@@ -867,4 +816,15 @@ public interface Seq<T> extends Traversable<T>, IntFunction<T> {
     @Override
     Seq<T> takeWhile(Predicate<? super T> predicate);
 
+    @Override
+    <T1, T2> Tuple2<? extends Seq<T1>, ? extends Seq<T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper);
+
+    @Override
+    <U> Seq<Tuple2<T, U>> zip(java.lang.Iterable<U> that);
+
+    @Override
+    <U> Seq<Tuple2<T, U>> zipAll(java.lang.Iterable<U> that, T thisElem, U thatElem);
+
+    @Override
+    Seq<Tuple2<T, Integer>> zipWithIndex();
 }

--- a/src/main/java/javaslang/collection/Set.java
+++ b/src/main/java/javaslang/collection/Set.java
@@ -87,59 +87,6 @@ public interface Set<T> extends Traversable<T> {
      */
     Set<T> union(Set<? extends T> that);
 
-    /**
-     * Unzips this elements by mapping this elements to pairs which are subsequentially split into two distinct
-     * sets.
-     *
-     * @param unzipper a function which converts elements of this to pairs
-     * @param <T1>     1st element type of a pair returned by unzipper
-     * @param <T2>     2nd element type of a pair returned by unzipper
-     * @return A pair of set containing elements split by unzipper
-     * @throws NullPointerException if {@code unzipper} is null
-     */
-    <T1, T2> Tuple2<? extends Set<T1>, ? extends Set<T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper);
-
-    /**
-     * Returns a set formed from this set and another java.lang.Iterable collection by combining corresponding elements
-     * in pairs. If one of the two iterables is longer than the other, its remaining elements are ignored.
-     * <p>
-     * The length of the returned set is the minimum of the lengths of this set and {@code that} iterable.
-     *
-     * @param <U>  The type of the second half of the returned pairs.
-     * @param that The java.lang.Iterable providing the second half of each result pair.
-     * @return a new set containing pairs consisting of corresponding elements of this set and {@code that} iterable.
-     * @throws NullPointerException if {@code that} is null
-     */
-    <U> Set<Tuple2<T, U>> zip(java.lang.Iterable<U> that);
-
-    /**
-     * Returns a set formed from this set and another java.lang.Iterable by combining corresponding elements in
-     * pairs. If one of the two collections is shorter than the other, placeholder elements are used to extend the
-     * shorter collection to the length of the longer.
-     * <p>
-     * The length of the returned set is the maximum of the lengths of this set and {@code that} iterable. Special case:
-     * if this set is shorter than that elements, and that elements contains duplicates, the resulting set may be shorter
-     * than the maximum of the lengths of this and that because a set contains an element at most once.
-     * <p>
-     * If this Traversable is shorter than that, thisElem values are used to fill the result.
-     * If that is shorter than this Traversable, thatElem values are used to fill the result.
-     *
-     * @param <U>      The type of the second half of the returned pairs.
-     * @param that     The java.lang.Iterable providing the second half of each result pair.
-     * @param thisElem The element to be used to fill up the result if this set is shorter than that.
-     * @param thatElem The element to be used to fill up the result if that is shorter than this set.
-     * @return A new set containing pairs consisting of corresponding elements of this set and that.
-     * @throws NullPointerException if {@code that} is null
-     */
-    <U> Set<Tuple2<T, U>> zipAll(java.lang.Iterable<U> that, T thisElem, U thatElem);
-
-    /**
-     * Zips this set with its indices.
-     *
-     * @return A new set containing all elements of this set paired with their index, starting with 0.
-     */
-    Set<Tuple2<T, Integer>> zipWithIndex();
-
     // -- Adjusted return types of Traversable methods
 
     @Override
@@ -236,5 +183,17 @@ public interface Set<T> extends Traversable<T> {
 
     @Override
     Set<T> takeWhile(Predicate<? super T> predicate);
+
+    @Override
+    <T1, T2> Tuple2<? extends Set<T1>, ? extends Set<T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper);
+
+    @Override
+    <U> Set<Tuple2<T, U>> zip(java.lang.Iterable<U> that);
+
+    @Override
+    <U> Set<Tuple2<T, U>> zipAll(java.lang.Iterable<U> that, T thisElem, U thatElem);
+
+    @Override
+    Set<Tuple2<T, Integer>> zipWithIndex();
 
 }

--- a/src/main/java/javaslang/collection/SortedMap.java
+++ b/src/main/java/javaslang/collection/SortedMap.java
@@ -145,21 +145,6 @@ public interface SortedMap<K, V> extends Map<K, V> {
     SortedMap<K, V> takeWhile(Predicate<? super Entry<K, V>> predicate);
 
     @Override
-    <K1, V1, K2, V2> Tuple2<? extends SortedMap<K1, V1>, ? extends SortedMap<K2, V2>> unzip(Function<? super Entry<? super K, ? super V>, Tuple2<? extends Entry<? extends K1, ? extends V1>, ? extends Entry<? extends K2, ? extends V2>>> unzipper);
-
-    @Override
-    <K1, V1, K2, V2> Tuple2<? extends SortedMap<K1, V1>, ? extends SortedMap<K2, V2>> unzip(BiFunction<? super K, ? super V, Tuple2<? extends Entry<? extends K1, ? extends V1>, ? extends Entry<? extends K2, ? extends V2>>> unzipper);
-
-    @Override
     Seq<V> values();
-
-    @Override
-    <U> SortedMap<Tuple2<K, V>, U> zip(java.lang.Iterable<U> that);
-
-    @Override
-    <U> SortedMap<Tuple2<K, V>, U> zipAll(java.lang.Iterable<U> that, Entry<K, V> thisElem, U thatElem);
-
-    @Override
-    SortedMap<Tuple2<K, V>, Integer> zipWithIndex();
 
 }

--- a/src/main/java/javaslang/collection/Traversable.java
+++ b/src/main/java/javaslang/collection/Traversable.java
@@ -166,4 +166,15 @@ public interface Traversable<T> extends TraversableOnce<T> {
     @Override
     Traversable<T> takeWhile(Predicate<? super T> predicate);
 
+    @Override
+    <T1, T2> Tuple2<? extends Traversable<T1>, ? extends Traversable<T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper);
+
+    @Override
+    <U> Traversable<Tuple2<T, U>> zip(java.lang.Iterable<U> that);
+
+    @Override
+    <U> Traversable<Tuple2<T, U>> zipAll(java.lang.Iterable<U> that, T thisElem, U thatElem);
+
+    @Override
+    Traversable<Tuple2<T, Integer>> zipWithIndex();
 }

--- a/src/main/java/javaslang/collection/TraversableOnce.java
+++ b/src/main/java/javaslang/collection/TraversableOnce.java
@@ -909,4 +909,61 @@ public interface TraversableOnce<T> extends Value<T> {
      */
     TraversableOnce<T> takeWhile(Predicate<? super T> predicate);
 
+    /**
+     * Unzips this elements by mapping this elements to pairs which are subsequentially split into two distinct
+     * sets.
+     *
+     * @param unzipper a function which converts elements of this to pairs
+     * @param <T1>     1st element type of a pair returned by unzipper
+     * @param <T2>     2nd element type of a pair returned by unzipper
+     * @return A pair of set containing elements split by unzipper
+     * @throws NullPointerException if {@code unzipper} is null
+     */
+    <T1, T2> Tuple2<? extends TraversableOnce<T1>, ? extends TraversableOnce<T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper);
+
+    /**
+     * Returns a traversable formed from this traversable and another java.lang.Iterable collection by combining
+     * corresponding elements in pairs. If one of the two iterables is longer than the other, its remaining elements
+     * are ignored.
+     * <p>
+     * The length of the returned traversable is the minimum of the lengths of this traversable and {@code that}
+     * iterable.
+     *
+     * @param <U>  The type of the second half of the returned pairs.
+     * @param that The java.lang.Iterable providing the second half of each result pair.
+     * @return a new traversable containing pairs consisting of corresponding elements of this traversable and {@code that} iterable.
+     * @throws NullPointerException if {@code that} is null
+     */
+    <U> TraversableOnce<Tuple2<T, U>> zip(java.lang.Iterable<U> that);
+
+    /**
+     * Returns a traversable formed from this traversable and another java.lang.Iterable by combining corresponding elements in
+     * pairs. If one of the two collections is shorter than the other, placeholder elements are used to extend the
+     * shorter collection to the length of the longer.
+     * <p>
+     * The length of the returned traversable is the maximum of the lengths of this traversable and {@code that}
+     * iterable.
+     * <p>
+     * Special case: if this traversable is shorter than that elements, and that elements contains duplicates, the
+     * resulting traversable may be shorter than the maximum of the lengths of this and that because a traversable
+     * contains an element at most once.
+     * <p>
+     * If this Traversable is shorter than that, thisElem values are used to fill the result.
+     * If that is shorter than this Traversable, thatElem values are used to fill the result.
+     *
+     * @param <U>      The type of the second half of the returned pairs.
+     * @param that     The java.lang.Iterable providing the second half of each result pair.
+     * @param thisElem The element to be used to fill up the result if this traversable is shorter than that.
+     * @param thatElem The element to be used to fill up the result if that is shorter than this traversable.
+     * @return A new traversable containing pairs consisting of corresponding elements of this traversable and that.
+     * @throws NullPointerException if {@code that} is null
+     */
+    <U> TraversableOnce<Tuple2<T, U>> zipAll(java.lang.Iterable<U> that, T thisElem, U thatElem);
+
+    /**
+     * Zips this traversable with its indices.
+     *
+     * @return A new traversable containing all elements of this traversable paired with their index, starting with 0.
+     */
+    TraversableOnce<Tuple2<T, Integer>> zipWithIndex();
 }

--- a/src/main/java/javaslang/collection/Tree.java
+++ b/src/main/java/javaslang/collection/Tree.java
@@ -272,6 +272,29 @@ public interface Tree<T> extends Traversable<T> {
     List<T> takeWhile(Predicate<? super T> predicate);
 
     @Override
+    default <T1, T2> Tuple2<Seq<T1>, Seq<T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
+        Objects.requireNonNull(unzipper, "unzipper is null");
+        return iterator().unzip(unzipper).map(Stream::ofAll, Stream::ofAll);
+    }
+
+    @Override
+    default <U> Seq<Tuple2<T, U>> zip(java.lang.Iterable<U> that) {
+        Objects.requireNonNull(that, "that is null");
+        return Stream.ofAll(iterator().zip(that));
+    }
+
+    @Override
+    default <U> Seq<Tuple2<T, U>> zipAll(java.lang.Iterable<U> that, T thisElem, U thatElem) {
+        Objects.requireNonNull(that, "that is null");
+        return Stream.ofAll(iterator().zipAll(that, thisElem, thatElem));
+    }
+
+    @Override
+    default Seq<Tuple2<T, Integer>> zipWithIndex() {
+        return Stream.ofAll(iterator().zipWithIndex());
+    }
+
+    @Override
     boolean equals(Object o);
 
     @Override

--- a/src/main/java/javaslang/collection/TreeMap.java
+++ b/src/main/java/javaslang/collection/TreeMap.java
@@ -592,49 +592,9 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Iterable<Entry<K, V
         return createTreeMap(entries.comparator(), entries.iterator().takeWhile(predicate));
     }
 
-    @SuppressWarnings("unchecked")
-    @Override
-    public <K1, V1, K2, V2> Tuple2<TreeMap<K1, V1>, TreeMap<K2, V2>> unzip(Function<? super Entry<? super K, ? super V>, Tuple2<? extends Entry<? extends K1, ? extends V1>, ? extends Entry<? extends K2, ? extends V2>>> unzipper) {
-        Objects.requireNonNull(unzipper, "unzipper is null");
-        final Comparator<K1> keyComparator1 = Comparators.naturalComparator();
-        final Comparator<K2> keyComparator2 = Comparators.naturalComparator();
-        RedBlackTree<Entry<K1, V1>> tree1 = RedBlackTree.empty(entryComparator(keyComparator1));
-        RedBlackTree<Entry<K2, V2>> tree2 = RedBlackTree.empty(entryComparator(keyComparator2));
-        for (Entry<K, V> entry : this) {
-            final Tuple2<? extends Entry<? extends K1, ? extends V1>, ? extends Entry<? extends K2, ? extends V2>> t = unzipper.apply(entry);
-            tree1 = tree1.insert((Entry<K1, V1>) t._1);
-            tree2 = tree2.insert((Entry<K2, V2>) t._2);
-        }
-        return Tuple.of(new TreeMap<>(tree1), new TreeMap<>(tree2));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <K1, V1, K2, V2> Tuple2<TreeMap<K1, V1>, TreeMap<K2, V2>> unzip(BiFunction<? super K, ? super V, Tuple2<? extends Entry<? extends K1, ? extends V1>, ? extends Entry<? extends K2, ? extends V2>>> unzipper) {
-        Objects.requireNonNull(unzipper, "unzipper is null");
-        return unzip(entry -> unzipper.apply((K) entry.key, (V) entry.value));
-    }
-
     @Override
     public Seq<V> values() {
         return iterator().map(Entry::value).toStream();
-    }
-
-    @Override
-    public <U> TreeMap<Tuple2<K, V>, U> zip(Iterable<U> that) {
-        Objects.requireNonNull(that, "that is null");
-        return TreeMap.ofAll(iterator().zip(that).map(t -> Entry.of(Tuple.of(t._1.key, t._1.value), t._2)));
-    }
-
-    @Override
-    public <U> TreeMap<Tuple2<K, V>, U> zipAll(Iterable<U> that, Entry<K, V> thisElem, U thatElem) {
-        Objects.requireNonNull(that, "that is null");
-        return TreeMap.ofAll(iterator().zipAll(that, thisElem, thatElem).map(t -> Entry.of(t._1 == null ? null : Tuple.of(t._1.key, t._1.value), t._2)));
-    }
-
-    @Override
-    public TreeMap<Tuple2<K, V>, Integer> zipWithIndex() {
-        return TreeMap.ofAll(iterator().zipWithIndex().map(t -> Entry.of(Tuple.of(t._1.key, t._1.value), t._2)));
     }
 
     private static <K, V> Comparator<Entry<K, V>> entryComparator(Comparator<? super K> keyComparator) {

--- a/src/test/java/javaslang/collection/AbstractMapTest.java
+++ b/src/test/java/javaslang/collection/AbstractMapTest.java
@@ -267,15 +267,15 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
 
     @Test
     public void shouldUnzipNil() {
-        assertThat(emptyMap().unzip(x -> Tuple.of(x, x))).isEqualTo(Tuple.of(emptyMap(), emptyMap()));
-        assertThat(emptyMap().unzip((k, v) -> Tuple.of(Entry.of(k, v), Entry.of(k, v)))).isEqualTo(Tuple.of(emptyMap(), emptyMap()));
+        assertThat(emptyMap().unzip(x -> Tuple.of(x, x))).isEqualTo(Tuple.of(Stream.empty(), Stream.empty()));
+        assertThat(emptyMap().unzip((k, v) -> Tuple.of(Entry.of(k, v), Entry.of(k, v)))).isEqualTo(Tuple.of(Stream.empty(), Stream.empty()));
     }
 
     @Test
     public void shouldUnzipNonNil() {
         Map<Integer, Integer> map = emptyIntInt().put(0, 0).put(1, 1);
-        final Tuple actual = map.unzip(i -> Tuple.of(i, Entry.of(i.key, (Integer) i.value + 1)));
-        final Tuple expected = Tuple.of(map, emptyMap().put(0, 1).put(1, 2));
+        final Tuple actual = map.unzip(entry -> Tuple.of(entry.key, entry.value + 1));
+        final Tuple expected = Tuple.of(Stream.of(0, 1), Stream.of(1, 2));
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -283,38 +283,38 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
 
     @Test
     public void shouldZipNils() {
-        final Map<?, ?> actual = emptyMap().zip(emptyMap());
-        assertThat(actual).isEqualTo(empty());
+        final Seq<Tuple2<Entry<Object, Object>, Object>> actual = emptyMap().zip(List.empty());
+        assertThat(actual).isEqualTo(Stream.empty());
     }
 
     @Test
     public void shouldZipEmptyAndNonNil() {
-        final Map<?, ?> actual = emptyMap().zip(emptyIntInt().put(0, 1));
-        assertThat(actual).isEqualTo(empty());
+        final Seq<Tuple2<Entry<Object, Object>, Integer>> actual = emptyMap().zip(List.of(1));
+        assertThat(actual).isEqualTo(Stream.empty());
     }
 
     @Test
     public void shouldZipNonEmptyAndNil() {
-        final Map<?, ?> actual = emptyIntInt().put(0, 1).zip(emptyMap());
-        assertThat(actual).isEqualTo(empty());
+        final Seq<Tuple2<Entry<Integer, Integer>, Object>> actual = emptyIntInt().put(0, 1).zip(List.empty());
+        assertThat(actual).isEqualTo(Stream.empty());
     }
 
     @Test
     public void shouldZipNonNilsIfThisIsSmaller() {
-        final Map<Tuple2<Integer, Integer>, Integer> actual = emptyIntInt().put(0, 0).put(1, 1).zip(List.of(5, 6, 7));
-        assertThat(actual).isEqualTo(emptyMap().put(Tuple.of(0, 0), 5).put(Tuple.of(1, 1), 6));
+        final Seq<Tuple2<Entry<Integer, Integer>, Integer>> actual = emptyIntInt().put(0, 0).put(1, 1).zip(List.of(5, 6, 7));
+        assertThat(actual).isEqualTo(Stream.of(Tuple.of(Entry.of(0, 0), 5), Tuple.of(Entry.of(1, 1), 6)));
     }
 
     @Test
     public void shouldZipNonNilsIfThatIsSmaller() {
-        final Map<Tuple2<Integer, Integer>, Integer> actual = emptyIntInt().put(0, 0).put(1, 1).put(2, 2).zip(List.of(5, 6));
-        assertThat(actual).isEqualTo(emptyMap().put(Tuple.of(0, 0), 5).put(Tuple.of(1, 1), 6));
+        final Seq<Tuple2<Entry<Integer, Integer>, Integer>> actual = emptyIntInt().put(0, 0).put(1, 1).put(2, 2).zip(List.of(5, 6));
+        assertThat(actual).isEqualTo(Stream.of(Tuple.of(Entry.of(0, 0), 5), Tuple.of(Entry.of(1, 1), 6)));
     }
 
     @Test
     public void shouldZipNonNilsOfSameSize() {
-        final Map<Tuple2<Integer, Integer>, Integer> actual = emptyIntInt().put(0, 0).put(1, 1).put(2, 2).zip(List.of(5, 6, 7));
-        assertThat(actual).isEqualTo(emptyMap().put(Tuple.of(0, 0), 5).put(Tuple.of(1, 1), 6).put(Tuple.of(2, 2), 7));
+        final Seq<Tuple2<Entry<Integer, Integer>, Integer>> actual = emptyIntInt().put(0, 0).put(1, 1).put(2, 2).zip(List.of(5, 6, 7));
+        assertThat(actual).isEqualTo(Stream.of(Tuple.of(Entry.of(0, 0), 5), Tuple.of(Entry.of(1, 1), 6), Tuple.of(Entry.of(2, 2), 7)));
     }
 
     @Test(expected = NullPointerException.class)
@@ -326,70 +326,67 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
 
     @Test
     public void shouldZipNilWithIndex() {
-        assertThat(emptyMap().zipWithIndex()).isEqualTo(emptyMap());
+        assertThat(emptyMap().zipWithIndex()).isEqualTo(Stream.empty());
     }
 
     @Test
     public void shouldZipNonNilWithIndex() {
-        final Map<Tuple2<Integer, Integer>, Integer> actual = emptyIntInt().put(0, 0).put(1, 1).put(2, 2).zipWithIndex();
-        assertThat(actual).isEqualTo(emptyMap().put(Tuple.of(0, 0), 0).put(Tuple.of(1, 1), 1).put(Tuple.of(2, 2), 2));
+        final Seq<Tuple2<Entry<Integer, Integer>, Integer>> actual = emptyIntInt().put(0, 0).put(1, 1).put(2, 2).zipWithIndex();
+        assertThat(actual).isEqualTo(Stream.of(Tuple.of(Entry.of(0, 0), 0), Tuple.of(Entry.of(1, 1), 1), Tuple.of(Entry.of(2, 2), 2)));
     }
 
     // -- zipAll
 
     @Test
     public void shouldZipAllNils() {
-        final Map<?, ?> actual = emptyMap().zipAll(empty(), null, null);
-        final Map<?, ?> expected = emptyMap();
-        assertThat(actual).isEqualTo(expected);
+        final Seq<Tuple2<Entry<Object, Object>, Object>> actual = emptyMap().zipAll(empty(), null, null);
+        assertThat(actual).isEqualTo(Stream.empty());
     }
 
     @Test
     public void shouldZipAllEmptyAndNonNil() {
-        final Map<?, ?> actual = emptyMap().zipAll(List.of(1), null, null);
-        final Map<?, ?> expected = emptyMap().put(null, 1);
-        assertThat(actual).isEqualTo(expected);
+        final Seq<Tuple2<Entry<Object, Object>, Object>> actual = emptyMap().zipAll(List.of(1), null, null);
+        assertThat(actual).isEqualTo(Stream.of(Tuple.of(null, 1)));
     }
 
     @Test
     public void shouldZipAllNonEmptyAndNil() {
-        final Map<?, ?> actual = emptyMap().put(0, 1).zipAll(empty(), null, null);
-        final Map<?, ?> expected = emptyMap().put(Tuple.of(0, 1), null);
-        assertThat(actual).isEqualTo(expected);
+        final Seq<Tuple2<Entry<Object, Object>, Object>> actual = emptyMap().put(0, 1).zipAll(empty(), null, null);
+        assertThat(actual).isEqualTo(Stream.of(Tuple.of(Entry.of(0, 1), null)));
     }
 
     @Test
     public void shouldZipAllNonNilsIfThisIsSmaller() {
-        final Map<?, ?> actual = emptyMap().put(1, 1).put(2, 2).zipAll(of("a", "b", "c"), Entry.of(9, 10), "z");
-        final Map<?, ?> expected = emptyMap().put(Tuple.of(1, 1), "a").put(Tuple.of(2, 2), "b").put(Tuple.of(9, 10), "c");
+        final Seq<Tuple2<Entry<Object, Object>, String>> actual = emptyMap().put(1, 1).put(2, 2).zipAll(of("a", "b", "c"), Entry.of(9, 10), "z");
+        final Seq<Tuple2<Entry<Object, Object>, String>> expected = Stream.of(Tuple.of(Entry.of(1, 1), "a"), Tuple.of(Entry.of(2, 2), "b"), Tuple.of(Entry.of(9, 10), "c"));
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldZipAllNonNilsIfThisIsMoreSmaller() {
-        final Map<?, ?> actual = emptyMap().put(1, 1).put(2, 2).zipAll(of("a", "b", "c", "d"), Entry.of(9, 10), "z");
-        final Map<?, ?> expected = emptyMap().put(Tuple.of(1, 1), "a").put(Tuple.of(2, 2), "b").put(Tuple.of(9, 10), "d");
+        final Seq<Tuple2<Entry<Object, Object>, String>> actual = emptyMap().put(1, 1).put(2, 2).zipAll(of("a", "b", "c", "d"), Entry.of(9, 10), "z");
+        final Seq<Tuple2<Entry<Object, Object>, String>> expected = Stream.of(Tuple.of(Entry.of(1, 1), "a"), Tuple.of(Entry.of(2, 2), "b"), Tuple.of(Entry.of(9, 10), "c"), Tuple.of(Entry.of(9, 10), "d"));
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldZipAllNonNilsIfThatIsSmaller() {
-        final Map<?, ?> actual = emptyMap().put(1, 1).put(2, 2).put(3, 3).zipAll(of("a", "b"), Entry.of(9, 10), "z");
-        final Map<?, ?> expected = emptyMap().put(Tuple.of(1, 1), "a").put(Tuple.of(2, 2), "b").put(Tuple.of(3, 3), "z");
+        final Seq<Tuple2<Entry<Object, Object>, String>> actual = emptyMap().put(1, 1).put(2, 2).put(3, 3).zipAll(of("a", "b"), Entry.of(9, 10), "z");
+        final Seq<Tuple2<Entry<Object, Object>, String>> expected = Stream.of(Tuple.of(Entry.of(1, 1), "a"), Tuple.of(Entry.of(2, 2), "b"), Tuple.of(Entry.of(3, 3), "z"));
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldZipAllNonNilsIfThatIsMoreSmaller() {
-        final Map<?, ?> actual = emptyMap().put(1, 1).put(2, 2).put(3, 3).put(4, 4).zipAll(of("a", "b"), Entry.of(9, 10), "z");
-        final Map<?, ?> expected = emptyMap().put(Tuple.of(1, 1), "a").put(Tuple.of(2, 2), "b").put(Tuple.of(3, 3), "z").put(Tuple.of(4, 4), "z");
+        final Seq<Tuple2<Entry<Object, Object>, String>> actual = emptyMap().put(1, 1).put(2, 2).put(3, 3).put(4, 4).zipAll(of("a", "b"), Entry.of(9, 10), "z");
+        final Seq<Tuple2<Entry<Object, Object>, String>> expected = Stream.of(Tuple.of(Entry.of(1, 1), "a"), Tuple.of(Entry.of(2, 2), "b"), Tuple.of(Entry.of(3, 3), "z"), Tuple.of(Entry.of(4, 4), "z"));
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldZipAllNonNilsOfSameSize() {
-        final Map<?, ?> actual = emptyMap().put(1, 1).put(2, 2).put(3, 3).zipAll(of("a", "b", "c"), Entry.of(9, 10), "z");
-        final Map<?, ?> expected = emptyMap().put(Tuple.of(1, 1), "a").put(Tuple.of(2, 2), "b").put(Tuple.of(3, 3), "c");
+        final Seq<Tuple2<Entry<Object, Object>, String>> actual = emptyMap().put(1, 1).put(2, 2).put(3, 3).zipAll(of("a", "b", "c"), Entry.of(9, 10), "z");
+        final Seq<Tuple2<Entry<Object, Object>, String>> expected = Stream.of(Tuple.of(Entry.of(1, 1), "a"), Tuple.of(Entry.of(2, 2), "b"), Tuple.of(Entry.of(3, 3), "c"));
         assertThat(actual).isEqualTo(expected);
     }
 

--- a/src/test/java/javaslang/collection/IntMap.java
+++ b/src/test/java/javaslang/collection/IntMap.java
@@ -289,4 +289,27 @@ public class IntMap<T> implements Traversable<T>, Serializable {
     public IntMap<T> takeWhile(Predicate<? super T> predicate) {
         return IntMap.of(original.takeWhile(p -> predicate.test(p.value)));
     }
+
+    @Override
+    public <T1, T2> Tuple2<Seq<T1>, Seq<T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
+        Objects.requireNonNull(unzipper, "unzipper is null");
+        return iterator().unzip(unzipper).map(Stream::ofAll, Stream::ofAll);
+    }
+
+    @Override
+    public <U> Seq<Tuple2<T, U>> zip(java.lang.Iterable<U> that) {
+        Objects.requireNonNull(that, "that is null");
+        return Stream.ofAll(iterator().zip(that));
+    }
+
+    @Override
+    public <U> Seq<Tuple2<T, U>> zipAll(java.lang.Iterable<U> that, T thisElem, U thatElem) {
+        Objects.requireNonNull(that, "that is null");
+        return Stream.ofAll(iterator().zipAll(that, thisElem, thatElem));
+    }
+
+    @Override
+    public Seq<Tuple2<T, Integer>> zipWithIndex() {
+        return Stream.ofAll(iterator().zipWithIndex());
+    }
 }


### PR DESCRIPTION
While searching for transformations of the domain of collections towards #658 (in order to see where an additional comparator argument is necessary), I realized that it was not a good idea from the API perspective to make unzip and zip* for Maps a special case. This commit moves unzip and zip* back to TraversableOnce.