### PR TITLE
Unified 'removeAll' and `retainAll` for `Traversable`s

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/Array.java
+++ b/javaslang/src/main/java/javaslang/collection/Array.java
@@ -11,7 +11,6 @@ import javaslang.control.Option;
 
 import java.io.Serializable;
 import java.util.*;
-import java.util.HashSet;
 import java.util.function.*;
 import java.util.stream.Collector;
 
@@ -593,7 +592,9 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
                 list.add(t);
             }
         }
-        if (list.size() == back.length) {
+        if (list.isEmpty()) {
+            return empty();
+        } else if (list.size() == size()) {
             return this;
         } else {
             return list.isEmpty() ? empty() : wrap(list.toArray());
@@ -899,38 +900,12 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
 
     @Override
     public Array<T> removeAll(T element) {
-        final java.util.List<T> list = new ArrayList<>();
-        for (int i = 0; i < length(); i++) {
-            T value = get(i);
-            if (!element.equals(value)) {
-                list.add(value);
-            }
-        }
-        if (list.size() == length()) {
-            return this;
-        } else {
-            return wrap(list.toArray());
-        }
+        return Collections.removeAll(this, element);
     }
 
     @Override
     public Array<T> removeAll(Iterable<? extends T> elements) {
-        final java.util.Set<T> removed = new HashSet<>();
-        for (T element : elements) {
-            removed.add(element);
-        }
-        final java.util.List<T> list = new ArrayList<>();
-        for (int i = 0; i < length(); i++) {
-            T value = get(i);
-            if (!removed.contains(value)) {
-                list.add(value);
-            }
-        }
-        if (list.size() == length()) {
-            return this;
-        } else {
-            return wrap(list.toArray());
-        }
+        return Collections.removeAll(this, elements);
     }
 
     @Override
@@ -971,23 +946,7 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
 
     @Override
     public Array<T> retainAll(Iterable<? extends T> elements) {
-        Objects.requireNonNull(elements, "elements is null");
-        final java.util.Set<T> kept = new HashSet<>();
-        for (T element : elements) {
-            kept.add(element);
-        }
-        final java.util.List<T> list = new ArrayList<>();
-        for (int i = 0; i < length(); i++) {
-            T value = get(i);
-            if (kept.contains(value)) {
-                list.add(value);
-            }
-        }
-        if (list.size() == length()) {
-            return this;
-        } else {
-            return wrap(list.toArray());
-        }
+        return Collections.retainAll(this, elements);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/CharSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/CharSeq.java
@@ -9,8 +9,7 @@ import javaslang.*;
 import javaslang.collection.CharSeqModule.Combinations;
 import javaslang.control.Option;
 
-import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 import java.nio.charset.Charset;
 import java.util.*;
 import java.util.function.*;
@@ -359,7 +358,13 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
                 sb.append(ch);
             }
         }
-        return sb.length() == 0 ? EMPTY : sb.length() == length() ? this : of(sb);
+        if (sb.length() == 0) {
+            return EMPTY;
+        } else if (sb.length() == length()) {
+            return this;
+        } else {
+            return of(sb);
+        }
     }
 
     @Override
@@ -650,28 +655,12 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
 
     @Override
     public CharSeq removeAll(Character element) {
-        final StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < length(); i++) {
-            final char c = get(i);
-            if (c != element) {
-                sb.append(c);
-            }
-        }
-        return sb.length() == 0 ? EMPTY : sb.length() == length() ? this : of(sb);
+        return Collections.removeAll(this, element);
     }
 
     @Override
     public CharSeq removeAll(Iterable<? extends Character> elements) {
-        Objects.requireNonNull(elements, "elements is null");
-        final Set<Character> distinct = HashSet.ofAll(elements);
-        final StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < length(); i++) {
-            final char c = get(i);
-            if (!distinct.contains(c)) {
-                sb.append(c);
-            }
-        }
-        return sb.length() == 0 ? EMPTY : sb.length() == length() ? this : of(sb);
+        return Collections.removeAll(this, elements);
     }
 
     @Override
