### PR TITLE
Add search to Seq

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/LinearSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/LinearSeq.java
@@ -5,6 +5,7 @@
  */
 package javaslang.collection;
 
+import javaslang.Function1;
 import javaslang.Tuple;
 import javaslang.Tuple2;
 import javaslang.control.Match;
@@ -303,6 +304,45 @@ public interface LinearSeq<T> extends Seq<T> {
     @Override
     LinearSeq<Tuple2<T, Long>> zipWithIndex();
 
+    /**
+     * Searches this sequence for a specific element using a linear search. The sequence must already be sorted into
+     * ascending natural order. If it is not sorted, the results are undefined.
+     *
+     * @param element the element to find
+     * @return the index of the search element, if it is contained in the sequence;
+     *         otherwise, <tt>(-(<i>insertion point</i>) - 1)</tt>. The
+     *         <i>insertion point</i> is defined as the point at which the
+     *         element would be inserted into the sequence. Note that this guarantees that
+     *         the return value will be &gt;= 0 if and only if the element is found.
+     * @throws ClassCastException if T cannot be cast to `Comparable<T>`
+     */
+    @SuppressWarnings("unchecked")
+    default int search(T element) {
+        Function1<T, Integer> comparison =  current -> {
+            Comparable<T> comparable = (Comparable<T>) element;
+            return comparable.compareTo(current);
+        };
+        return LinearSeqModule.Search.linearSearch(this, comparison);
+    }
+
+    /**
+     * Searches this sequence for a specific element using a linear search. The sequence must already be sorted into
+     * ascending order according to the specified comparator. If it is not sorted, the results are undefined.
+     *
+     * @param element the element to find
+     * @param comparator the comparator by which this sequence is ordered
+     * @return the index of the search element, if it is contained in the sequence;
+     *         otherwise, <tt>(-(<i>insertion point</i>) - 1)</tt>. The
+     *         <i>insertion point</i> is defined as the point at which the
+     *         element would be inserted into the sequence. Note that this guarantees that
+     *         the return value will be &gt;= 0 if and only if the element is found.
+     */
+    default int search(T element, Comparator<? super T> comparator) {
+        Objects.requireNonNull(comparator, "comparator is null");
+        Function1<T, Integer> comparison = current -> comparator.compare(element, current);
+        return LinearSeqModule.Search.linearSearch(this, comparison);
+    }
+
 }
 
 interface LinearSeqModule {
@@ -346,6 +386,21 @@ interface LinearSeqModule {
                 t = t.tail();
             }
             return null;
+        }
+    }
+    interface Search {
+        static <T> int linearSearch(LinearSeq<T> seq, Function1<T, Integer> comparison) {
+            int idx = 0;
+            for (T current : seq) {
+                int cmp = comparison.apply(current);
+                if (cmp == 0) {
+                    return idx;
+                } else if (cmp < 0) {
+                    return -(idx + 1);
+                }
+                idx += 1;
+            }
+            return -(idx + 1);
         }
     }
 

