### PR TITLE
Overwrite forEach method in Map to use BiConsumer

### DIFF
--- a/src/main/java/javaslang/collection/Map.java
+++ b/src/main/java/javaslang/collection/Map.java
@@ -5,15 +5,20 @@
  */
 package javaslang.collection;
 
-import javaslang.Tuple2;
-import javaslang.Tuple3;
-import javaslang.control.Option;
-
-import java.util.*;
+import java.util.Comparator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+
+import javaslang.Tuple2;
+import javaslang.Tuple3;
+import javaslang.control.Option;
 
 /**
  * An immutable {@code Map} interface.
@@ -224,10 +229,10 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function<K, V> {
         Objects.requireNonNull(unzipper, "unzipper is null");
         return iterator().unzip(unzipper).map(Stream::ofAll, Stream::ofAll);
     }
-    
+
     @Override
     default <T1, T2, T3> Tuple3<Seq<T1>, Seq<T2>, Seq<T3>> unzip3(
-    		Function<? super Tuple2<K,V>, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
+        Function<? super Tuple2<K,V>, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
         return iterator().unzip3(unzipper).map(Stream::ofAll, Stream::ofAll, Stream::ofAll);
     }
@@ -247,6 +252,19 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function<K, V> {
     @Override
     default Seq<Tuple2<Tuple2<K, V>, Integer>> zipWithIndex() {
         return Stream.ofAll(iterator().zipWithIndex());
+    }
+
+    /**
+     * Performs an action on key, value pair.
+     *
+     * @param action A {@code BiConsumer}
+     * @throws NullPointerException if {@code action} is null
+     */
+    default void forEach(BiConsumer<K, V> action) {
+        Objects.requireNonNull(action, "action is null");
+        for (Tuple2<K, V> t : this) {
+            action.accept(t._1, t._2);
+        }
     }
 
 }

--- a/src/main/java/javaslang/collection/Map.java
+++ b/src/main/java/javaslang/collection/Map.java
@@ -5,20 +5,12 @@
  */
 package javaslang.collection;
 
-import java.util.Comparator;
-import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Predicate;
-
 import javaslang.Tuple2;
 import javaslang.Tuple3;
 import javaslang.control.Option;
+
+import java.util.*;
+import java.util.function.*;
 
 /**
  * An immutable {@code Map} interface.
@@ -189,8 +181,8 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function<K, V> {
     Map<K, V> retainAll(java.lang.Iterable<? extends Tuple2<K, V>> elements);
 
     @Override
-    Map<K,V> scan(Tuple2<K, V> zero,
-            BiFunction<? super Tuple2<K, V>, ? super Tuple2<K, V>, ? extends Tuple2<K, V>> operation);
+    Map<K, V> scan(Tuple2<K, V> zero,
+                   BiFunction<? super Tuple2<K, V>, ? super Tuple2<K, V>, ? extends Tuple2<K, V>> operation);
 
     @Override
     <U> Seq<U> scanLeft(U zero, BiFunction<? super U, ? super Tuple2<K, V>, ? extends U> operation);
@@ -232,7 +224,7 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function<K, V> {
 
     @Override
     default <T1, T2, T3> Tuple3<Seq<T1>, Seq<T2>, Seq<T3>> unzip3(
-        Function<? super Tuple2<K,V>, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
+            Function<? super Tuple2<K, V>, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
         return iterator().unzip3(unzipper).map(Stream::ofAll, Stream::ofAll, Stream::ofAll);
     }

--- a/src/main/java/javaslang/collection/Traversable.java
+++ b/src/main/java/javaslang/collection/Traversable.java
@@ -5,6 +5,13 @@
  */
 package javaslang.collection;
 
+import javaslang.Tuple2;
+import javaslang.Tuple3;
+import javaslang.Value;
+import javaslang.control.None;
+import javaslang.control.Option;
+import javaslang.control.Some;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Comparator;
@@ -14,13 +21,6 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
-
-import javaslang.Tuple2;
-import javaslang.Tuple3;
-import javaslang.Value;
-import javaslang.control.None;
-import javaslang.control.Option;
-import javaslang.control.Some;
 
 /**
  * An interface for inherently recursive, multi-valued data structures. The order of elements is determined by
@@ -866,48 +866,48 @@ public interface Traversable<T> extends Value<T> {
 
     /**
      * Computes a prefix scan of the elements of the collection.
-     * 
+     *
      * Note: The neutral element z may be applied more than once.
-     * 
-     * @param zero neutral element for the operator op
+     *
+     * @param zero      neutral element for the operator op
      * @param operation the associative operator for the scan
      * @return a new traversable collection containing the prefix scan of the elements in this traversable collection
      */
     Traversable<T> scan(T zero, BiFunction<? super T, ? super T, ? extends T> operation);
