### PR TITLE
Lazy.filter() should not access Lazy.value member directly

### DIFF
--- a/javaslang/src/main/java/javaslang/Lazy.java
+++ b/javaslang/src/main/java/javaslang/Lazy.java
@@ -128,7 +128,8 @@ public final class Lazy<T> implements Value<T>, Supplier<T>, Serializable {
     }
 
     public Option<T> filter(Predicate<? super T> predicate) {
-        return predicate.test(value) ? Option.some(value) : Option.none();
+        T v = get();
+        return predicate.test(v) ? Option.some(v) : Option.none();
     }
 
     /**


### PR DESCRIPTION
The current implementation is wrong in case the `Lazy` value has not yet been evaluated.