@@ -708,16 +697,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
 
     @Override
     public CharSeq retainAll(Iterable<? extends Character> elements) {
-        Objects.requireNonNull(elements, "elements is null");
-        final Set<Character> kept = HashSet.ofAll(elements);
-        final StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < length(); i++) {
-            final char c = get(i);
-            if (kept.contains(c)) {
-                sb.append(c);
-            }
-        }
-        return sb.length() == 0 ? EMPTY : of(sb);
+        return Collections.retainAll(this, elements);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/Collections.java
+++ b/javaslang/src/main/java/javaslang/collection/Collections.java
@@ -6,9 +6,7 @@
 package javaslang.collection;
 
 import java.util.Objects;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Supplier;
+import java.util.function.*;
 
 /**
  * Internal class, containing helpers.
@@ -17,6 +15,25 @@ import java.util.function.Supplier;
  * @since 2.0.0
  */
 final class Collections {
+    @SuppressWarnings("unchecked")
+    static <C extends Traversable<T>, T> C removeAll(C collection, T element) {
+        Objects.requireNonNull(element, "element is null");
+        return removeAll(collection, List.of(element));
+    }
+
+    @SuppressWarnings("unchecked")
+    static <C extends Traversable<T>, T> C removeAll(C collection, Iterable<? extends T> elements) {
+        Objects.requireNonNull(elements, "elements is null");
+        final Set<T> removed = HashSet.ofAll(elements);
+        return (C) collection.filter(e -> !removed.contains(e));
+    }
+
+    @SuppressWarnings("unchecked")
+    static <C extends Traversable<T>, T> C retainAll(C collection, Iterable<? extends T> elements) {
+        Objects.requireNonNull(elements, "elements is null");
+        final Set<T> removed = HashSet.ofAll(elements);
+        return (C) collection.filter(removed::contains);
+    }
 
     // checks, if the *elements* of the given iterables are equal
     static boolean equals(Iterable<?> iterable1, Iterable<?> iterable2) {

--- a/javaslang/src/main/java/javaslang/collection/HashMap.java
+++ b/javaslang/src/main/java/javaslang/collection/HashMap.java
@@ -5,15 +5,11 @@
  */
 package javaslang.collection;
 
-import javaslang.Kind2;
-import javaslang.Tuple;
-import javaslang.Tuple2;
+import javaslang.*;
 import javaslang.control.Option;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.NoSuchElementException;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;
 
@@ -225,7 +221,7 @@ public final class HashMap<K, V> extends AbstractMap<K, V, HashMap<K, V>> implem
             for (Tuple2<? extends K, ? extends V> entry : entries) {
                 trie = trie.put(entry._1, entry._2);
             }
-            return wrap(trie);
+            return trie.isEmpty() ? empty() : wrap(trie);
         }
     }
 
@@ -331,7 +327,14 @@ public final class HashMap<K, V> extends AbstractMap<K, V, HashMap<K, V>> implem
         for (K key : keys) {
             result = result.remove(key);
         }
-        return result.size() == trie.size() ? this : wrap(result);
+
+        if (result.isEmpty()) {
+            return empty();
+        } else if (result.size() == trie.size()) {
+            return this;
+        } else {
+            return wrap(result);
+        }
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/Iterator.java
+++ b/javaslang/src/main/java/javaslang/collection/Iterator.java
@@ -5,23 +5,12 @@
  */
 package javaslang.collection;
 
-import javaslang.Tuple;
-import javaslang.Tuple2;
-import javaslang.Tuple3;
-import javaslang.collection.IteratorModule.ConcatIterator;
-import javaslang.collection.IteratorModule.DistinctIterator;
+import javaslang.*;
+import javaslang.collection.IteratorModule.*;
 import javaslang.control.Option;
 
