### PR TITLE
Add syntax sugar to singleton map creation

### DIFF
--- a/src/main/java/javaslang/collection/HashMap.java
+++ b/src/main/java/javaslang/collection/HashMap.java
@@ -5,20 +5,26 @@
  */
 package javaslang.collection;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
 import javaslang.Lazy;
 import javaslang.Tuple;
 import javaslang.Tuple2;
 import javaslang.control.None;
 import javaslang.control.Option;
 import javaslang.control.Some;
-
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.function.*;
-import java.util.stream.Collector;
 
 /**
  * An immutable {@code HashMap} implementation based on a
@@ -75,6 +81,19 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> HashMap<K, V> of(Tuple2<? extends K, ? extends V> entry) {
         return new HashMap<>(HashArrayMappedTrie.<K, V> empty().put(entry._1, entry._2));
+    }
+
+    /**
+     * Returns a singleton {@code HashMap}, i.e. a {@code HashMap} of one element.
+     *
+     * @param key A singleton map key.
+     * @param value A singleton map value.
+     * @param <K>   The key type
+     * @param <V>   The value type
+     * @return A new Map containing the given entry
+     */
+    public static <K, V> HashMap<K, V> of(K key, V value) {
+        return new HashMap<>(HashArrayMappedTrie.<K, V> empty().put(key, value));
     }
 
     /**

--- a/src/main/java/javaslang/collection/LinkedHashMap.java
+++ b/src/main/java/javaslang/collection/LinkedHashMap.java
@@ -5,18 +5,24 @@
  */
 package javaslang.collection;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
 import javaslang.Tuple;
 import javaslang.Tuple2;
 import javaslang.control.None;
 import javaslang.control.Option;
 import javaslang.control.Some;
-
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Objects;
-import java.util.function.*;
-import java.util.stream.Collector;
 
 /**
  * An immutable {@code LinkedHashMap} implementation.
@@ -74,6 +80,21 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public static <K, V> LinkedHashMap<K, V> of(Tuple2<? extends K, ? extends V> entry) {
         final HashMap<K, V> map = HashMap.of(entry);
         final Queue<Tuple2<K, V>> list = Queue.of((Tuple2<K, V>) entry);
+        return list.isEmpty() ? empty() : new LinkedHashMap<>(list, map);
+    }
+
+    /**
+     * Returns a singleton {@code HashMap}, i.e. a {@code HashMap} of one element.
+     *
+     * @param key A singleton map key.
+     * @param value A singleton map value.
+     * @param <K>   The key type
+     * @param <V>   The value type
+     * @return A new Map containing the given entry
+     */
+    public static <K, V> LinkedHashMap<K, V> of(K key, V value) {
+        final HashMap<K, V> map = HashMap.of(key, value);
+        final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(key, value));
         return list.isEmpty() ? empty() : new LinkedHashMap<>(list, map);
     }
 

