### PR TITLE
add consumer and runnable to MatchMonad pattern matching

### DIFF
--- a/src/main/java/javaslang/control/Match.java
+++ b/src/main/java/javaslang/control/Match.java
@@ -545,6 +545,22 @@ public interface Match<R> extends Function<Object, R> {
                 return new Otherwise<>(supplier);
             }
 
+            public Otherwise<Void> otherwiseRun(Consumer<? super T> action) {
+                Objects.requireNonNull(action, "action is null");
+                return new Otherwise<>(() -> {
+                    action.accept(value);
+                    return null;
+                });
+            }
+
+            public Otherwise<Void> otherwiseRun(Runnable action) {
+                Objects.requireNonNull(action, "action is null");
+                return new Otherwise<>(() -> {
+                    action.run();
+                    return null;
+                });
+            }
+
             public <R> Otherwise<R> otherwiseThrow(Supplier<? extends RuntimeException> supplier) {
                 Objects.requireNonNull(supplier, "supplier is null");
                 return new Otherwise<>(() -> {
@@ -572,6 +588,20 @@ public interface Match<R> extends Function<Object, R> {
 
             public <R> When.Then<T, R> then(R that) {
                 return then(ignored -> that);
+            }
+
+            public When.Then<T, Void> thenRun(Consumer<? super U> action) {
+                return then(param -> {
+                    action.accept(param);
+                    return null;
+                });
+            }
+
+            public When.Then<T, Void> thenRun(Runnable action) {
+                return then(ignored -> {
+                    action.run();
+                    return null;
+                });
             }
 
             public <R> When.Then<T, R> then(Supplier<? extends R> supplier) {
@@ -613,6 +643,20 @@ public interface Match<R> extends Function<Object, R> {
             public Then<T, R> then(Supplier<? extends R> supplier) {
                 Objects.requireNonNull(supplier, "supplier is null");
                 return then(ignored -> supplier.get());
+            }
+
+            public When.Then<T, R> thenRun(Consumer<? super U> action) {
+                return then(param -> {
+                    action.accept(param);
+                    return null;
+                });
+            }
+
+            public When.Then<T, R> thenRun(Runnable action) {
+                return then(ignored -> {
+                    action.run();
+                    return null;
+                });
             }
 
             public Then<T, R> thenThrow(Supplier<? extends RuntimeException> supplier) {
@@ -694,6 +738,22 @@ public interface Match<R> extends Function<Object, R> {
                 public Otherwise<R> otherwise(Supplier<? extends R> supplier) {
                     Objects.requireNonNull(supplier, "supplier is null");
                     return new Otherwise<>(() -> result.orElse(supplier).get());
+                }
+
+                public Otherwise<R> otherwiseRun(Consumer<? super T> action) {
+                    Objects.requireNonNull(action, "action is null");
+                    return new Otherwise<>(() -> result.orElse(() -> {
+                        action.accept(value);
+                        return null;
+                    }).get());
+                }
+
+                public Otherwise<R> otherwiseRun(Runnable action) {
+                    Objects.requireNonNull(action, "action is null");
+                    return new Otherwise<>(() -> result.orElse(() -> {
+                        action.run();
+                        return null;
+                    }).get());
                 }
 
                 public Otherwise<R> otherwiseThrow(Supplier<? extends RuntimeException> supplier) {

--- a/src/test/java/javaslang/control/IntegerConsumer.java
+++ b/src/test/java/javaslang/control/IntegerConsumer.java
@@ -1,0 +1,12 @@
+package javaslang.control;
+
+import java.util.function.Consumer;
+
+public class IntegerConsumer implements Consumer<Integer> {
+    public int value;
+
+    @Override
+    public void accept(Integer i) {
+        this.value = i;
+    }
+}

--- a/src/test/java/javaslang/control/MatchFunctionTest.java
+++ b/src/test/java/javaslang/control/MatchFunctionTest.java
@@ -678,22 +678,4 @@ public class MatchFunctionTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("runnable not consumed");
     }
-
-    static private class IntegerConsumer implements Consumer<Integer> {
-        public int value;
-
-        @Override
-        public void accept(Integer i) {
-            this.value = i;
-        }
-    }
-
-    static private class SimpleRunnable implements Runnable {
-        public boolean executed;
-
-        @Override
-        public void run() {
-            this.executed=true;
-        }
-    }
 }

--- a/src/test/java/javaslang/control/SimpleRunnable.java
+++ b/src/test/java/javaslang/control/SimpleRunnable.java
@@ -1,0 +1,10 @@
+package javaslang.control;
+
+public class SimpleRunnable implements Runnable {
+    public boolean executed;
+
+    @Override
+    public void run() {
+        this.executed=true;
+    }
+}


### PR DESCRIPTION
One open question is if we should add some more meaningful termination operation for monads with consumer/runnable. Currently we have get() which is a little strange in case when we have MatchMonad of Void. I will leave this decision to You.