### PR TITLE
min & max by(Function) improved

### DIFF
--- a/src/main/java/javaslang/collection/TraversableOnce.java
+++ b/src/main/java/javaslang/collection/TraversableOnce.java
@@ -592,10 +592,16 @@ public interface TraversableOnce<T> extends Value<T> {
         if (isEmpty()) {
             return None.instance();
         } else {
-            return new Some<>(foldLeft((Tuple2<U, T>) null, (u, t) -> {
-                final U tu = f.apply(t);
-                return u != null && u._1.compareTo(tu) >= 0 ? u : Tuple.of(tu, t);
-            })._2);
+            T tm = null;
+            U um = null;
+            for (T t : Iterator.ofAll(this)) {
+                U u = f.apply(t);
+                if (um == null || u.compareTo(um) >= 0) {
+                    um = u;
+                    tm = t;
+                }
+            }
+            return new Some<>(tm);
         }
     }
 
@@ -643,10 +649,16 @@ public interface TraversableOnce<T> extends Value<T> {
         if (isEmpty()) {
             return None.instance();
         } else {
-            return new Some<>(foldLeft((Tuple2<U, T>) null, (u, t) -> {
-                final U tu = f.apply(t);
-                return u != null && u._1.compareTo(tu) <= 0 ? u : Tuple.of(tu, t);
-            })._2);
+            T tm = null;
+            U um = null;
+            for (T t : Iterator.ofAll(this)) {
+                U u = f.apply(t);
+                if (um == null || u.compareTo(um) <= 0) {
+                    um = u;
+                    tm = t;
+                }
+            }
+            return new Some<>(tm);
         }
     }
 

--- a/src/main/java/javaslang/collection/TraversableOnce.java
+++ b/src/main/java/javaslang/collection/TraversableOnce.java
@@ -592,11 +592,13 @@ public interface TraversableOnce<T> extends Value<T> {
         if (isEmpty()) {
             return None.instance();
         } else {
-            T tm = null;
-            U um = null;
-            for (T t : Iterator.ofAll(this)) {
-                U u = f.apply(t);
-                if (um == null || u.compareTo(um) >= 0) {
+            final Iterator<T> iter = iterator();
+            T tm = iter.next();
+            U um = f.apply(tm);
+            while (iter.hasNext()) {
+                final T t = iter.next();
+                final U u = f.apply(t);
+                if (u.compareTo(um) > 0) {
                     um = u;
                     tm = t;
                 }
@@ -649,11 +651,13 @@ public interface TraversableOnce<T> extends Value<T> {
         if (isEmpty()) {
             return None.instance();
         } else {
-            T tm = null;
-            U um = null;
-            for (T t : Iterator.ofAll(this)) {
-                U u = f.apply(t);
-                if (um == null || u.compareTo(um) <= 0) {
+            final Iterator<T> iter = iterator();
+            T tm = iter.next();
+            U um = f.apply(tm);
+            while (iter.hasNext()) {
+                final T t = iter.next();
+                final U u = f.apply(t);
+                if (u.compareTo(um) < 0) {
                     um = u;
                     tm = t;
                 }

--- a/src/main/java/javaslang/collection/TraversableOnce.java
+++ b/src/main/java/javaslang/collection/TraversableOnce.java
@@ -5,6 +5,7 @@
  */
 package javaslang.collection;
 
+import javaslang.Tuple;
 import javaslang.Tuple2;
 import javaslang.Value;
 import javaslang.control.None;
@@ -591,7 +592,10 @@ public interface TraversableOnce<T> extends Value<T> {
         if (isEmpty()) {
             return None.instance();
         } else {
-            return maxBy((t1, t2) -> f.apply(t1).compareTo(f.apply(t2)));
+            return new Some<>(foldLeft((Tuple2<U, T>) null, (u, t) -> {
+                final U tu = f.apply(t);
+                return u != null && u._1.compareTo(tu) >= 0 ? u : Tuple.of(tu, t);
+            })._2);
         }
     }
 
@@ -639,7 +643,10 @@ public interface TraversableOnce<T> extends Value<T> {
         if (isEmpty()) {
             return None.instance();
         } else {
-            return minBy((t1, t2) -> f.apply(t1).compareTo(f.apply(t2)));
+            return new Some<>(foldLeft((Tuple2<U, T>) null, (u, t) -> {
+                final U tu = f.apply(t);
+                return u != null && u._1.compareTo(tu) <= 0 ? u : Tuple.of(tu, t);
+            })._2);
         }
     }
 

--- a/src/test/java/javaslang/collection/AbstractTraversableOnceTest.java
+++ b/src/test/java/javaslang/collection/AbstractTraversableOnceTest.java
@@ -779,6 +779,16 @@ public abstract class AbstractTraversableOnceTest extends AbstractValueTest {
         assertThat(of(1, 2, 3).maxBy(i -> -i)).isEqualTo(new Some<>(1));
     }
 
+    @Test
+    public void shouldCallMaxFunctionOncePerElement() {
+        final int[] cnt = {0};
+        assertThat(of(1, 2, 3).maxBy(i -> {
+            cnt[0]++;
+            return i;
+        })).isEqualTo(new Some<>(3));
+        assertThat(cnt[0]).isEqualTo(3);
+    }
+
     // -- min
 
     @Test
@@ -883,6 +893,16 @@ public abstract class AbstractTraversableOnceTest extends AbstractValueTest {
     @Test
     public void shouldCalculateInverseMinByFunctionOfInts() {
         assertThat(of(1, 2, 3).minBy(i -> -i)).isEqualTo(new Some<>(3));
+    }
+
+    @Test
+    public void shouldCallMinFunctionOncePerElement() {
+        final int[] cnt = {0};
+        assertThat(of(1, 2, 3).minBy(i -> {
+            cnt[0]++;
+            return i;
+        })).isEqualTo(new Some<>(1));
+        assertThat(cnt[0]).isEqualTo(3);
     }
 
     // -- product


### PR DESCRIPTION
This improvement is not obvious, but in case <code>Euler14Test</code> running time on my computer decreases by 20%. In case of delegating these methods to the comparator, function was called 2*n-1 times, where n is the length of sequence. It is bad if function is not primitive (even in case memoized (!) like in <code>Euler14Test</code>)