### PR TITLE
Add to Tuple2 overridden 'transform' method which takes BiFunction

### DIFF
--- a/src-gen/main/java/javaslang/Tuple2.java
+++ b/src-gen/main/java/javaslang/Tuple2.java
@@ -135,6 +135,18 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
         return f.apply(this);
     }
 
+    /**
+     * Transforms this tuple to an arbitrary object (which may be also a tuple of same or different arity).
+     *
+     * @param f Transformation which takes elements of this tuple and return an object of type U
+     * @param <U> New type
+     * @return An object of type U
+     */
+    public <U> U transform(BiFunction<? super T1, ? super T2, U> f) {
+        Objects.requireNonNull(f, "f is null");
+        return f.apply(_1, _2);
+    }
+
     @Override
     public Seq<?> toSeq() {
         return List.ofAll(_1, _2);

--- a/src-gen/test/java/javaslang/Tuple2Test.java
+++ b/src-gen/test/java/javaslang/Tuple2Test.java
@@ -94,6 +94,13 @@ public class Tuple2Test {
     }
 
     @Test
+    public void shouldTransformTupleWithBiFunction() {
+        final Tuple2<Object, Object> tuple = createTuple();
+        final Tuple0 actual = tuple.transform((fst, snd) -> Tuple0.instance());
+        assertThat(actual).isEqualTo(Tuple0.instance());
+    }
+
+    @Test
     public void shouldRecognizeEquality() {
         final Tuple2<Object, Object> tuple1 = createTuple();
         final Tuple2<Object, Object> tuple2 = createTuple();


### PR DESCRIPTION
This PR add 'Tuple2.transform' method which takes BiFunction.

I think this is useful since you can write:

```
tuple.transform((fst, snd) -> ...)
```

instead of:

```
tuple.transform(t -> {
    T fst = t._1();
    U snd = t._2();
    ...
})