--- a/javaslang/src/main/java/javaslang/collection/Seq.java
+++ b/javaslang/src/main/java/javaslang/collection/Seq.java
@@ -813,6 +813,38 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T> {
      */
     Seq<T> update(int index, T element);
 
+    /**
+     * Searches this sequence for a specific element. The sequence must already be sorted into ascending natural
+     * order. If it is not sorted, the results are undefined.
+     * <p>
+     * If this sequence is an `IndexedSeq`, a binary search is used. Otherwise, a linear search is used.
+     *
+     * @param element the element to find
+     * @return the index of the search element, if it is contained in the sequence;
+     *         otherwise, <tt>(-(<i>insertion point</i>) - 1)</tt>. The
+     *         <i>insertion point</i> is defined as the point at which the
+     *         element would be inserted into the sequence. Note that this guarantees that
+     *         the return value will be &gt;= 0 if and only if the element is found.
+     * @throws ClassCastException if T cannot be cast to `Comparable<T>`
+     */
+    int search(T element);
+
+    /**
+     * Searches this sequence for a specific element. The sequence must already be sorted into ascending order
+     * according to the specified comparator. If it is not sorted, the results are undefined.
+     * <p>
+     * If this sequence is an `IndexedSeq`, a binary search is used. Otherwise, a linear search is used.
+     *
+     * @param element the element to find
+     * @param comparator the comparator by which this sequence is ordered
+     * @return the index of the search element, if it is contained in the sequence;
+     *         otherwise, <tt>(-(<i>insertion point</i>) - 1)</tt>. The
+     *         <i>insertion point</i> is defined as the point at which the
+     *         element would be inserted into the sequence. Note that this guarantees that
+     *         the return value will be &gt;= 0 if and only if the element is found.
+     */
+    int search(T element, Comparator<? super T> comparator);
+
     // -- Adjusted return types of Traversable methods
 
     @Override

--- a/javaslang/src/test/java/javaslang/collection/AbstractIndexedSeqTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractIndexedSeqTest.java
@@ -14,10 +14,6 @@ public abstract class AbstractIndexedSeqTest extends AbstractSeqTest {
     @Override
     abstract protected <T> IndexedSeq<T> of(T element);
 
-    @SuppressWarnings("unchecked")
-    @Override
-    abstract protected <T> IndexedSeq<T> of(T... elements);
-
     // -- static narrow
 
     @Test
@@ -27,27 +23,4 @@ public abstract class AbstractIndexedSeqTest extends AbstractSeqTest {
         final int actual = numbers.append(new BigDecimal("2.0")).sum().intValue();
         assertThat(actual).isEqualTo(3);
     }
-
-    // -- search
-
-    @Test
-    public void shouldSearchIndexForPresentElements() {
-        assertThat(of(1, 2, 3, 4, 5, 6).search(3)).isEqualTo(2);
-    }
-
-    @Test
-    public void shouldSearchNegatedInsertionPointMinusOneForAbsentElements() {
-        assertThat(of(10, 20, 30).search(25)).isEqualTo(-3);
-    }
-
-    @Test
-    public void shouldSearchIndexForPresentElementsUsingComparator() {
-        assertThat(of(1, 2, 3, 4, 5, 6).search(3, Integer::compareTo)).isEqualTo(2);
-    }
-
-    @Test
-    public void shouldSearchNegatedInsertionPointMinusOneForAbsentElementsUsingComparator() {
-        assertThat(of(10, 20, 30).search(25, Integer::compareTo)).isEqualTo(-3);
-    }
-
 }

--- a/javaslang/src/test/java/javaslang/collection/AbstractIndexedSeqTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractIndexedSeqTest.java
@@ -14,6 +14,10 @@ public abstract class AbstractIndexedSeqTest extends AbstractSeqTest {
     @Override
     abstract protected <T> IndexedSeq<T> of(T element);
 
+    @SuppressWarnings("unchecked")
+    @Override
+    abstract protected <T> IndexedSeq<T> of(T... elements);
+
     // -- static narrow
 
     @Test
@@ -23,4 +27,27 @@ public abstract class AbstractIndexedSeqTest extends AbstractSeqTest {
         final int actual = numbers.append(new BigDecimal("2.0")).sum().intValue();
         assertThat(actual).isEqualTo(3);
     }
+
+    // -- search
+
+    @Test
+    public void shouldSearchIndexForPresentElements() {
+        assertThat(of(1, 2, 3, 4, 5, 6).search(3)).isEqualTo(2);
+    }
+
+    @Test
+    public void shouldSearchNegatedInsertionPointMinusOneForAbsentElements() {
+        assertThat(of(10, 20, 30).search(25)).isEqualTo(-3);
+    }
+
+    @Test
+    public void shouldSearchIndexForPresentElementsUsingComparator() {
+        assertThat(of(1, 2, 3, 4, 5, 6).search(3, Integer::compareTo)).isEqualTo(2);
+    }
+
+    @Test
+    public void shouldSearchNegatedInsertionPointMinusOneForAbsentElementsUsingComparator() {
+        assertThat(of(10, 20, 30).search(25, Integer::compareTo)).isEqualTo(-3);
+    }
+
 }

--- a/javaslang/src/test/java/javaslang/collection/AbstractSeqTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractSeqTest.java
@@ -1477,6 +1477,32 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
         of(1, 2, 3).subSequence(2, 1).mkString(); // force computation of last element, e.g. because Stream is lazy
     }
 
+    // -- search(element)
+
+    @Test
+    public void shouldSearchIndexForPresentElements() {
+        assertThat(of(1, 2, 3, 4, 5, 6).search(3)).isEqualTo(2);
+    }
+
+    @Test
+    public void shouldSearchNegatedInsertionPointMinusOneForAbsentElements() {
+        assertThat(empty().search(42)).isEqualTo(-1);
+        assertThat(of(10, 20, 30).search(25)).isEqualTo(-3);
+    }
+
+    // -- search(element,comparator)
+
+    @Test
+    public void shouldSearchIndexForPresentElementsUsingComparator() {
+        assertThat(of(1, 2, 3, 4, 5, 6).search(3, Integer::compareTo)).isEqualTo(2);
+    }
+
+    @Test
+    public void shouldSearchNegatedInsertionPointMinusOneForAbsentElementsUsingComparator() {
+        assertThat(this.<Integer> empty().search(42, Integer::compareTo)).isEqualTo(-1);
+        assertThat(of(10, 20, 30).search(25, Integer::compareTo)).isEqualTo(-3);
+    }
+
     // -- IndexedSeq special cases
 
     @Test


### PR DESCRIPTION
The **binary search** implementation in `IndexedSeq` is roughly ported from `java.util.Collections.binarySearch` (1.8.0_66). It deviates in the following points:
* Naming (seq vs. list, element vs. key)
* Code duplication avoided by abstracting over element comparison
* Fail fast upon `null` comparator

The **linear search** implementation in `LinearSeq` is roughly ported from `scala.collection.Searching.SearchImpl.linearSearch` (2.11.7). It uses an abstracted `comparison` in place of Scala's implicit `Ordering`.