### PR TITLE
Add 'accept' method to Option class

### DIFF
--- a/src/main/java/javaslang/control/None.java
+++ b/src/main/java/javaslang/control/None.java
@@ -7,6 +7,8 @@ package javaslang.control;
 
 import java.io.Serializable;
 import java.util.NoSuchElementException;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * None is a singleton representation of the undefined {@link javaslang.control.Option}. The instance is obtained by
@@ -49,6 +51,11 @@ public final class None<T> implements Option<T>, Serializable {
     @Override
     public T get() {
         throw new NoSuchElementException("No value present");
+    }
+
+    @Override
+    public <U> U accept(Supplier<U> visitNone, Function<? super T, ? extends U> visitSome) {
+        return visitNone.get();
     }
 
     @Override

--- a/src/main/java/javaslang/control/Option.java
+++ b/src/main/java/javaslang/control/Option.java
@@ -159,6 +159,16 @@ public interface Option<T> extends Value<T> {
     }
 
     /**
+     * Applies one of given functions depending on whether this object is None or Some
+     *
+     * @param visitNone A function which is applied when this object is None
+     * @param visitSome A function which is applied when this object is Some
+     * @param <U>        The new value type
+     * @return an object of type U returned by visitNone or visitSome
+     */
+    <U> U accept(Supplier<U> visitNone, Function<? super T, ? extends U> visitSome);
+
+    /**
      * Returns {@code Some(value)} if this is a {@code Some} and the value satisfies the given predicate.
      * Otherwise {@code None} is returned.
      *

--- a/src/main/java/javaslang/control/Some.java
+++ b/src/main/java/javaslang/control/Some.java
@@ -7,6 +7,8 @@ package javaslang.control;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Some represents a defined {@link javaslang.control.Option}. It contains a value which may be null. However, to
@@ -49,6 +51,11 @@ public final class Some<T> implements Option<T>, Serializable {
     @Override
     public T get() {
         return value;
+    }
+
+    @Override
+    public <U> U accept(Supplier<U> visitNone, Function<? super T, ? extends U> visitSome) {
+        return visitSome.apply(value);
     }
 
     @Override

--- a/src/test/java/javaslang/control/OptionTest.java
+++ b/src/test/java/javaslang/control/OptionTest.java
@@ -123,6 +123,18 @@ public class OptionTest {
         Option.none().orElseThrow(() -> new RuntimeException("none"));
     }
 
+    // -- accept
+
+    @Test
+    public void shouldApplyFirstFunctionWhenValueIsNotPresent() {
+        assertThat(Option.none().accept(() -> "none", v -> "some")).isEqualTo("none");
+    }
+
+    @Test
+    public void shouldApplySecondFunctionWhenValueIsNotPresent() {
+        assertThat(Option.of(1).accept(() -> "none", v -> "some")).isEqualTo("some");
+    }
+
     // -- toJavaOptional
 
     @Test


### PR DESCRIPTION
This PR adds 'accept' method to Option class; the following expression is equal to "none" if `opt` is of type None and "some" if it is of type Some.

```
opt.accept(() -> "none", v -> "some")
```

The term 'accept" comes from GoF Visitor pattern. Another candidate would be 'match', since this can be seen as pattern match against union type.