--- a/src/main/java/javaslang/collection/LinkedHashMap.java
+++ b/src/main/java/javaslang/collection/LinkedHashMap.java
@@ -84,7 +84,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     }
 
     /**
-     * Returns a singleton {@code HashMap}, i.e. a {@code HashMap} of one element.
+     * Returns a singleton {@code LinkedHashMap}, i.e. a {@code LinkedHashMap} of one element.
      *
      * @param key A singleton map key.
      * @param value A singleton map value.

--- a/src/main/java/javaslang/collection/LinkedHashMap.java
+++ b/src/main/java/javaslang/collection/LinkedHashMap.java
@@ -80,7 +80,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public static <K, V> LinkedHashMap<K, V> of(Tuple2<? extends K, ? extends V> entry) {
         final HashMap<K, V> map = HashMap.of(entry);
         final Queue<Tuple2<K, V>> list = Queue.of((Tuple2<K, V>) entry);
-        return list.isEmpty() ? empty() : new LinkedHashMap<>(list, map);
+        return new LinkedHashMap<>(list, map);
     }
 
     /**
@@ -95,7 +95,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public static <K, V> LinkedHashMap<K, V> of(K key, V value) {
         final HashMap<K, V> map = HashMap.of(key, value);
         final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(key, value));
-        return list.isEmpty() ? empty() : new LinkedHashMap<>(list, map);
+        return new LinkedHashMap<>(list, map);
     }
 
     /**
@@ -287,7 +287,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     @Override
     public <U> Seq<U> flatMap(Function<? super Tuple2<K, V>, ? extends java.lang.Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return (Seq<U>) list.flatMap(mapper).toStream();
+        return list.flatMap(mapper).toStream();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/javaslang/collection/TreeMap.java
+++ b/src/main/java/javaslang/collection/TreeMap.java
@@ -144,8 +144,6 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Iterable<Tuple2<K, 
      */
     public static <K extends Comparable<? super K>, V> TreeMap<K, V> of(Comparator<? super K> keyComparator, K key, V value) {
         Objects.requireNonNull(keyComparator, "keyComparator is null");
-        Objects.requireNonNull(key, "key is null");
-        Objects.requireNonNull(value, "value is null");
         return TreeMap.<K, V>empty(keyComparator).put(key, value);
     }
 

--- a/src/main/java/javaslang/collection/TreeMap.java
+++ b/src/main/java/javaslang/collection/TreeMap.java
@@ -105,19 +105,6 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Iterable<Tuple2<K, 
     }
 
     /**
-     * Returns a singleton {@code HashMap}, i.e. a {@code HashMap} of one element.
-     *
-     * @param key A singleton map key.
-     * @param value A singleton map value.
-     * @param <K>   The key type
-     * @param <V>   The value type
-     * @return A new Map containing the given entry
-     */
-    public static <K extends Comparable<? super K>, V> TreeMap<K, V> of(K key, V value) {
-        return of((Comparator<? super K> & Serializable) K::compareTo, Tuple.of(key, value));
-    }
-
-    /**
      * Returns a singleton {@code TreeMap}, i.e. a {@code TreeMap} of one entry using a specific key comparator.
      *
      * @param <K>           The key type
@@ -130,6 +117,36 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Iterable<Tuple2<K, 
         Objects.requireNonNull(keyComparator, "keyComparator is null");
         Objects.requireNonNull(entry, "entry is null");
         return TreeMap.<K, V> empty(keyComparator).put(entry);
+    }
+
+    /**
+     * Returns a singleton {@code HashMap}, i.e. a {@code HashMap} of one element.
+     *
+     * @param key A singleton map key.
+     * @param value A singleton map value.
+     * @param <K>   The key type
+     * @param <V>   The value type
+     * @return A new Map containing the given entry
+     */
+    public static <K extends Comparable<? super K>, V> TreeMap<K, V> of(K key, V value) {
+        return of((Comparator<? super K> & Serializable) K::compareTo, key, value);
+    }
+
+    /**
+     * Returns a singleton {@code HashMap}, i.e. a {@code HashMap} of one element.
+     *
+     * @param key A singleton map key.
+     * @param value A singleton map value.
+     * @param <K>   The key type
+     * @param <V>   The value type
+     * @param keyComparator The comparator used to sort the entries by their key.
+     * @return A new Map containing the given entry
+     */
+    public static <K extends Comparable<? super K>, V> TreeMap<K, V> of(Comparator<? super K> keyComparator, K key, V value) {
+        Objects.requireNonNull(keyComparator, "keyComparator is null");
+        Objects.requireNonNull(key, "key is null");
+        Objects.requireNonNull(value, "value is null");
+        return TreeMap.<K, V>empty(keyComparator).put(key, value);
     }
 
     /**
@@ -379,7 +396,7 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Iterable<Tuple2<K, 
     }
 
     @SuppressWarnings("unchecked")
-	@Override
+    @Override
     public Comparator<K> keyComparator() {
         return ((EntryComparator<K, V>) entries.comparator()).keyComparator;
     }
@@ -407,7 +424,7 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Iterable<Tuple2<K, 
     @Override
     public <U> Seq<U> map(Function<? super Tuple2<K, V>, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return (Seq<U>) entries.iterator().map(mapper).toStream();
+        return entries.iterator().map(mapper).toStream();
     }
 
     @Override

--- a/src/main/java/javaslang/collection/TreeMap.java
+++ b/src/main/java/javaslang/collection/TreeMap.java
@@ -120,7 +120,7 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Iterable<Tuple2<K, 
     }
 
     /**
-     * Returns a singleton {@code HashMap}, i.e. a {@code HashMap} of one element.
+     * Returns a singleton {@code TreeMap}, i.e. a {@code TreeMap} of one element.
      *
      * @param key A singleton map key.
      * @param value A singleton map value.
@@ -133,7 +133,7 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Iterable<Tuple2<K, 
     }
 
     /**
-     * Returns a singleton {@code HashMap}, i.e. a {@code HashMap} of one element.
+     * Returns a singleton {@code TreeMap}, i.e. a {@code TreeMap} of one element.
      *
      * @param key A singleton map key.
      * @param value A singleton map value.

--- a/src/main/java/javaslang/collection/TreeMap.java
+++ b/src/main/java/javaslang/collection/TreeMap.java
@@ -5,19 +5,25 @@
  */
 package javaslang.collection;
 