-    
+
     /**
      * Produces a collection containing cumulative results of applying the
      * operator going left to right.
-     * 
+     *
      * Note: will not terminate for infinite-sized collections.
-     * 
+     *
      * Note: might return different results for different runs, unless the
      * underlying collection type is ordered.
-     * 
-     * @param <U> the type of the elements in the resulting collection
-     * @param zero the initial value
+     *
+     * @param <U>       the type of the elements in the resulting collection
+     * @param zero      the initial value
      * @param operation the binary operator applied to the intermediate result and the element
      * @return collection with intermediate results
      */
     <U> Traversable<U> scanLeft(U zero, BiFunction<? super U, ? super T, ? extends U> operation);
-    
+
     /**
      * Produces a collection containing cumulative results of applying the
      * operator going right to left. The head of the collection is the last
      * cumulative result.
-     * 
+     *
      * Note: will not terminate for infinite-sized collections.
-     * 
+     *
      * Note: might return different results for different runs, unless the
      * underlying collection type is ordered.
-     * 
-     * @param <U> the type of the elements in the resulting collection
-     * @param zero the initial value
+     *
+     * @param <U>       the type of the elements in the resulting collection
+     * @param zero      the initial value
      * @param operation the binary operator applied to the intermediate result and the element
      * @return collection with intermediate results
      */
     <U> Traversable<U> scanRight(U zero, BiFunction<? super T, ? super U, ? extends U> operation);
-    
+
     /**
      * Returns a tuple where the first element is the longest prefix of elements that satisfy p and the second element is the remainder.
      *
@@ -1038,9 +1038,10 @@ public interface Traversable<T> extends Value<T> {
      * @param <T3>     3rd element type of a triplet returned by unzipper
      * @return A triplet of set containing elements split by unzipper
      * @throws NullPointerException if {@code unzipper} is null
-     */    
+     */
     <T1, T2, T3> Tuple3<? extends Traversable<T1>, ? extends Traversable<T2>, ? extends Traversable<T3>> unzip3(
-    		Function<? super T, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper);
+            Function<? super T, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper);
+
     /**
      * Returns a traversable formed from this traversable and another java.lang.Iterable collection by combining
      * corresponding elements in pairs. If one of the two iterables is longer than the other, its remaining elements

--- a/src/test/java/javaslang/IterableTest.java
+++ b/src/test/java/javaslang/IterableTest.java
@@ -5,14 +5,15 @@
  */
 package javaslang;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 import javaslang.collection.List;
 import javaslang.collection.Queue;
 import javaslang.collection.Stream;
 import javaslang.control.None;
 import javaslang.control.Some;
 import org.junit.Test;
-
-import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,7 +43,7 @@ public class IterableTest {
     @Test
     public void shouldEqNestedIterables() {
         // ((1, 2), ((3)))
-        final Iterable<?> i1 = List.ofAll(List.ofAll(1, 2), Arrays.asList(List.of(3)));
+        final Iterable<?> i1 = List.ofAll(List.ofAll(1, 2), Collections.singletonList(List.of(3)));
         final Iterable<?> i2 = Queue.ofAll(Stream.ofAll(1, 2), List.of(Lazy.of(() -> 3)));
         final Iterable<?> i3 = Queue.ofAll(Stream.ofAll(1, 2), List.of(List.ofAll()));
         assertThat(i1.eq(i2)).isTrue();

--- a/src/test/java/javaslang/collection/AbstractMapTest.java
+++ b/src/test/java/javaslang/collection/AbstractMapTest.java
@@ -567,4 +567,26 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
         final List<String> expected = List.ofAll('a', 'b', 'c').permutations().map(List::mkString);
         assertThat(actual).isIn(expected);
     }
+
+    // -- forEach
+
+    @Test
+    public void forEachByKeyValue() {
+        Map<Integer, Integer> map = of(1, 2).put(3, 4);
+        final int[] result = {0};
+        map.forEach((k, v) -> {
+            result[0] += k + v;
+        });
+        assertThat(result[0]).isEqualTo(10);
+    }
+
+    @Test
+    public void forEachByTuple() {
+        Map<Integer, Integer> map = of(1, 2).put(3, 4);
+        final int[] result = {0};
+        map.forEach(t -> {
+            result[0] += t._1 + t._2;
+        });
+        assertThat(result[0]).isEqualTo(10);
+    }
 }


### PR DESCRIPTION
Hi!

I have written an forEach method for map which is using BiConsumer.
It's convenient to write like this:
```java
map.forEach((k, v) -> { doSomething(k, v); });
```
instead of:
```
map.forEach(t -> { doSomething(t._1, t._2); });
```

