### PR TITLE
Add ability to wrap a Java future with a JavaSlang future

### DIFF
--- a/src/main/java/javaslang/concurrent/Future.java
+++ b/src/main/java/javaslang/concurrent/Future.java
@@ -218,6 +218,32 @@ public interface Future<T> extends Value<T> {
     }
 
     /**
+     * Creates a {@code Future} with the given java.util.concurrent.Future, backed by the {@link #DEFAULT_EXECUTOR_SERVICE}
+     * @param future
+     * @param <T>
+     * @return A new {@code Future} wrapping the result of the Java future
+     * @throws NullPointerException if future is null
+     */
+    static <T> Future<T> fromJavaFuture(java.util.concurrent.Future<T> future) {
+        Objects.requireNonNull(future, "future is null");
+        return Future.of(DEFAULT_EXECUTOR_SERVICE, future::get);
+    }
+
+    /**
+     * Creates a {@code Future} with the given java.util.concurrent.Future, backed by given {@link ExecutorService}
+     * @param executorService
+     * @param future
+     * @param <T>
+     * @return A new {@code Future} wrapping the result of the Java future
+     * @throws NullPointerException if executorService or future is null
+     */
+    static <T> Future<T> fromJavaFuture(ExecutorService executorService, java.util.concurrent.Future<T> future) {
+        Objects.requireNonNull(executorService, "executorService is null");
+        Objects.requireNonNull(future, "future is null");
+        return Future.of(executorService, future::get);
+    }
+
+    /**
      * Creates a {@code Future} from a {@link Try}, backed by the {@link #DEFAULT_EXECUTOR_SERVICE}.
      *
      * @param result The result.

--- a/src/test/java/javaslang/concurrent/FutureTest.java
+++ b/src/test/java/javaslang/concurrent/FutureTest.java
@@ -15,6 +15,7 @@ import org.assertj.core.api.IterableAssert;
 import org.junit.Test;
 
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 
 import static javaslang.concurrent.Concurrent.waitUntil;
 import static javaslang.concurrent.Concurrent.zZz;
@@ -80,6 +81,26 @@ public class FutureTest extends AbstractValueTest {
             throw new Error();
         });
         assertFailed(future, Error.class);
+    }
+
+    // -- static fromJavaFuture()
+
+    @Test
+    public void shouldCreateFutureFromJavaFuture() {
+        // Create slow-resolving Java future to show that the wrapping doesn't block
+        java.util.concurrent.Future<Integer> jFuture = generateJavaFuture(1, 3000);
+        final Future<Integer> future = Future.fromJavaFuture(jFuture);
+        waitUntil(future::isCompleted);
+        assertCompleted(future, 1);
+    }
+
+    @Test
+    public void shouldCreateFutureFromJavaFutureUsingTrivialExecutorService() {
+        // Create slow-resolving Java future to show that the wrapping doesn't block
+        java.util.concurrent.Future<String> jFuture = generateJavaFuture("Result", 3000);
+        final Future<String> future = Future.fromJavaFuture(TrivialExecutorService.instance(), jFuture);
+        waitUntil(future::isCompleted);
+        assertCompleted(future, "Result");
     }
 
     // -- static find()
@@ -417,5 +438,17 @@ public class FutureTest extends AbstractValueTest {
     <T> void assertCompleted(Future<?> future, T value) {
         assertThat(future.isCompleted()).isTrue();
         assertThat(future.getValue()).isEqualTo(new Some<>(new Success<>(value)));
+    }
+
+    <T> java.util.concurrent.Future<T> generateJavaFuture(T value, int waitPeriod) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                Thread.sleep(waitPeriod);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+            return value;
+        });
     }
 }


### PR DESCRIPTION
I didn't see this ability in the code, but I have occasions where I want to wrap my Java futures into JavaSlang futures to align with my other JavaSlang code. Please feel free to let me know if you agree with the ability to do this, and if you have feedback on the code itself. Thanks.