### PR TITLE
suggestion for static sorted method on Seq

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/Seq.java
+++ b/javaslang/src/main/java/javaslang/collection/Seq.java
@@ -109,6 +109,11 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T> {
         return (Seq<T>) seq;
     }
 
+    @SuppressWarnings("unchecked")
+    static <T extends Comparable<? super T>, S extends Seq<T>> S sorted2(S seq) {
+        return (S) seq.sorted(Comparator.naturalOrder());
+    }
+
     /**
      * A {@code Seq} is a partial function which returns the element at the specified index by calling
      * {@linkplain #get(int)}.


### PR DESCRIPTION
What do you think of replacing Seq#sorted() with a static method like this? Reasoning is that it's not a good idea to have a runtime ClassCastException if the elements of the Seq are not comparable, since we can't do implicit type constraints like in Scala. This one method would work for all subclasses of Seq as long as their sorted(Comparator) method returns the same instance as they are.

If you think it's good I'll remove the other one, rename this one properly and transform the test cases. Are there other methods that would benefit from a similar treatment (that throw ClassCastException)?