### PR TITLE
Add match() function to Value as syntactic sugar for Match.of(value)

### DIFF
--- a/generator/Generator.scala
+++ b/generator/Generator.scala
@@ -64,6 +64,7 @@ def generateMainClasses(): Unit = {
       val TreeType = im.getType("javaslang.collection.Tree")
       val TryType = im.getType("javaslang.control.Try")
       val VectorType = im.getType("javaslang.collection.Vector")
+      val MatchMonadTypeOf = im.getType("javaslang.control.Match.MatchMonad.Of")
 
       xs"""
         /**
@@ -449,6 +450,12 @@ def generateMainClasses(): Unit = {
              */
             $VectorType<T> toVector();
 
+            /**
+             * Provides syntactic sugar for {@link $MatchMonadTypeOf}.
+             *
+             * @return a new type-safe match builder.
+             */
+            $MatchMonadTypeOf<T> match();
         }
       """
     }

--- a/src-gen/main/java/javaslang/algebra/Monad.java
+++ b/src-gen/main/java/javaslang/algebra/Monad.java
@@ -18,6 +18,7 @@ import javaslang.collection.*;
 import javaslang.control.Either;
 import javaslang.control.Either.Left;
 import javaslang.control.Either.Right;
+import javaslang.control.Match.MatchMonad.Of;
 import javaslang.control.Option;
 import javaslang.control.Try;
 
@@ -529,4 +530,10 @@ interface Convertible<T> {
      */
     Vector<T> toVector();
 
+    /**
+     * Provides syntactic sugar for {@link Of}.
+     *
+     * @return a new type-safe match builder.
+     */
+    Of<T> match();
 }

--- a/src/main/java/javaslang/Value.java
+++ b/src/main/java/javaslang/Value.java
@@ -8,7 +8,10 @@ package javaslang;
 import javaslang.algebra.Foldable;
 import javaslang.algebra.Monad;
 import javaslang.collection.*;
-import javaslang.control.*;
+import javaslang.control.Either;
+import javaslang.control.Match;
+import javaslang.control.Option;
+import javaslang.control.Try;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
@@ -508,6 +511,12 @@ public interface Value<T> extends Foldable<T>, Monad<T>, ValueModule.Iterable<T>
     @Override
     default Vector<T> toVector() {
         return ValueModule.toTraversable(this, Vector.empty(), Vector::of, Vector::ofAll);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    default Match.MatchMonad.Of<T> match() {
+        return Match.of((T) this);
     }
 
     // -- Printable implementation

--- a/src/test/java/javaslang/collection/AbstractValueTest.java
+++ b/src/test/java/javaslang/collection/AbstractValueTest.java
@@ -10,6 +10,7 @@ import javaslang.Tuple;
 import javaslang.Value;
 import javaslang.control.*;
 import org.assertj.core.api.*;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -519,6 +520,13 @@ public abstract class AbstractValueTest {
         Either<String,Object> either2 = empty().toRight("fallback");
         assertThat(either2.isLeft()).isTrue();
         assertThat(either2.get()).isEqualTo("fallback");
+    }
+
+    @Test
+    @Ignore
+    public void shouldCreateMatchMonadFromValue() {
+        Value<Integer> value = of(1);
+        assertThat(value.match()).isEqualTo(Match.of(value));
     }
 
     // -- exists


### PR DESCRIPTION
Attempt to fix #968 

The only test is `@Ignore` right now, waiting for @danieldietrich to refactor `Match` provinding the `equals` method.

Feedbacks are welcome of course