### PR TITLE
Adjusted return type of Option.none().

### DIFF
--- a/src/main/java/javaslang/control/Option.java
+++ b/src/main/java/javaslang/control/Option.java
@@ -49,7 +49,7 @@ public interface Option<T> extends Value<T> {
      * @param <T> component type
      * @return the single instance of {@code None}
      */
-    static <T> None<T> none() {
+    static <T> Option<T> none() {
         return None.instance();
     }
 


### PR DESCRIPTION
Consistent compared to factory methods of Try et al.

If type None is needed, use None.instance().