-import java.util.Comparator;
-import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
+import java.util.*;
+import java.util.function.*;
 
 /**
  * {@code javaslang.collection.Iterator} is a compositional replacement for {@code java.util.Iterator}
@@ -1558,7 +1547,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
             throw new NoSuchElementException("reduceRight on Nil");
         } else {
             Stream<T> reversed = Stream.ofAll(this).reverse();
-            return reversed.tail().foldLeft(reversed.head(), (xs, x) -> op.apply(x, xs));
+            return reversed.reduceLeft((xs, x) -> op.apply(x, xs));
         }
     }
 
@@ -1617,12 +1606,9 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     default Iterator<T> retainAll(Iterable<? extends T> elements) {
-        Objects.requireNonNull(elements, "elements is null");
-        // DEV-NOTE: Only Eclipse does need this unchecked cast, IntelliJ and javac are fine.
-        return hasNext() ? filter(HashSet.ofAll((Iterable<T>) elements)::contains) : empty();
+        return Collections.retainAll(this, elements);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/LinkedHashSet.java
+++ b/javaslang/src/main/java/javaslang/collection/LinkedHashSet.java
@@ -9,10 +9,7 @@ import javaslang.*;
 import javaslang.control.Option;
 
 import java.io.*;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.NoSuchElementException;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;
 
@@ -669,12 +666,7 @@ public final class LinkedHashSet<T> implements Kind1<LinkedHashSet<?>, T>, Set<T
 
     @Override
     public LinkedHashSet<T> removeAll(Iterable<? extends T> elements) {
-        Objects.requireNonNull(elements, "elements is null");
-        LinkedHashMap<T, T> that = map;
-        for (T element : elements) {
-            that = that.remove(element);
-        }
-        return (that == map) ? this : new LinkedHashSet<>(that);
+        return Collections.removeAll(this, elements);
     }
 
     // DEV-NOTE: replace does not preserve the order, the new element may already be in the set
@@ -694,15 +686,7 @@ public final class LinkedHashSet<T> implements Kind1<LinkedHashSet<?>, T>, Set<T
 
     @Override
     public LinkedHashSet<T> retainAll(Iterable<? extends T> elements) {
-        Objects.requireNonNull(elements, "elements is null");
-        final LinkedHashMap<T, T> kept = addAll(LinkedHashMap.empty(), elements);
-        LinkedHashMap<T, T> that = LinkedHashMap.empty();
-        for (T element : this) {
-            if (kept.containsKey(element)) {
-                that = that.put(element, element);
-            }
-        }
-        return that.isEmpty() ? empty() : that.size() == size() ? this : new LinkedHashSet<>(that);
+        return Collections.retainAll(this, elements);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/Queue.java
+++ b/javaslang/src/main/java/javaslang/collection/Queue.java
@@ -664,7 +664,14 @@ public class Queue<T> implements Kind1<Queue<?>, T>, LinearSeq<T>, Serializable 
     public Queue<T> filter(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         final List<T> filtered = toList().filter(predicate);
-        return filtered.length() == length() ? this : filtered.toQueue();
+
+        if (filtered.isEmpty()) {
+            return Queue.empty();
+        } else if (filtered.length() == length()) {
+            return this;
+        } else {
+            return filtered.toQueue();
+        }
     }
 
     @Override
@@ -919,17 +926,12 @@ public class Queue<T> implements Kind1<Queue<?>, T>, LinearSeq<T>, Serializable 
 
     @Override
     public Queue<T> removeAll(T element) {
-        final List<T> newFront = front.removeAll(element);
-        final List<T> newRear = rear.removeAll(element);
-        return newFront.length() + newRear.length() == length() ? this : new Queue<>(newFront, newRear);
+        return Collections.removeAll(this, element);
     }
 
     @Override
     public Queue<T> removeAll(Iterable<? extends T> elements) {
-        Objects.requireNonNull(elements, "elements is null");
-        final List<T> newFront = front.removeAll(elements);
-        final List<T> newRear = rear.removeAll(elements);
-        return newFront.length() + newRear.length() == length() ? this : new Queue<>(newFront, newRear);
+        return Collections.removeAll(this, elements);
     }
 
     @Override
@@ -952,12 +954,7 @@ public class Queue<T> implements Kind1<Queue<?>, T>, LinearSeq<T>, Serializable 
 
     @Override
     public Queue<T> retainAll(Iterable<? extends T> elements) {
-        Objects.requireNonNull(elements, "elements is null");
-        final List<T> newFront = front.retainAll(elements);
-        final List<T> newRear = rear.retainAll(elements);
-        return newFront.size() + newRear.size() == 0 ? empty()
-                : newFront.size() + newRear.size() == size() ? this
-                : new Queue<>(newFront, newRear);
+        return Collections.retainAll(this, elements);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/Stream.java
+++ b/javaslang/src/main/java/javaslang/collection/Stream.java
@@ -6,8 +6,7 @@
 package javaslang.collection;
 
 import javaslang.*;
-import javaslang.collection.Stream.Cons;
-import javaslang.collection.Stream.Empty;
+import javaslang.collection.Stream.*;
 import javaslang.collection.StreamModule.*;
 import javaslang.control.Option;
 
@@ -802,7 +801,8 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
             stream = stream.tail();
         }
         final Stream<T> finalStream = stream;
-        return stream.isEmpty() ? stream : cons(stream.head(), () -> finalStream.tail().filter(predicate));
+        return stream.isEmpty() ? Stream.empty()
+                                : cons(stream.head(), () -> finalStream.tail().filter(predicate));
     }
 
     @Override
@@ -1080,16 +1080,13 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> removeAll(T removed) {
-        return filter(e -> !Objects.equals(e, removed));
+    default Stream<T> removeAll(T element) {
+        return Collections.removeAll(this, element);
     }
 
     @Override
     default Stream<T> removeAll(Iterable<? extends T> elements) {
-        Objects.requireNonNull(elements, "elements is null");
-
-        final Stream<T> distinct = Stream.ofAll(elements).distinct();
-        return filter(e -> !distinct.contains(e));
+        return Collections.removeAll(this, elements);
     }
 
     @Override
@@ -1119,14 +1116,7 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
 
     @Override
     default Stream<T> retainAll(Iterable<? extends T> elements) {
-        Objects.requireNonNull(elements, "elements is null");
-
-        if (isEmpty()) {
-            return this;
-        } else {
-            final Stream<T> retained = Stream.ofAll(elements).distinct();
-            return filter(retained::contains);
-        }
+        return Collections.retainAll(this, elements);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/Traversable.java
+++ b/javaslang/src/main/java/javaslang/collection/Traversable.java
@@ -5,15 +5,11 @@
  */
 package javaslang.collection;
 
