### PR TITLE
Skip evaluation of N+1 when taking N elements of a Stream

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/Stream.java
+++ b/javaslang/src/main/java/javaslang/collection/Stream.java
@@ -1218,6 +1218,8 @@ public interface Stream<T> extends LinearSeq<T> {
     default Stream<T> take(long n) {
         if (n < 1 || isEmpty()) {
             return Empty.instance();
+        } else if (n == 1) {
+            return cons(head(), Stream::empty);
         } else {
             return cons(head(), () -> tail().take(n - 1));
         }

--- a/javaslang/src/test/java/javaslang/collection/StreamTest.java
+++ b/javaslang/src/test/java/javaslang/collection/StreamTest.java
@@ -470,6 +470,19 @@ public class StreamTest extends AbstractLinearSeqTest {
         assertThat(actual.toString()).isEqualTo(expected.toString());
     }
 
+    @Test
+    public void shouldNotEvaluateNplusOneWhenTakeN() {
+        assertThat(Stream.from(0).filter(this::hiddenThrow).take(1).sum().intValue()).isEqualTo(0);
+
+    }
+
+    private boolean hiddenThrow(final int i) {
+        if (i == 0) {
+            return true;
+        }
+        throw new IllegalArgumentException();
+    }
+
     private Try<Void> flatTryWithJavaslangStream(Integer[] vals, Try.CheckedConsumer<Integer> func) {
         return Stream.of(vals)
                 .map(v -> Try.run(() -> func.accept(v)))


### PR DESCRIPTION
Hello,

I've made a little change in the take method of Stream to skip the evaluation of tail() if the current element is the last one (a.k.a. N == 1).

Evaluation of tail() can cause performance issue if the Stream is complicated to generate. 

It also can cause infinite recursion in some case. For example when you filter a stream and take all of the N elements corresponding to that filter then take(N) will try to find a N+1 element which doesn't exist (https://projecteuler.net/problem=37 is a good example as there only 11 Truncatable primes and take(11) try to find a 12th truncable prime)

Disclaimer: I can't get javaslang to compile on my computer so I've test the modification on a side project.

Jean-Marc