### PR TITLE
crossProduct refactored #1101

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/Array.java
+++ b/javaslang/src/main/java/javaslang/collection/Array.java
@@ -519,20 +519,8 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
     }
 
     @Override
-    public Array<Tuple2<T, T>> crossProduct() {
-        return crossProduct(this);
-    }
-
-    @Override
-    public Array<Array<T>> crossProduct(int power) {
-        return Collections.crossProduct(this, power).map(Array::ofAll).toArray();
-    }
-
-    @Override
-    public <U> Array<Tuple2<T, U>> crossProduct(Iterable<? extends U> that) {
-        Objects.requireNonNull(that, "that is null");
-        final Array<U> other = unit(that);
-        return flatMap(a -> other.map((Function<U, Tuple2<T, U>>) b -> Tuple.of(a, b)));
+    public Iterator<Array<T>> crossProduct(int power) {
+        return Collections.crossProduct(Array.empty(), this, power);
     }
 
     @SuppressWarnings("unchecked")

--- a/javaslang/src/main/java/javaslang/collection/CharSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/CharSeq.java
@@ -298,20 +298,8 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
     }
 
     @Override
-    public IndexedSeq<Tuple2<Character, Character>> crossProduct() {
-        return crossProduct(this);
-    }
-
-    @Override
-    public IndexedSeq<CharSeq> crossProduct(int power) {
-        return Collections.crossProduct(this, power).map(CharSeq::ofAll).toVector();
-    }
-
-    @Override
-    public <U> IndexedSeq<Tuple2<Character, U>> crossProduct(Iterable<? extends U> that) {
-        Objects.requireNonNull(that, "that is null");
-        final IndexedSeq<U> other = Vector.ofAll(that);
-        return flatMap(a -> other.map(b -> Tuple.of(a, b)));
+    public Iterator<CharSeq> crossProduct(int power) {
+        return Collections.crossProduct(CharSeq.empty(), this, power);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/Collections.java
+++ b/javaslang/src/main/java/javaslang/collection/Collections.java
@@ -71,13 +71,13 @@ final class Collections {
     }
 
     @SuppressWarnings("unchecked")
-    static <T> Iterator<Seq<T>> crossProduct(Seq<? extends T> seq, int power) {
+    static <T, S extends Seq<T>> Iterator<S> crossProduct(S empty, S seq, int power) {
         if (power < 0) {
             throw new IllegalArgumentException("negative power");
         }
         return Iterator
-                .range(1, power)
-                .foldLeft((Iterator<Seq<T>>) seq.sliding(1), (product, ignored) -> product.flatMap(tuple -> seq.map(tuple::append)));
+                .range(0, power)
+                .foldLeft(Iterator.of(empty), (product, ignored) -> product.flatMap(el -> seq.map(t -> (S) el.append(t))));
     }
 
     static <C extends Traversable<T>, T> C tabulate(int n, Function<? super Integer, ? extends T> f, C empty, Function<T[], C> of) {

--- a/javaslang/src/main/java/javaslang/collection/IndexedSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/IndexedSeq.java
@@ -60,13 +60,7 @@ public interface IndexedSeq<T> extends Seq<T> {
     IndexedSeq<? extends IndexedSeq<T>> combinations(int k);
 
     @Override
-    IndexedSeq<Tuple2<T, T>> crossProduct();
-
-    @Override
-    IndexedSeq<? extends IndexedSeq<T>> crossProduct(int power);
-
-    @Override
-    <U> IndexedSeq<Tuple2<T, U>> crossProduct(Iterable<? extends U> that);
+    Iterator<? extends IndexedSeq<T>> crossProduct(int power);
 
     @Override
     IndexedSeq<T> distinct();

--- a/javaslang/src/main/java/javaslang/collection/LinearSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/LinearSeq.java
@@ -59,13 +59,7 @@ public interface LinearSeq<T> extends Seq<T> {
     LinearSeq<? extends LinearSeq<T>> combinations(int k);
 
     @Override
-    LinearSeq<Tuple2<T, T>> crossProduct();
-
-    @Override
-    LinearSeq<? extends LinearSeq<T>> crossProduct(int power);
-
-    @Override
-    <U> LinearSeq<Tuple2<T, U>> crossProduct(Iterable<? extends U> that);
+    Iterator<? extends LinearSeq<T>> crossProduct(int power);
 
     @Override
     LinearSeq<T> distinct();

--- a/javaslang/src/main/java/javaslang/collection/List.java
+++ b/javaslang/src/main/java/javaslang/collection/List.java
@@ -557,20 +557,8 @@ public interface List<T> extends Kind1<List<?>, T>, LinearSeq<T>, Stack<T> {
     }
 
     @Override
-    default List<Tuple2<T, T>> crossProduct() {
-        return crossProduct(this);
-    }
-
-    @Override
-    default List<List<T>> crossProduct(int power) {
-        return Collections.crossProduct(this, power).map(List::ofAll).toList();
-    }
-
-    @Override
-    default <U> List<Tuple2<T, U>> crossProduct(Iterable<? extends U> that) {
-        Objects.requireNonNull(that, "that is null");
-        final List<U> other = unit(that);
-        return flatMap(a -> other.map((Function<U, Tuple2<T, U>>) b -> Tuple.of(a, b)));
+    default Iterator<List<T>> crossProduct(int power) {
+        return Collections.crossProduct(List.empty(), this, power);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/Queue.java
+++ b/javaslang/src/main/java/javaslang/collection/Queue.java
@@ -612,19 +612,8 @@ public class Queue<T> implements LinearSeq<T>, Serializable {
     }
 
     @Override
-    public Queue<Tuple2<T, T>> crossProduct() {
-        return crossProduct(this);
-    }
-
-    @Override
-    public Queue<Queue<T>> crossProduct(int power) {
-        return Collections.crossProduct(this, power).map(Queue::ofAll).toQueue();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <U> Queue<Tuple2<T, U>> crossProduct(Iterable<? extends U> that) {
-        return toList().crossProduct((Iterable<U>) that).toQueue();
+    public Iterator<Queue<T>> crossProduct(int power) {
+        return Collections.crossProduct(Queue.empty(), this, power);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/Seq.java
+++ b/javaslang/src/main/java/javaslang/collection/Seq.java
@@ -198,9 +198,11 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T> {
      * </code>
      * </pre>
      *
-     * @return a new Seq containing the square of {@code this}
+     * @return a new Iterator containing the square of {@code this}
      */
-    Seq<Tuple2<T, T>> crossProduct();
+    default Iterator<Tuple2<T, T>> crossProduct() {
+        return crossProduct(this);
+    }
 
     /**
      * Calculates the n-ary cartesian power (or <em>cross product</em> or simply <em>product</em>) of this.
@@ -214,9 +216,9 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T> {
      * </pre>
      *
      * @param power the number of cartesian multiplications
-     * @return A new Seq representing the n-ary cartesian power of this
+     * @return A new Iterator representing the n-ary cartesian power of this
      */
-    Seq<? extends Seq<T>> crossProduct(int power);
+    Iterator<? extends Seq<T>> crossProduct(int power);
 
     /**
      * Calculates the cross product {@code this x that}.
@@ -231,10 +233,14 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T> {
      *
      * @param that Another iterable
      * @param <U>  Component type
-     * @return a new Seq containing the cross product {@code this x that}
+     * @return a new Iterator containing the cross product {@code this x that}
      * @throws NullPointerException if that is null
      */
-    <U> Seq<Tuple2<T, U>> crossProduct(Iterable<? extends U> that);
+    default <U> Iterator<Tuple2<T, U>> crossProduct(Iterable<? extends U> that) {
+        Objects.requireNonNull(that, "that is null");
+        final Stream<U> other = Stream.ofAll(that);
+        return Iterator.ofAll(this).flatMap(a -> other.map((Function<U, Tuple2<T, U>>) b -> Tuple.of(a, b)));
+    }
 
     /**
      * Tests whether this sequence ends with the given sequence.

--- a/javaslang/src/main/java/javaslang/collection/Stack.java
+++ b/javaslang/src/main/java/javaslang/collection/Stack.java
@@ -546,13 +546,7 @@ public interface Stack<T> extends LinearSeq<T> {
     Stack<? extends Stack<T>> combinations(int k);
 
     @Override
-    Stack<Tuple2<T, T>> crossProduct();
-
-    @Override
-    Stack<? extends Stack<T>> crossProduct(int power);
-
-    @Override
-    <U> Stack<Tuple2<T, U>> crossProduct(Iterable<? extends U> that);
+    Iterator<? extends Stack<T>> crossProduct(int power);
 
     @Override
     Stack<T> distinct();

--- a/javaslang/src/main/java/javaslang/collection/Stream.java
+++ b/javaslang/src/main/java/javaslang/collection/Stream.java
@@ -653,20 +653,8 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<Tuple2<T, T>> crossProduct() {
-        return crossProduct(this);
-    }
-
-    @Override
-    default Stream<Stream<T>> crossProduct(int power) {
-        return Collections.crossProduct(this, power).map(Stream::ofAll).toStream();
-    }
-
-    @Override
-    default <U> Stream<Tuple2<T, U>> crossProduct(Iterable<? extends U> that) {
-        Objects.requireNonNull(that, "that is null");
-        final Stream<U> other = Stream.ofAll(that);
-        return flatMap(a -> other.map((Function<U, Tuple2<T, U>>) b -> Tuple.of(a, b)));
+    default Iterator<Stream<T>> crossProduct(int power) {
+        return Collections.crossProduct(Stream.empty(), this, power);
     }
 
     /**

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -494,20 +494,8 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
     }
 
     @Override
-    public Vector<Tuple2<T, T>> crossProduct() {
-        return crossProduct(this);
-    }
-
-    @Override
-    public Vector<Vector<T>> crossProduct(int power) {
-        return Collections.crossProduct(this, power).map(Vector::ofAll).toVector();
-    }
-
-    @Override
-    public <U> Vector<Tuple2<T, U>> crossProduct(Iterable<? extends U> that) {
-        Objects.requireNonNull(that, "that is null");
-        final Vector<U> other = Vector.ofAll(that);
-        return flatMap(a -> other.map((Function<U, Tuple2<T, U>>) b -> Tuple.of(a, b)));
+    public Iterator<Vector<T>> crossProduct(int power) {
+        return Collections.crossProduct(Vector.empty(), this, power);
     }
 
     @Override

--- a/javaslang/src/test/java/javaslang/collection/AbstractSeqTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractSeqTest.java
@@ -238,54 +238,59 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldCalculateCrossProductOfNil() {
-        final Traversable<Tuple2<Object, Object>> actual = empty().crossProduct();
+        final Iterator<Tuple2<Object, Object>> actual = empty().crossProduct();
         assertThat(actual).isEmpty();
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void shouldCalculateCrossProductOfNonNil() {
-        final Traversable<Tuple2<Integer, Integer>> actual = of(1, 2, 3).crossProduct();
-        final Traversable<Tuple2<Integer, Integer>> expected = of(Tuple.of(1, 1), Tuple.of(1, 2), Tuple.of(1, 3),
+        final List<Tuple2<Integer, Integer>> actual = of(1, 2, 3).crossProduct().toList();
+        final List<Tuple2<Integer, Integer>> expected = List.of(Tuple.of(1, 1), Tuple.of(1, 2), Tuple.of(1, 3),
                 Tuple.of(2, 1), Tuple.of(2, 2), Tuple.of(2, 3), Tuple.of(3, 1), Tuple.of(3, 2), Tuple.of(3, 3));
         assertThat(actual).isEqualTo(expected);
     }
 
     // -- crossProduct(int)
 
-    @SuppressWarnings("varargs")
     @Test
     public void shouldCalculateCrossProductPower() {
-        Seq<Seq<?>> expected = of(of(1, 1), of(1, 2), of(2, 1), of(2, 2));
-        assertThat(of(1, 2).crossProduct(2)).isEqualTo(expected);
+        assertThat(of(1, 2).crossProduct(0).toList()).isEqualTo(List.of(empty()));
+        assertThat(of(1, 2).crossProduct(1).toList()).isEqualTo(List.of(of(1), of(2)));
+        assertThat(of(1, 2).crossProduct(2).toList()).isEqualTo(List.of(of(1, 1), of(1, 2), of(2, 1), of(2, 2)));
+    }
+
+    @Test
+    public void shouldCrossProductPowerBeLazy() {
+        assertThat(range(0, 10).crossProduct(100).take(1).get()).isEqualTo(tabulate(100, i -> 0));
     }
 
     // -- crossProduct(Iterable)
 
     @Test
     public void shouldCalculateCrossProductOfNilAndNil() {
-        final Traversable<Tuple2<Object, Object>> actual = empty().crossProduct(empty());
+        final Iterator<Tuple2<Object, Object>> actual = empty().crossProduct(empty());
         assertThat(actual).isEmpty();
     }
 
     @Test
     public void shouldCalculateCrossProductOfNilAndNonNil() {
-        final Traversable<Tuple2<Object, Object>> actual = empty().crossProduct(of(1, 2, 3));
+        final Iterator<Tuple2<Object, Object>> actual = empty().crossProduct(of(1, 2, 3));
         assertThat(actual).isEmpty();
     }
 
     @Test
     public void shouldCalculateCrossProductOfNonNilAndNil() {
-        final Traversable<Tuple2<Integer, Integer>> actual = of(1, 2, 3).crossProduct(empty());
+        final Iterator<Tuple2<Integer, Integer>> actual = of(1, 2, 3).crossProduct(empty());
         assertThat(actual).isEmpty();
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void shouldCalculateCrossProductOfNonNilAndNonNil() {
-        final Traversable<Tuple2<Integer, Character>> actual = of(1, 2, 3).crossProduct(of('a', 'b'));
-        final Traversable<Tuple2<Integer, Character>> expected = of(Tuple.of(1, 'a'), Tuple.of(1, 'b'),
-                Tuple.of(2, 'a'), Tuple.of(2, 'b'), Tuple.of(3, 'a'), Tuple.of(3, 'b'));
+        final List<Tuple2<Integer, Character>> actual = of(1, 2, 3).crossProduct(of('a', 'b')).toList();
+        final List<Tuple2<Integer, Character>> expected = of(Tuple.of(1, 'a'), Tuple.of(1, 'b'),
+                Tuple.of(2, 'a'), Tuple.of(2, 'b'), Tuple.of(3, 'a'), Tuple.of(3, 'b')).toList();
         assertThat(actual).isEqualTo(expected);
     }
 

--- a/javaslang/src/test/java/javaslang/collection/CharSeqTest.java
+++ b/javaslang/src/test/java/javaslang/collection/CharSeqTest.java
@@ -1828,16 +1828,16 @@ public class CharSeqTest {
 
     @Test
     public void shouldCalculateCrossProductOfNil() {
-        final IndexedSeq<Tuple2<Character, Character>> actual = empty().crossProduct();
-        assertThat(actual).isEqualTo(Vector.empty());
+        final Iterator<Tuple2<Character, Character>> actual = empty().crossProduct();
+        assertThat(actual).isEmpty();
     }
 
     @Test
     public void shouldCalculateCrossProductOfNonNil() {
-        final IndexedSeq<Tuple2<Character, Character>> actual = CharSeq.of('1', '2', '3').crossProduct();
-        final Vector<Tuple2<Character, Character>> expected = Vector.of(Tuple.of('1', '1'), Tuple.of('1', '2'),
+        final List<Tuple2<Character, Character>> actual = CharSeq.of('1', '2', '3').crossProduct().toList();
+        final List<Tuple2<Character, Character>> expected = Iterator.of(Tuple.of('1', '1'), Tuple.of('1', '2'),
                 Tuple.of('1', '3'), Tuple.of('2', '1'), Tuple.of('2', '2'), Tuple.of('2', '3'), Tuple.of('3', '1'),
-                Tuple.of('3', '2'), Tuple.of('3', '3'));
+                Tuple.of('3', '2'), Tuple.of('3', '3')).toList();
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -1845,8 +1845,8 @@ public class CharSeqTest {
 
     @Test
     public void shouldCalculateCrossProductPower() {
-        final IndexedSeq<CharSeq> actual = CharSeq.of("12").crossProduct(2);
-        final Vector<CharSeq> expected = Vector.of(CharSeq.of('1', '1'), CharSeq.of('1', '2'), CharSeq.of('2', '1'), CharSeq.of('2', '2'));
+        final List<CharSeq> actual = CharSeq.of("12").crossProduct(2).toList();
+        final List<CharSeq> expected = Iterator.of(CharSeq.of('1', '1'), CharSeq.of('1', '2'), CharSeq.of('2', '1'), CharSeq.of('2', '2')).toList();
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -1855,13 +1855,13 @@ public class CharSeqTest {
     @Test
     public void shouldCalculateCrossProductOfNilAndNil() {
         final Traversable<Tuple2<Character, Object>> actual = empty().crossProduct(empty());
-        assertThat(actual).isEqualTo(Vector.empty());
+        assertThat(actual).isEmpty();
     }
 
     @Test
     public void shouldCalculateCrossProductOfNilAndNonNil() {
         final Traversable<Tuple2<Character, Object>> actual = empty().crossProduct(CharSeq.of('1', '2', '3'));
-        assertThat(actual).isEqualTo(Vector.empty());
+        assertThat(actual).isEmpty();
     }
 
     @Test
@@ -1869,16 +1869,17 @@ public class CharSeqTest {
         final Traversable<Tuple2<Character, Character>> actual = CharSeq
                 .of('1', '2', '3')
                 .crossProduct(CharSeq.empty());
-        assertThat(actual).isEqualTo(Vector.empty());
+        assertThat(actual).isEmpty();
     }
 
     @Test
     public void shouldCalculateCrossProductOfNonNilAndNonNil() {
-        final IndexedSeq<Tuple2<Character, Character>> actual = CharSeq
+        final List<Tuple2<Character, Character>> actual = CharSeq
                 .of('1', '2', '3')
-                .crossProduct(CharSeq.of('a', 'b'));
-        final IndexedSeq<Tuple2<Character, Character>> expected = Vector.of(Tuple.of('1', 'a'), Tuple.of('1', 'b'),
-                Tuple.of('2', 'a'), Tuple.of('2', 'b'), Tuple.of('3', 'a'), Tuple.of('3', 'b'));
+                .crossProduct(CharSeq.of('a', 'b'))
+                .toList();
+        final List<Tuple2<Character, Character>> expected = Vector.of(Tuple.of('1', 'a'), Tuple.of('1', 'b'),
+                Tuple.of('2', 'a'), Tuple.of('2', 'b'), Tuple.of('3', 'a'), Tuple.of('3', 'b')).toList();
         assertThat(actual).isEqualTo(expected);
     }
 


### PR DESCRIPTION
I changed the signatures of <code>Seq.crossProduct*()</code> respectively to <code>Seq.grouped()</code> and <code>Seq.sliding()</code>. Also it is possible to make <code>crossProduct(power)</code> of lazy (see [this](https://github.com/ruslansennov/javaslang/commit/80559d675a26d085ec452a6ca62112c91f5b87c9#diff-9ad4622e0a619ccef500bfb685736b7bR265))