-import javaslang.Tuple2;
-import javaslang.Tuple3;
-import javaslang.Value;
+import javaslang.*;
 import javaslang.control.Option;
 
 import java.math.BigInteger;
-import java.util.Comparator;
-import java.util.NoSuchElementException;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.*;
 
 /**
@@ -205,10 +201,9 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      * @return true, if this List contains all given elements, false otherwise.
      * @throws NullPointerException if {@code elements} is null
      */
-
     default boolean containsAll(Iterable<? extends T> elements) {
-        Objects.requireNonNull(elements, "elements is null");
-        return List.ofAll(elements).distinct().find(e -> !this.contains(e)).isEmpty();
+        HashSet<T> uniqueElements = HashSet.ofAll(elements);
+        return toSet().intersect(uniqueElements).size() == uniqueElements.size();
     }
 
     /**

--- a/javaslang/src/main/java/javaslang/collection/TreeMap.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeMap.java
@@ -5,16 +5,11 @@
  */
 package javaslang.collection;
 
-import javaslang.Kind2;
-import javaslang.Tuple;
-import javaslang.Tuple2;
+import javaslang.*;
 import javaslang.control.Option;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.NoSuchElementException;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;
 
@@ -588,7 +583,8 @@ public final class TreeMap<K, V> extends AbstractMap<K, V, TreeMap<K, V>> implem
         for (Tuple2<? extends K, ? extends V> entry : entries) {
             tree = tree.insert((Tuple2<K, V>) entry);
         }
-        return new TreeMap<>(tree);
+        return tree.isEmpty() ? (TreeMap<K, V>) TreeMap.empty()
+                              : new TreeMap<>(tree);
     }
 
     // -- Object

--- a/javaslang/src/main/java/javaslang/collection/TreeSet.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeSet.java
@@ -9,10 +9,7 @@ import javaslang.*;
 import javaslang.control.Option;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.NoSuchElementException;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;
 
@@ -731,21 +728,7 @@ public final class TreeSet<T> implements Kind1<TreeSet<?>, T>, SortedSet<T>, Ser
 
     @Override
     public TreeSet<T> removeAll(Iterable<? extends T> elements) {
-        Objects.requireNonNull(elements, "elements is null");
-        if (isEmpty()) {
-            return this;
-        } else {
-            RedBlackTree<T> that = tree;
-            final java.util.Iterator<? extends T> iter = elements.iterator();
-            while (!that.isEmpty() && iter.hasNext()) {
-                that = that.delete(iter.next());
-            }
-            if (that == tree) {
-                return this;
-            } else {
-                return new TreeSet<>(that);
-            }
-        }
+        return Collections.removeAll(this, elements);
     }
 
     @Override