-import javaslang.Tuple;
-import javaslang.Tuple2;
-import javaslang.control.None;
-import javaslang.control.Option;
-import javaslang.control.Some;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.function.*;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collector;
+
+import javaslang.Tuple;
+import javaslang.Tuple2;
+import javaslang.control.None;
+import javaslang.control.Option;
+import javaslang.control.Some;
 
 import static javaslang.collection.Comparators.naturalComparator;
 
@@ -96,6 +102,19 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Iterable<Tuple2<K, 
      */
     public static <K extends Comparable<? super K>, V> TreeMap<K, V> of(Tuple2<? extends K, ? extends V> entry) {
         return of((Comparator<? super K> & Serializable) K::compareTo, entry);
+    }
+
+    /**
+     * Returns a singleton {@code HashMap}, i.e. a {@code HashMap} of one element.
+     *
+     * @param key A singleton map key.
+     * @param value A singleton map value.
+     * @param <K>   The key type
+     * @param <V>   The value type
+     * @return A new Map containing the given entry
+     */
+    public static <K extends Comparable<? super K>, V> TreeMap<K, V> of(K key, V value) {
+        return of((Comparator<? super K> & Serializable) K::compareTo, Tuple.of(key, value));
     }
 
     /**
@@ -269,7 +288,7 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Iterable<Tuple2<K, 
     @Override
     public <U> Seq<U> flatMap(Function<? super Tuple2<K, V>, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return (Seq<U>) entries.iterator().flatMap(mapper).toStream();
+        return entries.iterator().flatMap(mapper).toStream();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/javaslang/collection/AbstractMapTest.java
+++ b/src/test/java/javaslang/collection/AbstractMapTest.java
@@ -5,12 +5,6 @@
  */
 package javaslang.collection;
 
-import javaslang.Tuple;
-import javaslang.Tuple2;
-import javaslang.control.Some;
-import org.assertj.core.api.IterableAssert;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -19,6 +13,12 @@ import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
+
+import javaslang.Tuple;
+import javaslang.Tuple2;
+import javaslang.control.Some;
+import org.assertj.core.api.IterableAssert;
+import org.junit.Test;
 
 import static javaslang.Serializables.deserialize;
 import static javaslang.Serializables.serialize;
@@ -103,6 +103,8 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
     @SuppressWarnings("unchecked")
     abstract protected <K, V> Map<K, V> mapOf(Tuple2<? extends K, ? extends V>... entries);
 
+    abstract protected <K extends Comparable<? super K>, V> Map<K, V> of(K key, V value);
+
     @Override
     protected boolean useIsEqualToInsteadOfIsSameAs() {
         return true;
@@ -179,7 +181,14 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
         return ofAll(Iterator.ofAll(array));
     }
 
