### PR TITLE
Add draw() method for trees

### DIFF
--- a/src/main/java/javaslang/collection/Tree.java
+++ b/src/main/java/javaslang/collection/Tree.java
@@ -631,6 +631,13 @@ public interface Tree<T> extends Traversable<T> {
     String toString();
 
     /**
+     * Creates a neat 2-dimensional drawing of a tree. Unicode characters are used to draw node junctions.
+     *
+     * @return A nice string representation of the tree.
+     */
+    String draw();
+
+    /**
      * Represents a tree node.
      *
      * @param <T> value type
@@ -706,6 +713,24 @@ public interface Tree<T> extends Traversable<T> {
         @Override
         public String toString() {
             return stringPrefix() + (isLeaf() ? "(" + value + ")" : toLispString(this));
+        }
+
+        @Override
+        public String draw() {
+            StringBuilder builder = new StringBuilder();
+            drawAux("", builder);
+            return builder.toString();
+        }
+
+        private void drawAux(String indent, StringBuilder builder) {
+            builder.append(value);
+            for (List<Node<T>> it = children; !it.isEmpty(); it = it.tail()) {
+                final boolean isLast = it.tail().isEmpty();
+                builder.append('\n')
+                        .append(indent)
+                        .append(isLast ? "└──" : "├──");
+                it.head().drawAux(indent + (isLast ? "   " : "│  "), builder);
+            }
         }
 
         private static String toLispString(Tree<?> tree) {
@@ -871,6 +896,9 @@ public interface Tree<T> extends Traversable<T> {
         public String toString() {
             return stringPrefix() + "()";
         }
+
+        @Override
+        public String draw() { return "▣"; }
 
         // -- Serializable implementation
 

--- a/src/test/java/javaslang/collection/TreeTest.java
+++ b/src/test/java/javaslang/collection/TreeTest.java
@@ -571,6 +571,26 @@ public class TreeTest extends AbstractTraversableTest {
         assertThat(tree.toString()).isEqualTo("Tree(1 (2 (4 7) 5) (3 (6 8 9)))");
     }
 
+    // draw
+
+    @Test
+    public void shouldReturnDrawStringOfEmpty() {
+        assertThat(Tree.empty().draw()).isEqualTo("▣");
+    }
+
+    @Test
+    public void shouldReturnDrawStringOfNode() {
+        assertThat(tree.draw()).isEqualTo("1\n" +
+                "├──2\n" +
+                "│  ├──4\n" +
+                "│  │  └──7\n" +
+                "│  └──5\n" +
+                "└──3\n" +
+                "   └──6\n" +
+                "      ├──8\n" +
+                "      └──9");
+    }
+
     // -- Serializable interface
 
     @Test


### PR DESCRIPTION
This adds the `String draw()` method to the `Tree` interface. It pretty prints a tree, like `Data.Tree.drawTree` from Haskell, in a nice two dimensional way.