@@ -765,14 +748,7 @@ public final class TreeSet<T> implements Kind1<TreeSet<?>, T>, SortedSet<T>, Ser
 
     @Override
     public TreeSet<T> retainAll(Iterable<? extends T> elements) {
-        Objects.requireNonNull(elements, "elements is null");
-        if (isEmpty()) {
-            return this;
-        } else {
-            final RedBlackTree<T> kept = RedBlackTree.ofAll(tree.comparator(), elements);
-            final RedBlackTree<T> newTree = tree.intersection(kept);
-            return newTree.size() == tree.size() ? this : new TreeSet<>(tree.intersection(kept));
-        }
+        return Collections.retainAll(this, elements);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -560,16 +560,19 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     @Override
     public Vector<T> filter(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
+        HashArrayMappedTrie<Integer, T> filtered = HashArrayMappedTrie.empty();
         for (T t : this) {
             if (predicate.test(t)) {
-                trie = trie.put(trie.size(), t);
+                filtered = filtered.put(filtered.size(), t);
             }
         }
-        if (trie.size() == length()) {
+
+        if (filtered.isEmpty()) {
+            return Vector.empty();
+        } else if (filtered.size() == size()) {
             return this;
         } else {
-            return wrap(trie);
+            return wrap(filtered);
         }
     }
 
@@ -907,34 +910,12 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public Vector<T> removeAll(T element) {
-        HashArrayMappedTrie<Integer, T> result = HashArrayMappedTrie.empty();
-        for (int i = 0; i < length(); i++) {
-            final T value = get(i);
-            if (!element.equals(value)) {
-                result = result.put(result.size(), value);
-            }
-        }
-        return result.size() == length() ? this : wrap(result);
+        return Collections.removeAll(this, element);
     }
 
     @Override
     public Vector<T> removeAll(Iterable<? extends T> elements) {
-        Objects.requireNonNull(elements, "elements is null");
-        HashArrayMappedTrie<T, T> removed = HashArrayMappedTrie.empty();
-        for (T element : elements) {
-            removed = removed.put(element, element);
-        }
-        HashArrayMappedTrie<Integer, T> result = HashArrayMappedTrie.empty();
-        boolean found = false;
-        for (int i = 0; i < length(); i++) {
-            T element = get(i);
-            if (removed.get(element).isDefined()) {
-                found = true;
-            } else {
-                result = result.put(result.size(), element);
-            }
-        }
-        return found ? wrap(result) : this;
+        return Collections.removeAll(this, elements);
     }
 
     @Override
@@ -973,19 +954,9 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
         return changed ? wrap(trie) : this;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public Vector<T> retainAll(Iterable<? extends T> elements) {
-        Objects.requireNonNull(elements, "elements is null");
-        // TODO(Eclipse bug): remove cast + SuppressWarnings
-        final Vector<T> kept = (Vector<T>) (Object) Vector.ofAll(elements).distinct();
-        HashArrayMappedTrie<Integer, T> result = HashArrayMappedTrie.empty();
-        for (T element : this) {
-            if (kept.contains(element)) {
-                result = result.put(result.size(), element);
-            }
-        }
-        return result.size() == trie.size() ? this : wrap(result);
+        return Collections.retainAll(this, elements);
     }
 
     @Override

--- a/javaslang/src/test/java/javaslang/collection/AbstractTraversableTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractTraversableTest.java
@@ -5,25 +5,19 @@
  */
 package javaslang.collection;
 
-import javaslang.AbstractValueTest;
-import javaslang.Tuple;
-import javaslang.Tuple2;
+import javaslang.*;
 import javaslang.control.Option;
 import org.junit.Test;
 
 import java.io.*;
-import java.math.BigDecimal;
-import java.math.BigInteger;
+import java.math.*;
 import java.util.*;
-import java.util.function.Function;
-import java.util.function.Supplier;
+import java.util.function.*;
 import java.util.stream.Collector;
 
 import static java.lang.System.lineSeparator;
-import static javaslang.Serializables.deserialize;
-import static javaslang.Serializables.serialize;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.Assertions.within;
+import static javaslang.Serializables.*;
+import static org.assertj.core.api.Assertions.*;
 
 public abstract class AbstractTraversableTest extends AbstractValueTest {
 
@@ -243,6 +237,12 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
     }
 
     // -- containsAll
+
+    @Test
+    public void shouldHandleDuplicates() {
+        final boolean actual = of(1, 2, 3, 2, 3, 1).containsAll(of(1, 2, 2));
+        assertThat(actual).isTrue();
+    }
 
     @Test
     public void shouldRecognizeNilNotContainsAllElements() {
@@ -1326,34 +1326,45 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
 
     @Test
     public void shouldRetainAllElementsFromNil() {
+        Traversable<Object> src = empty();
+        Traversable<Object> expected = src;
+        Traversable<Object> actual = src.retainAll(of(1, 2, 3));
         if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(empty().retainAll(of(1, 2, 3))).isEqualTo(empty());
+            assertThat(actual).isEqualTo(expected);
         } else {
-            assertThat(empty().retainAll(of(1, 2, 3))).isSameAs(empty());
+            assertThat(actual).isSameAs(expected);
         }
     }
 
     @Test
     public void shouldRetainAllExistingElementsFromNonNil() {
-        assertThat(of(1, 2, 3, 1, 2, 3).retainAll(of(1, 2))).isEqualTo(of(1, 2, 1, 2));
+        Traversable<Integer> src = of(1, 2, 3, 2, 1, 3);
+        Traversable<Integer> expected = of(1, 2, 2, 1);
+        Traversable<Integer> actual = src.retainAll(of(1, 2));
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldRetainAllElementsFromNonNil() {
+        Traversable<Integer> src = of(1, 2, 1, 2, 2);
+        Traversable<Integer> expected = of(1, 2, 1, 2, 2);
+        Traversable<Integer> actual = src.retainAll(of(1, 2));
         if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(of(1, 2, 1, 2, 2).retainAll(of(1, 2))).isEqualTo(of(1, 2, 1, 2, 2));
+            assertThat(actual).isEqualTo(expected);
         } else {
-            final Traversable<Integer> src = of(1, 2, 1, 2, 2);
-            assertThat(src.retainAll(of(1, 2))).isSameAs(src);
+            assertThat(actual).isSameAs(src);
         }
     }
 
     @Test
     public void shouldNotRetainAllNonExistingElementsFromNonNil() {
+        Traversable<Integer> src = of(1, 2, 3);
+        Traversable<Object> expected = empty();
+        Traversable<Integer> actual = src.retainAll(of(4, 5));
         if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(of(1, 2, 3).retainAll(of(4, 5))).isEqualTo(empty());
+            assertThat(actual).isEqualTo(expected);
         } else {
-            assertThat(of(1, 2, 3).retainAll(of(4, 5))).isSameAs(empty());
+            assertThat(actual).isSameAs(expected);
         }
     }
 

--- a/javaslang/src/test/java/javaslang/collection/IntMap.java
+++ b/javaslang/src/test/java/javaslang/collection/IntMap.java
@@ -5,19 +5,12 @@
  */
 package javaslang.collection;
 
-import javaslang.Tuple;
-import javaslang.Tuple2;
-import javaslang.Tuple3;
+import javaslang.*;
 import javaslang.control.Option;
 
 import java.io.Serializable;
-import java.util.Comparator;
-import java.util.Objects;
-import java.util.Spliterator;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Predicate;
+import java.util.*;
+import java.util.function.*;
 
 public class IntMap<T> implements Traversable<T>, Serializable {
 
@@ -25,8 +18,12 @@ public class IntMap<T> implements Traversable<T>, Serializable {
 
     private final Map<Integer, T> original;
 
+    private static final IntMap<?> EMPTY = new IntMap<>(HashMap.empty());
+
+    @SuppressWarnings("unchecked")
     public static <T> IntMap<T> of(Map<Integer, T> original) {
-        return new IntMap<>(original);
+        return original.isEmpty() ? (IntMap<T>) EMPTY
+                                  : new IntMap<>(original);
     }
 
     private IntMap(Map<Integer, T> original) {


### PR DESCRIPTION
This should improve complexity (speed-wise and code-wise) significantly in many cases.

Coverage is reduced, because there are fewer lines :).

Fixes https://github.com/javaslang/javaslang/issues/1276