-    // - toString
+    // -- construction
+
+    @Test
+    public void shouldBeTheSame() {
+        assertThat(of(1, 2)).isEqualTo(emptyMap().put(1, 2));
+    }
+
+    // -- toString
 
     @Test
     public void shouldMakeString() {

--- a/src/test/java/javaslang/collection/HashMapTest.java
+++ b/src/test/java/javaslang/collection/HashMapTest.java
@@ -5,10 +5,10 @@
  */
 package javaslang.collection;
 
-import javaslang.Tuple2;
-
 import java.util.ArrayList;
 import java.util.stream.Collector;
+
+import javaslang.Tuple2;
 
 public class HashMapTest extends AbstractMapTest {
 
@@ -24,7 +24,7 @@ public class HashMapTest extends AbstractMapTest {
 
     @Override
     protected <T> Collector<Tuple2<Integer, T>, ArrayList<Tuple2<Integer, T>>, ? extends Map<Integer, T>> mapCollector() {
-        return HashMap.<Integer, T> collector();
+        return HashMap.<Integer, T>collector();
     }
 
     @SuppressWarnings("varargs")
@@ -32,5 +32,10 @@ public class HashMapTest extends AbstractMapTest {
     @Override
     protected final <K, V> Map<K, V> mapOf(Tuple2<? extends K, ? extends V>... entries) {
         return HashMap.ofAll(entries);
+    }
+
+    @Override
+    protected <K  extends Comparable<? super K>, V> Map<K, V> of(K key, V value) {
+        return HashMap.of(key, value);
     }
 }

--- a/src/test/java/javaslang/collection/LinkedHashMapTest.java
+++ b/src/test/java/javaslang/collection/LinkedHashMapTest.java
@@ -1,10 +1,10 @@
 package javaslang.collection;
 
-import javaslang.Tuple2;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.stream.Collector;
+
+import javaslang.Tuple2;
+import org.junit.Test;
 
 public class LinkedHashMapTest extends AbstractMapTest {
     @Override
@@ -27,6 +27,11 @@ public class LinkedHashMapTest extends AbstractMapTest {
     @Override
     protected final <K, V> Map<K, V> mapOf(Tuple2<? extends K, ? extends V>... entries) {
         return LinkedHashMap.ofAll(entries);
+    }
+
+    @Override
+    protected <K extends Comparable<? super K>, V> Map<K, V> of(K key, V value) {
+        return LinkedHashMap.of(key, value);
     }
 
     @Test

--- a/src/test/java/javaslang/collection/TreeMapTest.java
+++ b/src/test/java/javaslang/collection/TreeMapTest.java
@@ -6,10 +6,10 @@
 package javaslang.collection;
 
 
-import javaslang.Tuple2;
-
 import java.util.ArrayList;
 import java.util.stream.Collector;
+
+import javaslang.Tuple2;
 
 import static javaslang.collection.Comparators.naturalComparator;
 
@@ -35,6 +35,11 @@ public class TreeMapTest extends AbstractMapTest {
     @Override
     protected final <K, V> Map<K, V> mapOf(Tuple2<? extends K, ? extends V>... entries) {
         return TreeMap.ofAll(naturalComparator(), entries);
+    }
+
+    @Override
+    protected <K extends Comparable<? super K>, V> Map<K, V> of(K key, V value) {
+        return TreeMap.of(key, value);
     }
 
     // -- obsolete tests


### PR DESCRIPTION
Hi!
I have added another syntax sugar to simplify singleton map creation.
for instance:
```java
Map<Integer, Integer> map = HashMap.of(1, 2);
```
instead of
```java
Map<Integer, Integer> map = HashMap.empty().put(1, 2);
```
or
```java
Map<Integer, Integer> map = HashMap.of(Tuple.of(1, 2));
```

P.S. I'm sorry if I'm annoying :) 