### PR TITLE
Remove redundant imports and casts

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/AbstractMap.java
+++ b/javaslang/src/main/java/javaslang/collection/AbstractMap.java
@@ -5,7 +5,6 @@
  */
 package javaslang.collection;
 
-import javaslang.API;
 import javaslang.Tuple;
 import javaslang.Tuple2;
 import javaslang.control.Option;

--- a/javaslang/src/main/java/javaslang/collection/List.java
+++ b/javaslang/src/main/java/javaslang/collection/List.java
@@ -1004,7 +1004,7 @@ public interface List<T> extends Kind1<List<?>, T>, LinearSeq<T>, Stack<T> {
     @Override
     default List<T> removeAll(Iterable<? extends T> elements) {
         Objects.requireNonNull(elements, "elements is null");
-        final List<T> removed = List.<T> ofAll(elements).distinct();
+        final List<T> removed = List.ofAll(elements).distinct();
         List<T> result = Nil.instance();
         boolean found = false;
         for (T element : this) {
@@ -1055,7 +1055,7 @@ public interface List<T> extends Kind1<List<?>, T>, LinearSeq<T>, Stack<T> {
     @Override
     default List<T> retainAll(Iterable<? extends T> elements) {
         Objects.requireNonNull(elements, "elements is null");
-        final List<T> kept = List.<T> ofAll(elements).distinct();
+        final List<T> kept = List.ofAll(elements).distinct();
         List<T> result = Nil.instance();
         for (T element : this) {
             if (kept.contains(element)) {

--- a/javaslang/src/main/java/javaslang/collection/SortedMap.java
+++ b/javaslang/src/main/java/javaslang/collection/SortedMap.java
@@ -5,7 +5,6 @@
  */
 package javaslang.collection;
 
-import javaslang.API;
 import javaslang.Tuple2;
 import javaslang.control.Option;
 

--- a/javaslang/src/main/java/javaslang/collection/Stream.java
+++ b/javaslang/src/main/java/javaslang/collection/Stream.java
@@ -911,14 +911,13 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     default Stream<T> insertAll(int index, Iterable<? extends T> elements) {
         Objects.requireNonNull(elements, "elements is null");
         if (index < 0) {
             throw new IndexOutOfBoundsException("insertAll(" + index + ", elements)");
         } else if (index == 0) {
-            return isEmpty() ? Stream.ofAll(elements) : Stream.ofAll((Iterable<T>) elements).appendAll(this);
+            return isEmpty() ? Stream.ofAll(elements) : Stream.ofAll(elements).appendAll(this);
         } else if (isEmpty()) {
             throw new IndexOutOfBoundsException("insertAll(" + index + ", elements) on Nil");
         } else {
@@ -1031,11 +1030,10 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
         return cons(element, () -> this);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     default Stream<T> prependAll(Iterable<? extends T> elements) {
         Objects.requireNonNull(elements, "elements is null");
-        return Stream.ofAll((Iterable<T>) elements).appendAll(this);
+        return Stream.ofAll(elements).appendAll(this);
     }
 
     @Override
@@ -1082,11 +1080,11 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
         return filter(e -> !Objects.equals(e, removed));
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     default Stream<T> removeAll(Iterable<? extends T> elements) {
         Objects.requireNonNull(elements, "elements is null");
-        final Stream<T> distinct = Stream.ofAll((Iterable<T>) elements).distinct();
+
+        final Stream<T> distinct = Stream.ofAll(elements).distinct();
         return filter(e -> !distinct.contains(e));
     }
 
@@ -1115,14 +1113,14 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     default Stream<T> retainAll(Iterable<? extends T> elements) {
         Objects.requireNonNull(elements, "elements is null");
+
         if (isEmpty()) {
             return this;
         } else {
-            final Stream<T> retained = Stream.ofAll((Iterable<T>) elements).distinct();
+            final Stream<T> retained = Stream.ofAll(elements).distinct();
             return filter(retained::contains);
         }
     }

--- a/javaslang/src/main/java/javaslang/concurrent/Future.java
+++ b/javaslang/src/main/java/javaslang/concurrent/Future.java
@@ -5,7 +5,6 @@
  */
 package javaslang.concurrent;
 
-import javaslang.API;
 import javaslang.Tuple;
 import javaslang.Tuple2;
 import javaslang.Value;
@@ -271,7 +270,7 @@ public interface Future<T> extends Value<T> {
     static <T> Future<T> fromTry(ExecutorService executorService, Try<? extends T> result) {
         Objects.requireNonNull(executorService, "executorService is null");
         Objects.requireNonNull(result, "result is null");
-        return Promise.<T> fromTry(executorService, result).future();
+        return Promise.fromTry(executorService, result).future();
     }
 
     /**
@@ -353,7 +352,7 @@ public interface Future<T> extends Value<T> {
         if (!futures.iterator().hasNext()) {
             throw new NoSuchElementException("Future.reduce on empty futures");
         } else {
-            return Future.<T> sequence(futures).map(seq -> seq.reduceLeft(f));
+            return Future.sequence(futures).map(seq -> seq.reduceLeft(f));
         }
     }
 

--- a/javaslang/src/main/java/javaslang/control/Either.java
+++ b/javaslang/src/main/java/javaslang/control/Either.java
@@ -5,7 +5,6 @@
  */
 package javaslang.control;
 
-import javaslang.API;
 import javaslang.Value;
 import javaslang.collection.Iterator;
 

--- a/javaslang/src/main/java/javaslang/control/Option.java
+++ b/javaslang/src/main/java/javaslang/control/Option.java
@@ -5,7 +5,6 @@
  */
 package javaslang.control;
 
-import javaslang.API;
 import javaslang.Value;
 import javaslang.collection.Iterator;
 import javaslang.collection.List;

--- a/javaslang/src/main/java/javaslang/control/Try.java
+++ b/javaslang/src/main/java/javaslang/control/Try.java
@@ -5,7 +5,6 @@
  */
 package javaslang.control;
 
-import javaslang.API;
 import javaslang.Value;
 import javaslang.collection.Iterator;
 import javaslang.collection.List;


### PR DESCRIPTION
Stumbled upon one and ran code inspection. I am not sure though if those casts will not cause same problems as those commented as a must-have for Eclipse