### PR TITLE
Added persistent `PriorityQueue` implementation

### DIFF
--- a/javaslang-benchmark/pom.xml
+++ b/javaslang-benchmark/pom.xml
@@ -27,11 +27,6 @@
             <artifactId>javaslang</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!--<dependency>-->
-        <!--<groupId>org.scala-lang</groupId>-->
-        <!--<artifactId>scala-library</artifactId>-->
-        <!--<version>2.12.0-M4</version>-->
-        <!--</dependency>-->
         <dependency>
             <groupId>org.scalaz</groupId>
             <artifactId>scalaz-core_2.11</artifactId>

--- a/javaslang-benchmark/pom.xml
+++ b/javaslang-benchmark/pom.xml
@@ -27,6 +27,16 @@
             <artifactId>javaslang</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!--<dependency>-->
+        <!--<groupId>org.scala-lang</groupId>-->
+        <!--<artifactId>scala-library</artifactId>-->
+        <!--<version>2.12.0-M4</version>-->
+        <!--</dependency>-->
+        <dependency>
+            <groupId>org.scalaz</groupId>
+            <artifactId>scalaz-core_2.11</artifactId>
+            <version>7.3.0-M1</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/BenchmarkResultAggregator.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/BenchmarkResultAggregator.java
@@ -1,0 +1,77 @@
+package javaslang.benchmark;
+
+import javaslang.*;
+import javaslang.collection.*;
+import org.openjdk.jmh.results.*;
+
+import java.text.DecimalFormat;
+import java.util.Collection;
+
+public class BenchmarkResultAggregator {
+    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("#0.00");
+
+    public static void displayRatios(Collection<RunResult> runResults) {
+        final Multimap<Integer, Tuple2<String, Double>> results = aggregate(runResults);
+        final Multimap<String, Double> ratios = getRatios(results);
+        if (!ratios.isEmpty()) { // TODO ratios.isNotEmpty()
+            final Seq<String> output = getFormattedRatios(results, ratios);
+
+            output.forEach(System.out::println);
+        }
+    }
+
+    private static Multimap<Integer, Tuple2<String, Double>> aggregate(Collection<RunResult> runResults) {
+        Multimap<Integer, Tuple2<String, Double>> results = HashMultimap.withSeq().empty();
+        for (RunResult runResult : runResults) {
+            final BenchmarkResult benchmarkResult = runResult.getAggregatedResult();
+            results = results.put(getContainerSize(benchmarkResult), getPrimaryResult(benchmarkResult));
+        }
+        return results;
+    }
+
+    private static Integer getContainerSize(BenchmarkResult benchmarkResult) {
+        return Integer.parseInt(benchmarkResult.getParams().getParam("CONTAINER_SIZE"));
+    }
+
+    private static Tuple2<String, Double> getPrimaryResult(BenchmarkResult benchmarkResult) {
+        final Result primaryResult = benchmarkResult.getPrimaryResult();
+        return Tuple.of(primaryResult.getLabel(), primaryResult.getScore());
+    }
+
+    private static Multimap<String, Double> getRatios(Multimap<Integer, Tuple2<String, Double>> results) {
+        Multimap<String, Double> ratios = HashMultimap.withSeq().empty();
+        for (Integer size : results.keySet().toList().sorted()) {
+            for (List<Tuple2<String, Double>> pairs : results.get(size).get().toList().combinations(2)) {
+                final Tuple2<String, Double> first = pairs.get(0), second = pairs.get(1);
+                ratios = ratios.put(formatBenchmarks(first, second), formatRatios(first, second));
+            }
+        }
+        return ratios;
+    }
+
+    private static List<String> getFormattedRatios(Multimap<Integer, Tuple2<String, Double>> results, Multimap<String, Double> ratios) {
+        final List<String> sortedNames = ratios.keySet().toList().sorted();
+        final int padLength = sortedNames.map(String::length).max().get();
+        final List<String> output = sortedNames.map(
+                name -> {
+                    final CharSeq benchmarks = CharSeq.of(name).padTo(padLength, ' ');
+                    final String benchmarkSpeedRatios = formatList(ratios.get(name).get().map(DECIMAL_FORMAT::format));
+                    return benchmarks + ": " + benchmarkSpeedRatios;
+                }
+        );
+        final String header = formatList(results.keySet().toList().sorted());
+        return output.prepend("\nRatios for: " + header);
+    }
+
+    private static String formatBenchmarks(Tuple2<String, Double> first, Tuple2<String, Double> second) {
+        return first._1 + "/" + second._1;
+    }
+
+    private static double formatRatios(Tuple2<String, Double> first, Tuple2<String, Double> second) {
+        return first._2 / second._2;
+    }
+
+    private static String formatList(Traversable<?> elements) {
+        return elements.mkString("[", ", ", "]");
+    }
+}

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/BenchmarkResultAggregator.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/BenchmarkResultAggregator.java
@@ -10,17 +10,41 @@ import java.util.Collection;
 public class BenchmarkResultAggregator {
     private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("#0.00");
 
-    public static void displayRatios(Collection<RunResult> runResults) {
-        final Multimap<Integer, Tuple2<String, Double>> results = aggregate(runResults);
-        final Multimap<String, Double> ratios = getRatios(results);
-        if (!ratios.isEmpty()) { // TODO ratios.isNotEmpty()
-            final Seq<String> output = getFormattedRatios(results, ratios);
+    public static void displayRatios(Collection<RunResult> runResultsCollection) {
+        final Array<RunResult> runResults = Array.ofAll(runResultsCollection);
 
-            output.forEach(System.out::println);
+        if (runResults.size() > 1) {
+            printHeader(runResults);
+            for (Tuple2<String, Array<RunResult>> group : getGroupsBasedOnBenchmarkPrefix(runResults)) {
+                final Multimap<Integer, Tuple2<String, Double>> results = aggregate(group._2);
+                final Multimap<String, Double> ratios = getRatios(results);
+                if (!ratios.isEmpty()) {
+                    System.out.println("Group '" + group._1 + "':");
+
+                    final Seq<String> output = getFormattedRatios(ratios);
+                    output.forEach(System.out::println);
+                }
+            }
         }
     }
 
-    private static Multimap<Integer, Tuple2<String, Double>> aggregate(Collection<RunResult> runResults) {
+    private static void printHeader(Array<RunResult> list) {
+        if (!list.isEmpty()) {
+            final Array<Integer> containerSizes = list.map(r -> getContainerSize(r.getAggregatedResult())).distinct().sorted();
+            final String header = formatList(containerSizes);
+            System.out.println("\nRatios for: " + header);
+        }
+    }
+
+    private static Map<String, Array<RunResult>> getGroupsBasedOnBenchmarkPrefix(Array<RunResult> runResults) {
+        return runResults.groupBy(r -> {
+            final String[] parts = r.getParams().getBenchmark().split("\\.");
+            final String enclosingClassName = parts[parts.length - 2];
+            return enclosingClassName;
+        });
+    }
+
+    private static Multimap<Integer, Tuple2<String, Double>> aggregate(Array<RunResult> runResults) {
         Multimap<Integer, Tuple2<String, Double>> results = HashMultimap.withSeq().empty();
         for (RunResult runResult : runResults) {
             final BenchmarkResult benchmarkResult = runResult.getAggregatedResult();
@@ -41,7 +65,7 @@ public class BenchmarkResultAggregator {
     private static Multimap<String, Double> getRatios(Multimap<Integer, Tuple2<String, Double>> results) {
         Multimap<String, Double> ratios = HashMultimap.withSeq().empty();
         for (Integer size : results.keySet().toList().sorted()) {
-            for (List<Tuple2<String, Double>> pairs : results.get(size).get().toList().combinations(2)) {
+            for (Array<Tuple2<String, Double>> pairs : results.get(size).get().toArray().combinations(2)) {
                 final Tuple2<String, Double> first = pairs.get(0), second = pairs.get(1);
                 ratios = ratios.put(formatBenchmarks(first, second), formatRatios(first, second));
             }
@@ -49,18 +73,17 @@ public class BenchmarkResultAggregator {
         return ratios;
     }
 
-    private static List<String> getFormattedRatios(Multimap<Integer, Tuple2<String, Double>> results, Multimap<String, Double> ratios) {
-        final List<String> sortedNames = ratios.keySet().toList().sorted();
+    private static Array<String> getFormattedRatios(Multimap<String, Double> ratios) {
+        final Array<String> sortedNames = ratios.keySet().toArray().sorted();
         final int padLength = sortedNames.map(String::length).max().get();
-        final List<String> output = sortedNames.map(
+        final Array<String> output = sortedNames.map(
                 name -> {
                     final CharSeq benchmarks = CharSeq.of(name).padTo(padLength, ' ');
                     final String benchmarkSpeedRatios = formatList(ratios.get(name).get().map(DECIMAL_FORMAT::format));
                     return benchmarks + ": " + benchmarkSpeedRatios;
                 }
         );
-        final String header = formatList(results.keySet().toList().sorted());
-        return output.prepend("\nRatios for: " + header);
+        return output;
     }
 
     private static String formatBenchmarks(Tuple2<String, Double> first, Tuple2<String, Double> second) {

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/PriorityQueueBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/PriorityQueueBenchmark.java
@@ -1,0 +1,120 @@
+package javaslang.benchmark;
+
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.*;
+import scala.math.Ordering;
+import scala.math.Ordering$;
+import scalaz.*;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static javaslang.benchmark.BenchmarkResultAggregator.displayRatios;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3, jvmArgsAppend = { "-XX:+UseG1GC", "-Xss100m", "-Xms1g", "-Xmx1g", "-disableassertions" })
+public class PriorityQueueBenchmark {
+    private static final Ordering<Integer> SCALA_ORDERING = Ordering$.MODULE$.comparatorToOrdering(Integer::compareTo);
+    private static final Order<Integer> SCALAZ_ORDER = Order$.MODULE$.fromScalaOrdering(SCALA_ORDERING);
+
+    @Param({ "10", "1000", "100000" })
+    protected int CONTAINER_SIZE;
+
+    @Test
+    public void launchBenchmark() throws Exception {
+        final Options opts = new OptionsBuilder()
+                .include(PriorityQueueBenchmark.class.getSimpleName())
+                .shouldDoGC(false)
+                .shouldFailOnError(true)
+                .build();
+
+        displayRatios(new Runner(opts).run());
+    }
+
+    private List<Integer> ELEMENTS;
+
+    @Setup
+    public void setup() {
+        final Random random = new Random(0);
+
+        final List<Integer> copy = new ArrayList<>(CONTAINER_SIZE);
+        for (int i = 0; i < CONTAINER_SIZE; i++) {
+            final int value = random.nextInt(CONTAINER_SIZE) - (CONTAINER_SIZE / 2);
+            copy.add(value);
+        }
+
+        ELEMENTS = Collections.unmodifiableList(copy);
+        assertEquals(ELEMENTS.size(), CONTAINER_SIZE);
+    }
+
+    @Benchmark
+    public void sort_java_mutable() {
+        final java.util.PriorityQueue<Integer> q = new java.util.PriorityQueue<>(ELEMENTS);
+        assertEquals(q.size(), CONTAINER_SIZE);
+
+        final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
+        for (; !q.isEmpty(); q.poll()) {
+            result.add(q.peek());
+        }
+        assertEquals(q.size(), 0);
+        assertEquals(result.size(), CONTAINER_SIZE);
+    }
+
+    @Benchmark
+    public void sort_scala_mutable() {
+        scala.collection.mutable.PriorityQueue<Integer> q = new scala.collection.mutable.PriorityQueue<>(SCALA_ORDERING);
+        for (Integer element : ELEMENTS) {
+            q = q.$plus$eq(element);
+        }
+        assertEquals(q.size(), CONTAINER_SIZE);
+
+        final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
+        while (!q.isEmpty()) {
+            result.add(q.dequeue());
+        }
+        assertEquals(q.size(), 0);
+        assertEquals(result.size(), CONTAINER_SIZE);
+    }
+
+    @Benchmark
+    public void sort_scalaz_persistent() {
+        scalaz.Heap<Integer> q = scalaz.Heap.Empty$.MODULE$.apply();
+        for (Integer element : ELEMENTS) {
+            q = q.insert(element, SCALAZ_ORDER);
+        }
+        assertEquals(q.size(), CONTAINER_SIZE);
+
+        final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
+        for (; !q.isEmpty(); q = q.deleteMin()) {
+            result.add(q.minimum());
+        }
+        assertEquals(q.size(), 0);
+        assertEquals(result.size(), CONTAINER_SIZE);
+    }
+
+    @Benchmark
+    public void sort_slang_persistent() {
+        javaslang.collection.PriorityQueue<Integer> q = javaslang.collection.PriorityQueue.ofAll(ELEMENTS);
+        assertEquals(q.size(), CONTAINER_SIZE);
+
+        final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
+        for (; !q.isEmpty(); q = q.tail()) {
+            result.add(q.head());
+        }
+        assertEquals(q.size(), 0);
+        assertEquals(result.size(), CONTAINER_SIZE);
+    }
+
+    private static <T> void assertEquals(T a, T b) {
+        if (!Objects.equals(a, b)) {
+            throw new IllegalStateException(a + " != " + b);
+        }
+    }
+}

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/PriorityQueueBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/PriorityQueueBenchmark.java
@@ -1,9 +1,10 @@
 package javaslang.benchmark;
 
-import org.junit.Test;
+import javaslang.Tuple2;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.*;
 import org.openjdk.jmh.runner.options.*;
 import scala.math.Ordering;
 import scala.math.Ordering$;
@@ -14,107 +15,251 @@ import java.util.concurrent.TimeUnit;
 
 import static javaslang.benchmark.BenchmarkResultAggregator.displayRatios;
 
-@State(Scope.Benchmark)
-@BenchmarkMode(Mode.Throughput)
-@OutputTimeUnit(TimeUnit.SECONDS)
-@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 3, jvmArgsAppend = { "-XX:+UseG1GC", "-Xss100m", "-Xms1g", "-Xmx1g", "-disableassertions" })
 public class PriorityQueueBenchmark {
-    private static final Ordering<Integer> SCALA_ORDERING = Ordering$.MODULE$.comparatorToOrdering(Integer::compareTo);
-    private static final Order<Integer> SCALAZ_ORDER = Order$.MODULE$.fromScalaOrdering(SCALA_ORDERING);
-
-    @Param({ "10", "1000", "100000" })
-    protected int CONTAINER_SIZE;
-
-    @Test
-    public void launchBenchmark() throws Exception {
+    public static void main(String... args) throws Exception { // main is more reliable than a test
         final Options opts = new OptionsBuilder()
                 .include(PriorityQueueBenchmark.class.getSimpleName())
                 .shouldDoGC(false)
                 .shouldFailOnError(true)
                 .build();
 
-        displayRatios(new Runner(opts).run());
+        final Collection<RunResult> results = new Runner(opts).run();
+        displayRatios(results);
     }
 
-    private List<Integer> ELEMENTS;
+    @State(Scope.Benchmark)
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Fork(value = 1, jvmArgsAppend = { "-XX:+UseG1GC", "-Xss100m", "-Xms1g", "-Xmx1g", "-disableassertions" }) /* set fork to 0 if you want to debug */
+    public static class Base {
+        protected static final Ordering<Integer> SCALA_ORDERING = Ordering$.MODULE$.comparatorToOrdering(Integer::compareTo);
+        protected static final Order<Integer> SCALAZ_ORDER = Order$.MODULE$.fromScalaOrdering(SCALA_ORDERING);
 
-    @Setup
-    public void setup() {
-        final Random random = new Random(0);
+        @Param({ "10", "1000", "100000" })
+        public int CONTAINER_SIZE;
 
-        final List<Integer> copy = new ArrayList<>(CONTAINER_SIZE);
-        for (int i = 0; i < CONTAINER_SIZE; i++) {
-            final int value = random.nextInt(CONTAINER_SIZE) - (CONTAINER_SIZE / 2);
-            copy.add(value);
+        public List<Integer> ELEMENTS;
+
+        @Setup
+        public void setup() {
+            final Random random = new Random(0);
+
+            final List<Integer> copy = new ArrayList<>(CONTAINER_SIZE);
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                final int value = random.nextInt(CONTAINER_SIZE) - (CONTAINER_SIZE / 2);
+                copy.add(value);
+            }
+
+            ELEMENTS = Collections.unmodifiableList(copy);
+            assertEquals(ELEMENTS.size(), CONTAINER_SIZE);
         }
 
-        ELEMENTS = Collections.unmodifiableList(copy);
-        assertEquals(ELEMENTS.size(), CONTAINER_SIZE);
+        protected static <T> void assertEquals(T a, T b) {
+            if (!Objects.equals(a, b)) {
+                throw new IllegalStateException(a + " != " + b);
+            }
+        }
     }
 
-    @Benchmark
-    public void sort_java_mutable() {
-        final java.util.PriorityQueue<Integer> q = new java.util.PriorityQueue<>(ELEMENTS);
-        assertEquals(q.size(), CONTAINER_SIZE);
-
-        final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-        for (; !q.isEmpty(); q.poll()) {
-            result.add(q.peek());
+    public static class Enqueue extends Base {
+        @Benchmark
+        @SuppressWarnings("Convert2streamapi")
+        public void java_mutable() {
+            final java.util.PriorityQueue<Integer> q = new java.util.PriorityQueue<>(ELEMENTS.size());
+            for (Integer element : ELEMENTS) {
+                q.add(element);
+            }
+            assertEquals(q.size(), CONTAINER_SIZE);
         }
-        assertEquals(q.size(), 0);
-        assertEquals(result.size(), CONTAINER_SIZE);
+
+        @Benchmark
+        public void scala_mutable() {
+            scala.collection.mutable.PriorityQueue<Integer> q = new scala.collection.mutable.PriorityQueue<>(SCALA_ORDERING);
+            for (Integer element : ELEMENTS) {
+                q = q.$plus$eq(element);
+            }
+            assertEquals(q.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void scalaz_persistent() {
+            scalaz.Heap<Integer> q = scalaz.Heap.Empty$.MODULE$.apply();
+            for (Integer element : ELEMENTS) {
+                q = q.insert(element, SCALAZ_ORDER);
+            }
+            assertEquals(q.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            javaslang.collection.PriorityQueue<Integer> q = javaslang.collection.PriorityQueue.empty();
+            for (Integer element : ELEMENTS) {
+                q = q.enqueue(element);
+            }
+            assertEquals(q.size(), CONTAINER_SIZE);
+        }
     }
 
-    @Benchmark
-    public void sort_scala_mutable() {
-        scala.collection.mutable.PriorityQueue<Integer> q = new scala.collection.mutable.PriorityQueue<>(SCALA_ORDERING);
-        for (Integer element : ELEMENTS) {
-            q = q.$plus$eq(element);
-        }
-        assertEquals(q.size(), CONTAINER_SIZE);
+    public static class Dequeue extends Base {
+        @State(Scope.Thread)
+        public static class InitializedQueues {
+            java.util.PriorityQueue<Integer> javaQueueMutable = new java.util.PriorityQueue<>();
+            scala.collection.mutable.PriorityQueue<Integer> scalaQueueMutable = new scala.collection.mutable.PriorityQueue<>(SCALA_ORDERING);
 
-        final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-        while (!q.isEmpty()) {
-            result.add(q.dequeue());
+            boolean initializedPersistent = false;
+            scalaz.Heap<Integer> scalazQueuePersistent = scalaz.Heap.Empty$.MODULE$.apply();
+            javaslang.collection.PriorityQueue<Integer> slangQueuePersistent = javaslang.collection.PriorityQueue.empty();
+
+            @Setup(Level.Invocation)
+            public void initializeMutable(Base state) {
+                assertEquals(javaQueueMutable.size(), 0);
+                javaQueueMutable.addAll(state.ELEMENTS);
+                assertEquals(javaQueueMutable.size(), state.CONTAINER_SIZE);
+
+                assertEquals(scalaQueueMutable.size(), 0);
+                for (Integer element : state.ELEMENTS) {
+                    scalaQueueMutable = scalaQueueMutable.$plus$eq(element);
+                }
+                assertEquals(scalaQueueMutable.size(), state.CONTAINER_SIZE);
+
+                if (!initializedPersistent) {
+                    assertEquals(scalazQueuePersistent.size(), 0);
+                    assertEquals(slangQueuePersistent.size(), 0);
+                    for (Integer element : state.ELEMENTS) {
+                        scalazQueuePersistent = scalazQueuePersistent.insert(element, SCALAZ_ORDER);
+                        slangQueuePersistent = slangQueuePersistent.enqueue(element);
+                    }
+                    assertEquals(scalazQueuePersistent.size(), state.CONTAINER_SIZE);
+                    assertEquals(slangQueuePersistent.size(), state.CONTAINER_SIZE);
+
+                    initializedPersistent = true;
+                }
+            }
+
+            @TearDown(Level.Invocation)
+            public void tearDown() {
+                javaQueueMutable.clear();
+                scalaQueueMutable.clear();
+            }
         }
-        assertEquals(q.size(), 0);
-        assertEquals(result.size(), CONTAINER_SIZE);
+
+        @Benchmark
+        public void java_mutable(InitializedQueues state) {
+            final java.util.PriorityQueue<Integer> q = state.javaQueueMutable;
+
+            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
+            for (; !q.isEmpty(); q.poll()) {
+                result.add(q.peek());
+            }
+            assertEquals(q.size(), 0);
+            assertEquals(result.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void scala_mutable(InitializedQueues state) {
+            final scala.collection.mutable.PriorityQueue<Integer> q = state.scalaQueueMutable;
+
+            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
+            while (!q.isEmpty()) {
+                result.add(q.dequeue());
+            }
+            assertEquals(q.size(), 0);
+            assertEquals(result.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void scalaz_persistent(InitializedQueues state) {
+            scalaz.Heap<Integer> q = state.scalazQueuePersistent;
+
+            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
+            while (!q.isEmpty()) {
+                final scala.Tuple2<Integer, Heap<Integer>> uncons = q.uncons().get();
+                result.add(uncons._1);
+                q = uncons._2;
+            }
+            assertEquals(q.size(), 0);
+            assertEquals(result.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void slang_persistent(InitializedQueues state) {
+            javaslang.collection.PriorityQueue<Integer> q = state.slangQueuePersistent;
+
+            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
+            while (!q.isEmpty()) {
+                final Tuple2<Integer, javaslang.collection.PriorityQueue<Integer>> dequeue = q.dequeue();
+                result.add(dequeue._1);
+                q = dequeue._2;
+            }
+            assertEquals(q.size(), 0);
+            assertEquals(result.size(), CONTAINER_SIZE);
+        }
+
     }
 
-    @Benchmark
-    public void sort_scalaz_persistent() {
-        scalaz.Heap<Integer> q = scalaz.Heap.Empty$.MODULE$.apply();
-        for (Integer element : ELEMENTS) {
-            q = q.insert(element, SCALAZ_ORDER);
+    public static class Sort extends Base {
+        @Benchmark
+        public void java_mutable() {
+            final java.util.PriorityQueue<Integer> q = new java.util.PriorityQueue<>(ELEMENTS);
+            assertEquals(q.size(), CONTAINER_SIZE);
+
+            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
+            for (; !q.isEmpty(); q.poll()) {
+                result.add(q.peek());
+            }
+            assertEquals(q.size(), 0);
+            assertEquals(result.size(), CONTAINER_SIZE);
         }
-        assertEquals(q.size(), CONTAINER_SIZE);
 
-        final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-        for (; !q.isEmpty(); q = q.deleteMin()) {
-            result.add(q.minimum());
+        @Benchmark
+        public void scala_mutable() {
+            scala.collection.mutable.PriorityQueue<Integer> q = new scala.collection.mutable.PriorityQueue<>(SCALA_ORDERING);
+            for (Integer element : ELEMENTS) {
+                q = q.$plus$eq(element);
+            }
+            assertEquals(q.size(), CONTAINER_SIZE);
+
+            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
+            while (!q.isEmpty()) {
+                result.add(q.dequeue());
+            }
+            assertEquals(q.size(), 0);
+            assertEquals(result.size(), CONTAINER_SIZE);
         }
-        assertEquals(q.size(), 0);
-        assertEquals(result.size(), CONTAINER_SIZE);
-    }
 
-    @Benchmark
-    public void sort_slang_persistent() {
-        javaslang.collection.PriorityQueue<Integer> q = javaslang.collection.PriorityQueue.ofAll(ELEMENTS);
-        assertEquals(q.size(), CONTAINER_SIZE);
+        @Benchmark
+        public void scalaz_persistent() {
+            scalaz.Heap<Integer> q = scalaz.Heap.Empty$.MODULE$.apply();
+            for (Integer element : ELEMENTS) {
+                q = q.insert(element, SCALAZ_ORDER);
+            }
+            assertEquals(q.size(), CONTAINER_SIZE);
 
-        final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-        for (; !q.isEmpty(); q = q.tail()) {
-            result.add(q.head());
+            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
+            while (!q.isEmpty()) {
+                final scala.Tuple2<Integer, Heap<Integer>> uncons = q.uncons().get();
+                result.add(uncons._1);
+                q = uncons._2;
+            }
+            assertEquals(q.size(), 0);
+            assertEquals(result.size(), CONTAINER_SIZE);
         }
-        assertEquals(q.size(), 0);
-        assertEquals(result.size(), CONTAINER_SIZE);
-    }
 
-    private static <T> void assertEquals(T a, T b) {
-        if (!Objects.equals(a, b)) {
-            throw new IllegalStateException(a + " != " + b);
+        @Benchmark
+        public void slang_persistent() {
+            javaslang.collection.PriorityQueue<Integer> q = javaslang.collection.PriorityQueue.ofAll(ELEMENTS);
+            assertEquals(q.size(), CONTAINER_SIZE);
+
+            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
+            while (!q.isEmpty()) {
+                final Tuple2<Integer, javaslang.collection.PriorityQueue<Integer>> dequeue = q.dequeue();
+                result.add(dequeue._1);
+                q = dequeue._2;
+            }
+            assertEquals(q.size(), 0);
+            assertEquals(result.size(), CONTAINER_SIZE);
         }
     }
 }

--- a/javaslang/src/main/java/javaslang/Value.java
+++ b/javaslang/src/main/java/javaslang/Value.java
@@ -11,6 +11,7 @@ import javaslang.collection.HashSet;
 import javaslang.collection.Iterator;
 import javaslang.collection.List;
 import javaslang.collection.Map;
+import javaslang.collection.PriorityQueue;
 import javaslang.collection.Queue;
 import javaslang.collection.Set;
 import javaslang.collection.SortedSet;
@@ -100,6 +101,7 @@ import java.util.stream.StreamSupport;
  * <li>{@link #toRight(Supplier)}</li>
  * <li>{@link #toSet()}</li>
  * <li>{@link #toSortedSet(Comparator)}</li>
+ * <li>{@link #toSortedQueue(Comparator)}</li>
  * <li>{@link #toStack()}</li>
  * <li>{@link #toStream()}</li>
  * <li>{@link #toString()}</li>
@@ -655,6 +657,22 @@ public interface Value<T> extends Iterable<T> {
      */
     default Queue<T> toQueue() {
         return ValueModule.toTraversable(this, Queue.empty(), Queue::of, Queue::ofAll);
+    }
+
+    /**
+     * Converts this to a sorted {@link Queue}.
+     *
+     * @return A new {@link Queue}.
+     */
+    default PriorityQueue<T> toSortedQueue(Comparator<? super T> comparator) {
+        if (this instanceof PriorityQueue) {
+            return (PriorityQueue<T>) this;
+        } else {
+            final PriorityQueue<T> empty = PriorityQueue.empty(comparator);
+            final Function<T, PriorityQueue<T>> of = value -> PriorityQueue.of(comparator, value);
+            final Function<Iterable<T>, PriorityQueue<T>> ofAll = values -> PriorityQueue.ofAll(comparator, values);
+            return ValueModule.toTraversable(this, empty, of, ofAll);
+        }
     }
 
     /**

--- a/javaslang/src/main/java/javaslang/collection/AbstractsQueue.java
+++ b/javaslang/src/main/java/javaslang/collection/AbstractsQueue.java
@@ -1,0 +1,176 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2016 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+
+package javaslang.collection;
+
+import javaslang.*;
+import javaslang.control.Option;
+
+import java.util.*;
+import java.util.function.*;
+
+/**
+ * @author Pap Lőrinc, Daniel Dietrich
+ * @since 2.1.0
+ */
+abstract class AbstractsQueue<T, Q extends AbstractsQueue<T, Q>> implements Traversable<T> {
+    /**
+     * Removes an element from this Queue.
+     *
+     * @return a tuple containing the first element and the remaining elements of this Queue
+     * @throws NoSuchElementException if this Queue is empty
+     */
+    public Tuple2<T, Q> dequeue() {
+        if (isEmpty()) {
+            throw new NoSuchElementException("dequeue of empty " + getClass().getSimpleName());
+        } else {
+            return Tuple.of(head(), tail());
+        }
+    }
+
+    /**
+     * Removes an element from this Queue.
+     *
+     * @return {@code None} if this Queue is empty, otherwise {@code Some} {@code Tuple} containing the first element and the remaining elements of this Queue
+     */
+    public Option<Tuple2<T, Q>> dequeueOption() {
+        return isEmpty() ? Option.none() : Option.some(dequeue());
+    }
+
+    /**
+     * Enqueues a new element.
+     *
+     * @param element The new element
+     * @return a new {@code Queue} instance, containing the new element
+     */
+    public abstract Q enqueue(T element);
+
+    /**
+     * Enqueues the given elements. A queue has FIFO order, i.e. the first of the given elements is
+     * the first which will be retrieved.
+     *
+     * @param elements Elements, may be empty
+     * @return a new {@code Queue} instance, containing the new elements
+     * @throws NullPointerException if elements is null
+     */
+    @SuppressWarnings("unchecked")
+    public Q enqueue(T... elements) {
+        Objects.requireNonNull(elements, "elements is null");
+        return enqueueAll(List.of(elements));
+    }
+
+    /**
+     * Enqueues the given elements. A queue has FIFO order, i.e. the first of the given elements is
+     * the first which will be retrieved.
+     *
+     * @param elements An Iterable of elements, may be empty
+     * @return a new {@code Queue} instance, containing the new elements
+     * @throws NullPointerException if elements is null
+     */
+    @SuppressWarnings("unchecked")
+    public Q enqueueAll(Iterable<? extends T> elements) {
+        Objects.requireNonNull(elements, "elements is null");
+
+        return List.ofAll(elements).foldLeft((Q) this, AbstractsQueue<T, Q>::enqueue);
+    }
+
+    /**
+     * Returns the first element without modifying it.
+     *
+     * @return the first element
+     * @throws NoSuchElementException if this Queue is empty
+     */
+    public T peek() {
+        if (isEmpty()) {
+            throw new NoSuchElementException("peek of empty " + getClass().getSimpleName());
+        } else {
+            return head();
+        }
+    }
+
+    /**
+     * Returns the first element without modifying the Queue.
+     *
+     * @return {@code None} if this Queue is empty, otherwise a {@code Some} containing the first element
+     */
+    public Option<T> peekOption() {
+        return isEmpty() ? Option.none() : Option.some(peek());
+    }
+
+    /**
+     * Dual of {@linkplain #tail()}, returning all elements except the last.
+     *
+     * @return a new instance containing all elements except the last.
+     * @throws UnsupportedOperationException if this is empty
+     */
+    @Override
+    public abstract Q init();
+
+    /**
+     * Dual of {@linkplain #tailOption()}, returning all elements except the last as {@code Option}.
+     *
+     * @return {@code Some(Q)} or {@code None} if this is empty.
+     */
+    @Override
+    public Option<Q> initOption() {
+        return isEmpty() ? Option.none() : Option.some(init());
+    }
+
+    /**
+     * Drops the first element of a non-empty Traversable.
+     *
+     * @return A new instance of Traversable containing all elements except the first.
+     * @throws UnsupportedOperationException if this is empty
+     */
+    @Override
+    public abstract Q tail();
+
+    @Override
+    public Option<Q> tailOption() {
+        return isEmpty() ? Option.none() : Option.some(tail());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Q retainAll(Iterable<? extends T> elements) {
+        return Collections.retainAll((Q) this, elements);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Q removeAll(Iterable<? extends T> elements) {
+        return Collections.removeAll((Q) this, elements);
+    }
+
+    @Override
+    public Q takeWhile(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return takeUntil(predicate.negate());
+    }
+
+    @Override
+    public abstract Q takeUntil(Predicate<? super T> predicate);
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Q peek(Consumer<? super T> action) {
+        Objects.requireNonNull(action, "action is null");
+        if (!isEmpty()) {
+            action.accept(head());
+        }
+        return (Q) this;
+    }
+
+    @Override
+    public int hashCode() {
+        return Collections.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        return mkString(stringPrefix() + "(", ", ", ")");
+    }
+
+}

--- a/javaslang/src/main/java/javaslang/collection/List.java
+++ b/javaslang/src/main/java/javaslang/collection/List.java
@@ -938,22 +938,21 @@ public interface List<T> extends Kind1<List<?>, T>, LinearSeq<T>, Stack<T> {
 
     @Override
     default List<T> remove(T element) {
-        List<T> preceding = Nil.instance();
-        List<T> tail = this;
+        final Deque<T> preceding = new ArrayDeque<>(size());
+        List<T> result = this;
         boolean found = false;
-        while (!found && !tail.isEmpty()) {
-            final T head = tail.head();
+        while (!found && !result.isEmpty()) {
+            final T head = result.head();
             if (head.equals(element)) {
                 found = true;
             } else {
-                preceding = preceding.prepend(head);
+                preceding.addFirst(head);
             }
-            tail = tail.tail();
+            result = result.tail();
         }
         if (!found) {
             return this;
         }
-        List<T> result = tail;
         for (T next : preceding) {
             result = result.prepend(next);
         }

--- a/javaslang/src/main/java/javaslang/collection/PriorityQueue.java
+++ b/javaslang/src/main/java/javaslang/collection/PriorityQueue.java
@@ -1,0 +1,737 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2016 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+import javaslang.*;
+import javaslang.collection.Comparators.SerializableComparator;
+import javaslang.collection.Tree.Node;
+
+import java.io.Serializable;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.Collector;
+
+import static javaslang.collection.Comparators.naturalComparator;
+import static javaslang.collection.PriorityQueue.PriorityQueueHelper.*;
+
+/**
+ * @author Pap Lőrinc
+ * @since 2.1.0
+ */
+public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> implements Serializable, Kind1<PriorityQueue<T>, T> {
+    private static final long serialVersionUID = 1L;
+
+    private final SerializableComparator<? super T> comparator;
+    private final List<Node<Ranked<T>>> forest;
+    private final int size;
+
+    private PriorityQueue(SerializableComparator<? super T> comparator, List<Node<Ranked<T>>> forest, int size) {
+        this.comparator = comparator;
+        this.forest = forest;
+        this.size = size;
+    }
+
+    private PriorityQueue<T> with(List<Node<Ranked<T>>> forest, int size) {
+        return new PriorityQueue<>(this.comparator, forest, size);
+    }
+
+    private PriorityQueue<T> with(SerializableComparator<? super T> comparator) {
+        return new PriorityQueue<>(comparator, this.forest, this.size);
+    }
+
+    /**
+     * Enqueues a new element.
+     *
+     * @param element The new element
+     * @return a new {@code PriorityQueue} instance, containing the new element
+     */
+    @Override
+    public PriorityQueue<T> enqueue(T element) {
+        final List<Node<Ranked<T>>> insert = insert(comparator, forest, element);
+        return with(insert, size + 1);
+    }
+
+    /**
+     * Enqueues the given elements.
+     *
+     * @param elements An {@link PriorityQueue} of elements, may be empty
+     * @return a new {@link PriorityQueue} instance, containing the new elements
+     * @throws NullPointerException if elements is null
+     */
+    @Override
+    public PriorityQueue<T> enqueueAll(Iterable<? extends T> elements) {
+        return merge(ofAll(comparator, elements));
+    }
+
+    /**
+     * Returns the first element of a non-empty {@link PriorityQueue}.
+     *
+     * @return The first element of this {@link PriorityQueue}.
+     * @throws NoSuchElementException if this is empty
+     */
+    @Override
+    public T head() {
+        if (isEmpty()) {
+            throw new NoSuchElementException("head of empty " + stringPrefix());
+        } else {
+            final T currentMin = root(forest.head());
+            return findMin(comparator, forest, currentMin);
+        }
+    }
+
+    /**
+     * Drops the first element of a non-empty {@link PriorityQueue}.
+     *
+     * @return A new instance of PriorityQueue containing all elements except the first.
+     * @throws UnsupportedOperationException if this is empty
+     */
+    @Override
+    public PriorityQueue<T> tail() {
+        if (isEmpty()) {
+            throw new UnsupportedOperationException("tail of empty " + stringPrefix());
+        } else {
+            final List<Node<Ranked<T>>> forest = deleteMin(comparator, this.forest);
+            return with(forest, this.size - 1);
+        }
+    }
+
+    public PriorityQueue<T> merge(PriorityQueue<T> target) {
+        final List<Node<Ranked<T>>> meld = meld(comparator, this.forest, target.forest);
+        return with(meld, this.size + target.size);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return forest.isEmpty();
+    }
+
+    /**
+     * Returns the empty PriorityQueue.
+     *
+     * @param <T> Component type
+     * @return The empty PriorityQueue.
+     */
+    public static <T extends Comparable<T>> PriorityQueue<T> empty() {
+        return empty(naturalComparator());
+    }
+
+    public static <T> PriorityQueue<T> empty(Comparator<? super T> comparator) {
+        return new PriorityQueue<>(SerializableComparator.of(comparator), List.empty(), 0);
+    }
+
+    /**
+     * Returns a {@link Collector} which may be used in conjunction with
+     * {@link java.util.stream.Stream#collect(Collector)} to obtain a {@code PriorityQueue<T>}.
+     *
+     * @param <T> Component type of the {@code PriorityQueue}.
+     * @return A {@code PriorityQueue<T>} Collector.
+     */
+    static <T> Collector<T, ArrayList<T>, PriorityQueue<T>> collector() {
+        final Supplier<ArrayList<T>> supplier = ArrayList::new;
+        final BiConsumer<ArrayList<T>, T> accumulator = ArrayList::add;
+        final BinaryOperator<ArrayList<T>> combiner = (left, right) -> {
+            left.addAll(right);
+            return left;
+        };
+        final Function<ArrayList<T>, PriorityQueue<T>> finisher = values -> ofAll(naturalComparator(), values);
+        return Collector.of(supplier, accumulator, combiner, finisher);
+    }
+
+    /**
+     * Narrows a widened {@code PriorityQueue<? extends T>} to {@code PriorityQueue<T>}
+     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * collections are covariant.
+     *
+     * @param queue An {@code PriorityQueue}.
+     * @param <T>   Component type of the {@code PriorityQueue}.
+     * @return the given {@code PriorityQueue} instance as narrowed type {@code PriorityQueue<T>}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> PriorityQueue<T> narrow(PriorityQueue<? extends T> queue) {
+        return (PriorityQueue<T>) queue;
+    }
+
+    public static <T extends Comparable<T>> PriorityQueue<T> of(T element) {
+        return of(naturalComparator(), element);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T extends Comparable<T>> PriorityQueue<T> of(T... elements) {
+        return ofAll(naturalComparator(), List.of(elements));
+    }
+
+    public static <T> PriorityQueue<T> of(Comparator<? super T> comparator, T element) {
+        return ofAll(comparator, List.of(element));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> PriorityQueue<T> of(Comparator<? super T> comparator, T... elements) {
+        return ofAll(comparator, List.of(elements));
+    }
+
+    public static <T extends Comparable<T>> PriorityQueue<T> ofAll(Iterable<? extends T> elements) {
+        return ofAll(naturalComparator(), elements);
+    }
+
+    public static <T> PriorityQueue<T> ofAll(Comparator<? super T> comparator, Iterable<? extends T> elements) {
+        Objects.requireNonNull(elements, "elements is null");
+
+        final List<T> values = List.ofAll(elements);
+        final SerializableComparator<? super T> serializableComparator = SerializableComparator.of(comparator);
+
+        return new PriorityQueue<>(serializableComparator, asForest(serializableComparator, values), values.size());
+    }
+
+    /**
+     * Returns a {@link PriorityQueue} containing {@code size} values of a given Function {@code function}
+     * over a range of integer values from {@code 0} to {@code size - 1}.
+     *
+     * @param <T>      Component type of the {@link PriorityQueue}
+     * @param size     The number of elements in the {@link PriorityQueue}
+     * @param function The Function computing element values
+     * @return A {@link PriorityQueue} consisting of elements {@code function(0),function(1), ..., function(size - 1)}
+     * @throws NullPointerException if {@code function} is null
+     */
+    static <T> PriorityQueue<T> tabulate(int size, Function<? super Integer, ? extends T> function) {
+        Objects.requireNonNull(function, "function is null");
+        final Comparator<? super T> comparator = naturalComparator();
+        return Collections.tabulate(size, function, empty(comparator), values -> ofAll(comparator, List.of(values)));
+    }
+
+    /**
+     * Returns a {@link PriorityQueue} containing {@code size} values supplied by a given Supplier {@code supplier}.
+     *
+     * @param <T>      Component type of the {@link PriorityQueue}
+     * @param size     The number of elements in the {@link PriorityQueue}
+     * @param supplier The Supplier computing element values
+     * @return A {@link PriorityQueue} of size {@code size}, where each element contains the result supplied by {@code supplier}.
+     * @throws NullPointerException if {@code supplier} is null
+     */
+    static <T> PriorityQueue<T> fill(int size, Supplier<? extends T> supplier) {
+        Objects.requireNonNull(supplier, "supplier is null");
+        final Comparator<? super T> comparator = naturalComparator();
+        return Collections.fill(size, supplier, empty(comparator), values -> ofAll(comparator, List.of(values)));
+    }
+
+    @Override
+    public List<T> toList() {
+        List<T> results = List.empty();
+        for (PriorityQueue<T> queue = this; !queue.isEmpty(); queue = queue.tail()) {
+            results = results.prepend(queue.head());
+        }
+        return results.reverse();
+    }
+
+    @Override
+    public PriorityQueue<T> distinct() {
+        return ofAll(comparator, iterator().distinctBy(comparator));
+    }
+
+    @Override
+    public <U> PriorityQueue<T> distinctBy(Function<? super T, ? extends U> keyExtractor) {
+        Objects.requireNonNull(keyExtractor, "keyExtractor is null");
+        final Comparator<? super T> comparator = (o1, o2) -> (keyExtractor.apply(o1) == keyExtractor.apply(o2)) ? 0 : -1;
+        return distinctBy(comparator);
+    }
+
+    @Override
+    @SuppressWarnings("TrivialMethodReference")
+    public PriorityQueue<T> distinctBy(Comparator<? super T> comparator) {
+        Objects.requireNonNull(comparator, "comparator is null");
+        return with(comparator::compare).distinct();
+    }
+
+    @Override
+    public PriorityQueue<T> drop(long n) {
+        PriorityQueue<T> result = this;
+        for (long i = n; i > 0 && !result.isEmpty(); i--) {
+            result = result.tail();
+        }
+        return result;
+    }
+
+    @Override
+    public PriorityQueue<T> dropRight(long n) {
+        if (n <= 0) {
+            return this;
+        } else if (n >= length()) {
+            return empty(comparator);
+        } else {
+            return ofAll(comparator, iterator().dropRight(n));
+        }
+    }
+
+    @Override
+    public PriorityQueue<T> dropUntil(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return dropWhile(predicate.negate());
+    }
+
+    @Override
+    public PriorityQueue<T> dropWhile(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        PriorityQueue<T> result = this;
+        while (!result.isEmpty() && predicate.test(result.head())) {
+            result = result.tail();
+        }
+        return result;
+    }
+
+    @Override
+    public PriorityQueue<T> filter(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return ofAll(comparator, iterator().filter(predicate));
+    }
+
+    @Override
+    public <U> PriorityQueue<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
+        return flatMap(naturalComparator(), mapper);
+    }
+
+    public <U> PriorityQueue<U> flatMap(Comparator<U> comparator, Function<? super T, ? extends Iterable<? extends U>> mapper) {
+        Objects.requireNonNull(comparator, "comparator is null");
+        Objects.requireNonNull(mapper, "mapper is null");
+        return ofAll(comparator, iterator().flatMap(mapper));
+    }
+
+    /**
+     * Accumulates the elements of this {@link PriorityQueue} by successively calling the given function {@code f} from the right,
+     * starting with a value {@code zero} of type B.
+     * <p>
+     * Example: {@code PriorityQueue.of("a", "b", "c").foldRight("", (x, xs) -> x + xs) = "abc"}
+     *
+     * @param zero        Value to start the accumulation with.
+     * @param accumulator The accumulator function.
+     * @return an accumulated version of this.
+     * @throws NullPointerException if {@code f} is null
+     */
+    @Override
+    public <U> U foldRight(U zero, BiFunction<? super T, ? super U, ? extends U> accumulator) {
+        Objects.requireNonNull(zero, "zero is null");
+        Objects.requireNonNull(accumulator, "accumulator is null");
+        return toList().foldRight(zero, accumulator);
+    }
+
+    @Override
+    public <C> Map<C, ? extends PriorityQueue<T>> groupBy(Function<? super T, ? extends C> classifier) {
+        Objects.requireNonNull(classifier, "classifier is null");
+        return iterator().groupBy(classifier).map((c, q) -> Tuple.of(c, ofAll(comparator, q)));
+    }
+
+    @Override
+    public Iterator<? extends PriorityQueue<T>> grouped(long size) {
+        return sliding(size, size);
+    }
+
+    /**
+     * Checks if this {@link PriorityQueue} is known to have a finite size.
+     * <p>
+     * This method should be implemented by classes only, i.e. not by interfaces.
+     *
+     * @return true, if this {@link PriorityQueue} is known to have a finite size, false otherwise.
+     */
+    @Override
+    public boolean hasDefiniteSize() {
+        return true;
+    }
+
+    /**
+     * Dual of {@linkplain #tail()}, returning all elements except the last.
+     *
+     * @return a new instance containing all elements except the last.
+     * @throws UnsupportedOperationException if this is empty
+     */
+    @Override
+    public PriorityQueue<T> init() {
+        return ofAll(comparator, iterator().init());
+    }
+
+    /**
+     * Checks if this {@link PriorityQueue} can be repeatedly traversed.
+     * <p>
+     * This method should be implemented by classes only, i.e. not by interfaces.
+     *
+     * @return true, if this {@link PriorityQueue} is known to be traversable repeatedly, false otherwise.
+     */
+    @Override
+    public boolean isTraversableAgain() {
+        return true;
+    }
+
+    /**
+     * Computes the number of elements of this {@link PriorityQueue}.
+     * <p>
+     * Same as {@link #size()}.
+     *
+     * @return the number of elements
+     */
+    @Override
+    public int length() {
+        return size;
+    }
+
+    @Override
+    public <U> PriorityQueue<U> map(Function<? super T, ? extends U> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        return map(naturalComparator(), mapper);
+    }
+
+    public <U> PriorityQueue<U> map(Comparator<U> comparator, Function<? super T, ? extends U> mapper) {
+        Objects.requireNonNull(comparator, "comparator is null");
+        Objects.requireNonNull(mapper, "mapper is null");
+        return ofAll(comparator, iterator().map(mapper));
+    }
+
+    @Override
+    public Tuple2<? extends PriorityQueue<T>, ? extends PriorityQueue<T>> partition(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        PriorityQueue<T> left = empty(comparator), right = left;
+        for (T t : this) {
+            if (predicate.test(t)) {
+                left = left.enqueue(t);
+            } else {
+                right = right.enqueue(t);
+            }
+        }
+        return Tuple.of(left, right);
+
+    }
+
+    @Override
+    public PriorityQueue<T> replace(T currentElement, T newElement) {
+        Objects.requireNonNull(currentElement, "currentElement is null");
+        Objects.requireNonNull(newElement, "newElement is null");
+        return ofAll(comparator, iterator().replace(currentElement, newElement));
+    }
+
+    @Override
+    public PriorityQueue<T> replaceAll(T currentElement, T newElement) {
+        Objects.requireNonNull(currentElement, "currentElement is null");
+        Objects.requireNonNull(newElement, "newElement is null");
+        return ofAll(comparator, iterator().replaceAll(currentElement, newElement));
+    }
+
+    @Override
+    public PriorityQueue<T> scan(T zero, BiFunction<? super T, ? super T, ? extends T> operation) {
+        return Collections.scanLeft(this, zero, operation, empty(comparator), PriorityQueue::enqueue, Function.identity());
+    }
+
+    @Override
+    public <U> PriorityQueue<U> scanLeft(U zero, BiFunction<? super U, ? super T, ? extends U> operation) {
+        Objects.requireNonNull(operation, "operation is null");
+        return Collections.scanLeft(this, zero, operation, empty(naturalComparator()), PriorityQueue::enqueue, Function.identity());
+    }
+
+    @Override
+    public <U> PriorityQueue<U> scanRight(U zero, BiFunction<? super T, ? super U, ? extends U> operation) {
+        Objects.requireNonNull(operation, "operation is null");
+        return Collections.scanRight(this, zero, operation, empty(naturalComparator()), PriorityQueue::enqueue, Function.identity());
+    }
+
+    @Override
+    public Iterator<? extends PriorityQueue<T>> sliding(long size) {
+        return iterator().sliding(size).map(v -> ofAll(comparator, v));
+    }
+
+    @Override
+    public Iterator<? extends PriorityQueue<T>> sliding(long size, long step) {
+        return iterator().sliding(size, step).map(v -> ofAll(comparator, v));
+    }
+
+    @Override
+    public Tuple2<? extends PriorityQueue<T>, ? extends PriorityQueue<T>> span(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return Tuple.of(takeWhile(predicate), dropWhile(predicate));
+    }
+
+    @Override
+    public PriorityQueue<T> take(long n) {
+        return ofAll(comparator, iterator().take(n));
+    }
+
+    @Override
+    public PriorityQueue<T> takeRight(long n) {
+        return ofAll(comparator, toList().takeRight(n));
+    }
+
+    @Override
+    public PriorityQueue<T> takeUntil(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return ofAll(comparator, iterator().takeUntil(predicate));
+    }
+
+    @Override
+    public <T1, T2> Tuple2<? extends PriorityQueue<T1>, ? extends PriorityQueue<T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
+        Objects.requireNonNull(unzipper, "unzipper is null");
+        final Tuple2<Iterator<T1>, Iterator<T2>> unzip = iterator().unzip(unzipper);
+        return Tuple.of(ofAll(naturalComparator(), unzip._1), ofAll(naturalComparator(), unzip._2));
+    }
+
+    @Override
+    public <T1, T2, T3> Tuple3<? extends PriorityQueue<T1>, ? extends PriorityQueue<T2>, ? extends PriorityQueue<T3>> unzip3(Function<? super T, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
+        Objects.requireNonNull(unzipper, "unzipper is null");
+        final Tuple3<Iterator<T1>, Iterator<T2>, Iterator<T3>> unzip3 = iterator().unzip3(unzipper);
+        return Tuple.of(ofAll(naturalComparator(), unzip3._1), ofAll(naturalComparator(), unzip3._2), ofAll(naturalComparator(), unzip3._3));
+    }
+
+    @Override
+    public <U> PriorityQueue<Tuple2<T, U>> zip(Iterable<? extends U> that) {
+        Objects.requireNonNull(that, "that is null");
+        return ofAll(iterator().zip(that));
+    }
+
+    @Override
+    public <U> PriorityQueue<Tuple2<T, U>> zipAll(Iterable<? extends U> that, T thisElem, U thatElem) {
+        Objects.requireNonNull(that, "that is null");
+        return ofAll(iterator().zipAll(that, thisElem, thatElem));
+    }
+
+    @Override
+    public PriorityQueue<Tuple2<T, Long>> zipWithIndex() {
+        return ofAll(iterator().zipWithIndex());
+    }
+
+    @Override
+    public Spliterator<T> spliterator() {
+        return Spliterators.spliterator(iterator(), length(), Spliterator.ORDERED | Spliterator.IMMUTABLE);
+    }
+
+    @Override
+    public String stringPrefix() {
+        return "PriorityQueue";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o == this || o instanceof PriorityQueue && Collections.equals(this, (Iterable) o);
+    }
+
+    protected static class PriorityQueueHelper {
+        /* Based on http://www.brics.dk/RS/96/37/BRICS-RS-96-37.pdf */
+
+        /*
+       * fun deleteMin [] = raise EMPTY
+       * * | deleteMin ts =
+       * *     let fun getMin [t]=(t, [])
+       * *           | getMin (t :: ts) =
+       * *               let val (t', ts') = getMin ts
+       * *               in if Elem.leq(root t, root t') then (t, ts)
+       * *                  else                              (t', t :: ts') end
+       * *         fun split (ts,xs,[]) = (ts, xs)
+       * *           | split (ts,xs,t :: c) =
+       * *               if rank t = 0 then split (ts,root t :: xs,c)
+       * *               else               split (t :: ts,xs,c)
+       * *         val (Node (x,r,c), ts) = getMin ts
+       * *         val (ts',xs') = split ([],[],c)
+       * * in fold insert xs' (meld (ts, ts')) end
+       * */
+        protected static <T> List<Node<Ranked<T>>> deleteMin(SerializableComparator<? super T> comparator, List<Node<Ranked<T>>> forest) {
+            if (forest.isEmpty()) {
+                throw new NoSuchElementException();
+            } else {
+                /* get the minimum tree and the rest of the forest */
+                final Node<Ranked<T>> minTree = forest.reduce((t1, t2) -> comparator.isLessOrEqual(root(t1), root(t2)) ? t1 : t2); // TODO could we use PriorityQueue here instead ... no, really
+                final List<Node<Ranked<T>>> forestTail = (minTree == forest.head()) ? forest.tail() : forest.remove(minTree);
+
+                final List<Node<Ranked<T>>> newForest = rebuild(comparator, minTree.getChildren());
+                return meld(comparator, newForest, forestTail);
+            }
+        }
+
+        /* Separate the rank 0 trees from the rest, rebuild the 0 rank ones and merge them back */
+        private static <T> List<Node<Ranked<T>>> rebuild(SerializableComparator<? super T> comparator, List<Node<Ranked<T>>> forest) {
+            List<Node<Ranked<T>>> nonZeroRank = List.empty(), zeroRank = List.empty();
+            for (; !forest.isEmpty(); forest = forest.tail()) {
+                final Node<Ranked<T>> initialForestHead = forest.head();
+                if (rank(initialForestHead) == 0) {
+                    zeroRank = insert(comparator, zeroRank, root(initialForestHead));
+                } else {
+                    nonZeroRank = concat(initialForestHead, nonZeroRank);
+                }
+            }
+            return meld(comparator, nonZeroRank, zeroRank);
+        }
+
+        /**
+         * fun insert (x, ts as t1 :: t2 :: rest) =
+         * *     if rank t1 = rank t2 then skewLink(Node(x,0,[]),t1,t2) :: rest
+         * *     else                      Node (x,0,[]) :: ts
+         * * | insert (x, ts) =            Node (x,0,[]) :: ts
+         **/
+        protected static <T> List<Node<Ranked<T>>> insert(SerializableComparator<? super T> comparator, List<Node<Ranked<T>>> forest, T element) {
+            Node<Ranked<T>> tree = Tree.of(Ranked.of(element, 0));
+            if (forest.size() >= 3) {
+                final Node<Ranked<T>> t1 = forest.head(), t2 = forest.get(1);
+                if (rank(t1) == rank(t2)) {
+                    forest = forest.drop(2);
+                    tree = skewLink(comparator, tree, t1, t2);
+                }
+            }
+            return concat(tree, forest);
+        }
+
+        protected static <T> List<Node<Ranked<T>>> asForest(SerializableComparator<? super T> comparator, Traversable<? extends T> targetValues) {
+            return targetValues.foldLeft(List.empty(), (f, e) -> insert(comparator, f, e));
+        }
+
+        /**
+         * fun meld (ts, ts') = meldUniq (uniqify ts, uniqify ts')
+         **/
+        protected static <T> List<Node<Ranked<T>>> meld(SerializableComparator<? super T> comparator, List<Node<Ranked<T>>> source, List<Node<Ranked<T>>> target) {
+            return meldUnique(comparator, uniqify(comparator, source), uniqify(comparator, target));
+        }
+
+        /**
+         * fun uniqify [] = []
+         * *  | uniqify (t :: ts) = ins (t, ts) (∗ eliminate initial duplicate ∗)
+         **/
+        private static <T> List<Node<Ranked<T>>> uniqify(SerializableComparator<? super T> comparator, List<Node<Ranked<T>>> forest) {
+            return forest.isEmpty()
+                    ? List.empty()
+                    : ins(comparator, forest.head(), forest.tail());
+        }
+
+        /**
+         * fun ins (t, []) = [t]
+         * * | ins (t, t' :: ts) = (∗ rank t ≤ rank t' ∗)
+         * *     if rank t < rank t' then t :: t' :: ts
+         * *     else                     ins (link (t, t'), ts)
+         */
+        private static <T> List<Node<Ranked<T>>> ins(SerializableComparator<? super T> comparator, Node<Ranked<T>> tree, List<Node<Ranked<T>>> forest) {
+            while (!forest.isEmpty() && rank(tree) >= rank(forest.head())) {
+                tree = link(comparator, tree, forest.head());
+                forest = forest.tail();
+            }
+            return concat(tree, forest);
+        }
+
+        /**
+         * fun meldUniq ([], ts) = ts
+         * *  | meldUniq (ts, []) = ts
+         * *  | meldUniq (t1 :: ts1, t2 :: ts2) =
+         * *      if rank t1 < rank t2 then      t1 :: meldUniq (ts1, t2 :: ts2)
+         * *      else if rank t2 < rank t1 then t2 :: meldUniq (t1 :: ts1, ts2)
+         * *      else                           ins (link (t1, t2), meldUniq (ts1, ts2))
+         **/
+        private static <T> List<Node<Ranked<T>>> meldUnique(SerializableComparator<? super T> comparator, List<Node<Ranked<T>>> forest1, List<Node<Ranked<T>>> forest2) {
+            if (forest1.isEmpty()) {
+                return forest2;
+            } else if (forest2.isEmpty()) {
+                return forest1;
+            } else {
+                final Node<Ranked<T>> tree1 = forest1.head(), tree2 = forest2.head();
+
+                if (rank(tree1) < rank(tree2)) {
+                    final List<Node<Ranked<T>>> tail = meldUnique(comparator, forest1.tail(), forest2);
+                    return concat(tree1, tail);
+                } else if (rank(tree1) > rank(tree2)) {
+                    final List<Node<Ranked<T>>> tail = meldUnique(comparator, forest1, forest2.tail());
+                    return concat(tree2, tail);
+                } else {
+                    final Node<Ranked<T>> link = link(comparator, tree1, tree2);
+                    final List<Node<Ranked<T>>> tail = meldUnique(comparator, forest1.tail(), forest2.tail());
+                    return ins(comparator, link, tail);
+                }
+            }
+        }
+
+        /**
+         * fun link (t1 as Node (x1,r1,c1), t2 as Node (x2,r2,c2)) = (∗ r1 = r2 ∗)
+         * *  if Elem.leq (x1,x2) then Node (x1,r1+1,t2 :: c1)
+         * *  else                     Node (x2,r2+1,t1 :: c2
+         */
+        private static <T> Node<Ranked<T>> link(SerializableComparator<? super T> comparator, Node<Ranked<T>> tree1, Node<Ranked<T>> tree2) {
+            final T root1 = root(tree1), root2 = root(tree2);
+
+            final Ranked<T> ranked;
+            final List<Node<Ranked<T>>> children;
+            if (comparator.isLessOrEqual(root1, root2)) {
+                ranked = Ranked.of(root1, rank(tree1) + 1);
+                children = concat(tree2, tree1.getChildren());
+            } else {
+                ranked = Ranked.of(root2, rank(tree2) + 1);
+                children = concat(tree1, tree2.getChildren());
+            }
+            return Tree.of(ranked, children);
+        }
+
+        /**
+         * fun skewLink (t0 as Node (x0,r0, _), t1 as Node (x1,r1,c1), t2 as Node (x2,r2,c2)) =
+         * *  if Elem.leq (x1,x0) andalso Elem.leq (x1,x2) then      Node (x1,r1+1,t0 :: t2 :: c1)
+         * *  else if Elem.leq (x2,x0) andalso Elem.leq (x2,x1) then Node (x2,r2+1,t0 :: t1 :: c2)
+         * *  else                                                   Node (x0,r1+1,[t1, t2])
+         **/
+        private static <T> Node<Ranked<T>> skewLink(SerializableComparator<? super T> comparator, Node<Ranked<T>> tree0, Node<Ranked<T>> tree1, Node<Ranked<T>> tree2) {
+            final T root0 = root(tree0), root1 = root(tree1), root2 = root(tree2);
+
+            final Ranked<T> ranked;
+            final List<Node<Ranked<T>>> children;
+            if (comparator.isLessOrEqual(root1, root0) && comparator.isLessOrEqual(root1, root2)) {
+                ranked = Ranked.of(root1, rank(tree1) + 1);
+                children = concat(tree0, concat(tree2, tree1.getChildren()));
+            } else if (comparator.isLessOrEqual(root2, root0) && comparator.isLessOrEqual(root2, root1)) {
+                ranked = Ranked.of(root2, rank(tree2) + 1);
+                children = concat(tree0, concat(tree1, tree2.getChildren()));
+            } else {
+                ranked = Ranked.of(root0, rank(tree1) + 1);
+                children = List.of(tree1, tree2);
+            }
+            return Tree.of(ranked, children);
+        }
+
+        /**
+         * fun findMin [] = raise EMPTY
+         * * | findMin [t] = root t
+         * * | findMin (t :: ts) =
+         * *     let val x = findMin ts
+         * *     in if Elem.leq (root t, x) then root t else x end
+         */
+        protected static <T> T findMin(SerializableComparator<? super T> comparator, List<Node<Ranked<T>>> forest, T currentMin) {
+            while (forest.size() > 1) {
+                forest = forest.tail();
+                currentMin = min(comparator, currentMin, root(forest.head()));
+            }
+            return currentMin;
+        }
+
+        private static <T> T min(SerializableComparator<? super T> comparator, T value1, T value2) {
+            return comparator.isLessOrEqual(value1, value2) ? value1 : value2;
+        }
+
+        protected static <T> T root(Node<Ranked<T>> tree) {
+            return tree.getValue().value;
+        }
+
+        private static <T> int rank(Node<Ranked<T>> tree) {
+            return tree.getValue().rank;
+        }
+
+        private static <T> List<T> concat(T head, List<T> rest) {
+            return rest.prepend(head);
+        }
+
+        protected static class Ranked<T> implements Serializable {
+            private static final long serialVersionUID = 1L;
+
+            final T value;
+            final int rank;
+
+            Ranked(T value, int rank) {
+                this.value = value;
+                this.rank = rank;
+            }
+
+            static <T> Ranked<T> of(T value, int rank) {
+                return new Ranked<>(value, rank);
+            }
+
+            @Override
+            public String toString() {
+                return "Ranked(" + value + ", " + rank + ')';
+            }
+        }
+    }
+}

--- a/javaslang/src/test/java/javaslang/AbstractValueTest.java
+++ b/javaslang/src/test/java/javaslang/AbstractValueTest.java
@@ -10,6 +10,7 @@ import javaslang.collection.HashMap;
 import javaslang.collection.HashSet;
 import javaslang.collection.List;
 import javaslang.collection.Map;
+import javaslang.collection.PriorityQueue;
 import javaslang.collection.Queue;
 import javaslang.collection.Set;
 import javaslang.collection.Stack;
@@ -239,6 +240,17 @@ public abstract class AbstractValueTest {
             assertThat(queue).isEqualTo(Queue.of(1));
         } else {
             assertThat(queue).isEqualTo(Queue.of(1, 2, 3));
+        }
+    }
+
+    @Test
+    public void shouldConvertToSortedQueue() {
+        final Value<Integer> value = of(1, 3, 2);
+        final PriorityQueue<Integer> queue = value.toSortedQueue(Comparator.naturalOrder());
+        if (value.isSingleValued()) {
+            assertThat(queue).isEqualTo(PriorityQueue.of(1));
+        } else {
+            assertThat(queue).isEqualTo(PriorityQueue.of(1, 2, 3));
         }
     }
 

--- a/javaslang/src/test/java/javaslang/collection/AbstractSeqTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractSeqTest.java
@@ -933,6 +933,11 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     }
 
     @Test
+    public void shouldNotRemoveDuplicateElement() {
+        assertThat(of(1, 2, 3, 1, 2).remove(2)).isEqualTo(of(1, 3, 1, 2));
+    }
+
+    @Test
     public void shouldRemoveNonExistingElement() {
         final Seq<Integer> t = of(1, 2, 3);
         if (useIsEqualToInsteadOfIsSameAs()) {

--- a/javaslang/src/test/java/javaslang/collection/AbstractTraversableTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractTraversableTest.java
@@ -315,7 +315,9 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
     @Test
     public void shouldComputeDistinctByOfNonEmptyTraversableUsingComparator() {
         final Comparator<String> comparator = (s1, s2) -> (s1.charAt(1)) - (s2.charAt(1));
-        assertThat(of("1a", "2a", "3a", "3b", "4b", "5c").distinctBy(comparator)).isEqualTo(of("1a", "3b", "5c"));
+
+        final Traversable<String> distinct = of("1a", "2a", "3a", "3b", "4b", "5c").distinctBy(comparator).map(s -> s.substring(1));
+        assertThat(distinct).isEqualTo(of("a", "b", "c"));
     }
 
     // -- distinct(Function)
@@ -331,8 +333,9 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
 
     @Test
     public void shouldComputeDistinctByOfNonEmptyTraversableUsingKeyExtractor() {
-        assertThat(of("1a", "2a", "3a", "3b", "4b", "5c").distinctBy(c -> c.charAt(1)))
-                .isEqualTo(of("1a", "3b", "5c"));
+        final Function<String, Character> function = c -> c.charAt(1);
+        final Traversable<String> distinct = of("1a", "2a", "3a", "3b", "4b", "5c").distinctBy(function).map(s -> s.substring(1));
+        assertThat(distinct).isEqualTo(of("a", "b", "c"));
     }
 
     // -- drop
@@ -1418,6 +1421,7 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         final List<NonComparable> actual = List.ofAll(testee.scan(new NonComparable("x"), (u1, u2) -> new NonComparable(u1.value + u2.value)));
         final List<NonComparable> expected = List.of("x", "xa").map(NonComparable::new);
         assertThat(actual).containsAll(expected);
+        assertThat(expected).containsAll(actual);
         assertThat(actual.length()).isEqualTo(expected.length());
     }
 
@@ -1427,6 +1431,7 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         final List<NonComparable> actual = List.ofAll(testee.scanLeft(new NonComparable("x"), (u1, u2) -> new NonComparable(u1.value + u2.value)));
         final List<NonComparable> expected = List.of("x", "xa").map(NonComparable::new);
         assertThat(actual).containsAll(expected);
+        assertThat(expected).containsAll(actual);
         assertThat(actual.length()).isEqualTo(expected.length());
     }
 
@@ -1436,6 +1441,7 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         final List<NonComparable> actual = List.ofAll(testee.scanRight(new NonComparable("x"), (u1, u2) -> new NonComparable(u1.value + u2.value)));
         final List<NonComparable> expected = List.of("ax", "x").map(NonComparable::new);
         assertThat(actual).containsAll(expected);
+        assertThat(expected).containsAll(actual);
         assertThat(actual.length()).isEqualTo(expected.length());
     }
 
@@ -2145,8 +2151,8 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
 
     @Test
     public void shouldPreserveSingletonInstanceOnDeserialization() {
-        final boolean actual = deserialize(serialize(empty())) == empty();
-        assertThat(actual).isTrue();
+        final Object actual = deserialize(serialize(empty()));
+        assertThat(actual).isSameAs(empty());
     }
 
     @Test
@@ -2235,13 +2241,13 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
 
     @Test
     public void ofShouldReturnTheSingletonEmpty() {
-        if (!emptyShouldBeSingleton()) return;
+        if (!emptyShouldBeSingleton()) { return; }
         assertThat(of()).isSameAs(empty());
     }
 
     @Test
     public void ofAllShouldReturnTheSingletonEmpty() {
-        if (!emptyShouldBeSingleton()) return;
+        if (!emptyShouldBeSingleton()) { return; }
         assertThat(ofAll(Iterator.empty())).isSameAs(empty());
     }
 

--- a/javaslang/src/test/java/javaslang/collection/PriorityQueueTest.java
+++ b/javaslang/src/test/java/javaslang/collection/PriorityQueueTest.java
@@ -1,0 +1,253 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2016 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+import javaslang.Tuple;
+import javaslang.collection.Comparators.SerializableComparator;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.Collector;
+
+import static java.lang.Integer.bitCount;
+import static java.util.stream.Collectors.toList;
+import static javaslang.collection.Comparators.naturalComparator;
+
+public class PriorityQueueTest extends AbstractTraversableTest {
+    private final List<Integer> values = List.of(3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3, 2, 3, 8, 4, 6, 2, 6, 4, 3, 3, 8, 3, 2, 7, 9, 5, 0, 2, 8, 8, 4, 1, 9, 7, 1, 6, 9, 3, 9, 9, 3, 7, 5, 1, 0);
+
+    @Override
+    protected <T> Collector<T, ArrayList<T>, PriorityQueue<T>> collector() {
+        return PriorityQueue.collector();
+    }
+
+    @Override
+    protected <T> PriorityQueue<T> empty() {
+        return PriorityQueue.empty(toStringComparator());
+    }
+
+    @Override
+    protected <T> PriorityQueue<T> of(T element) {
+        return PriorityQueue.ofAll(toStringComparator(), List.of(element));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected final <T> PriorityQueue<T> of(T... elements) {
+        return PriorityQueue.ofAll(toStringComparator(), List.of(elements));
+    }
+
+    @Override
+    protected <T> PriorityQueue<T> ofAll(Iterable<? extends T> elements) {
+        return PriorityQueue.ofAll(toStringComparator(), elements);
+    }
+
+    @Override
+    protected PriorityQueue<Boolean> ofAll(boolean[] array) {
+        return PriorityQueue.ofAll(List.ofAll(array));
+    }
+
+    @Override
+    protected PriorityQueue<Byte> ofAll(byte[] array) {
+        return PriorityQueue.ofAll(List.ofAll(array));
+    }
+
+    @Override
+    protected PriorityQueue<Character> ofAll(char[] array) {
+        return PriorityQueue.ofAll(List.ofAll(array));
+    }
+
+    @Override
+    protected PriorityQueue<Double> ofAll(double[] array) {
+        return PriorityQueue.ofAll(List.ofAll(array));
+    }
+
+    @Override
+    protected PriorityQueue<Float> ofAll(float[] array) {
+        return PriorityQueue.ofAll(List.ofAll(array));
+    }
+
+    @Override
+    protected PriorityQueue<Integer> ofAll(int[] array) {
+        return PriorityQueue.ofAll(List.ofAll(array));
+    }
+
+    @Override
+    protected PriorityQueue<Long> ofAll(long[] array) {
+        return PriorityQueue.ofAll(List.ofAll(array));
+    }
+
+    @Override
+    protected PriorityQueue<Short> ofAll(short[] array) {
+        return PriorityQueue.ofAll(List.ofAll(array));
+    }
+
+    @Override
+    protected <T> PriorityQueue<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
+        return PriorityQueue.tabulate(n, f);
+    }
+
+    @Override
+    protected <T> PriorityQueue<T> fill(int n, Supplier<? extends T> s) {
+        return PriorityQueue.fill(n, s);
+    }
+
+    @Override
+    protected boolean useIsEqualToInsteadOfIsSameAs() {
+        return true;
+    }
+
+    @Override
+    protected int getPeekNonNilPerformingAnAction() {
+        return 1;
+    }
+
+    @Override
+    protected boolean emptyShouldBeSingleton() {
+        return false;
+    }
+
+    private static SerializableComparator<Object> toStringComparator() {
+        return (o1, o2) -> String.valueOf(o1).compareTo(String.valueOf(o2));
+    }
+
+    private static Comparator<Integer> composedComparator() {
+        final Comparator<Integer> bitCountComparator = (o1, o2) -> Integer.compare(bitCount(o1), bitCount(o2));
+        return bitCountComparator.thenComparing(naturalComparator());
+    }
+
+    @Test
+    @Override
+    public void shouldScanLeftWithNonComparable() {
+        // The resulting type would need a comparator
+    }
+
+    @Test
+    @Override
+    public void shouldScanRightWithNonComparable() {
+        // The resulting type would need a comparator
+    }
+
+    @Override
+    public void shouldPreserveSingletonInstanceOnDeserialization() {
+        // The empty PriorityQueue encapsulates a comparator and therefore cannot be a singleton
+    }
+
+    // -- static narrow
+
+    @Test
+    public void shouldNarrowQueue() {
+        final PriorityQueue<Double> doubles = of(1.0d);
+        final PriorityQueue<Number> numbers = PriorityQueue.narrow(doubles);
+        final int actual = numbers.enqueue(new BigDecimal("2.0")).sum().intValue();
+        assertThat(actual).isEqualTo(3);
+    }
+
+    // -- toList
+
+    @Test
+    public void toListIsSortedAccordingToComparator() {
+        final Comparator<Integer> comparator = composedComparator();
+        final PriorityQueue<Integer> queue = PriorityQueue.ofAll(comparator, values);
+        assertThat(queue.toList()).isEqualTo(values.sorted(comparator));
+    }
+
+    // -- merge
+
+    @Test
+    public void shouldMergeTwoPriorityQueues() {
+        final PriorityQueue<Integer> source = of(3, 1, 4, 1, 5);
+        final PriorityQueue<Integer> target = of(9, 2, 6, 5, 3);
+        assertThat(source.merge(target)).isEqualTo(of(3, 1, 4, 1, 5, 9, 2, 6, 5, 3));
+
+        assertThat(PriorityQueue.of(3).merge(PriorityQueue.of(toStringComparator(), 1))).isEqualTo(of(3, 1));
+    }
+
+    // -- distinct
+
+    @Test
+    public void shouldComputeDistinctOfNonEmptyTraversableUsingKeyExtractor() {
+        final Comparator<String> comparator = (o1, o2) -> Integer.compare(o1.charAt(1), o2.charAt(1));
+        assertThat(PriorityQueue.of(comparator, "5c", "1a", "3a", "1a", "2a", "4b", "3b").distinct().map(s -> s.substring(1))).isEqualTo(of("a", "b", "c"));
+    }
+
+    // -- removeAll
+
+    @Test
+    public void shouldRemoveAllElements() {
+        assertThat(of(3, 1, 4, 1, 5, 9, 2, 6).removeAll(of(1, 9, 1, 2))).isEqualTo(of(3, 4, 5, 6));
+    }
+
+    // -- enqueueAll
+
+    @Test
+    public void shouldEnqueueAllElements() {
+        assertThat(of(3, 1, 4).enqueueAll(of(1, 5, 9, 2))).isEqualTo(of(3, 1, 4, 1, 5, 9, 2));
+    }
+
+    // -- peek
+
+    @Test(expected = NoSuchElementException.class)
+    public void shouldFailPeekOfEmpty() {
+        empty().peek();
+    }
+
+    // -- dequeue
+
+    @Test
+    public void shouldDeque() {
+        assertThat(of(3, 1, 4, 1, 5).dequeue()).isEqualTo(Tuple.of(1, of(3, 4, 1, 5)));
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void shouldFailDequeueOfEmpty() {
+        empty().dequeue();
+    }
+
+    // -- property based tests
+
+    @Test
+    public void shouldBehaveExactlyLikeAnotherPriorityQueue() {
+        final Random random = new Random();
+
+        final java.util.PriorityQueue<Integer> mutablePriorityQueue = new java.util.PriorityQueue<>();
+        javaslang.collection.PriorityQueue<Integer> functionalPriorityQueue = javaslang.collection.PriorityQueue.empty();
+
+        for (int i = 0; i < 1_000_000; i++) {
+            /* Insert */
+            if (random.nextInt() % 3 == 0) {
+                assertMinimumsAreEqual(mutablePriorityQueue, functionalPriorityQueue);
+
+                final int value = random.nextInt();
+                mutablePriorityQueue.add(value);
+                functionalPriorityQueue = functionalPriorityQueue.enqueue(value);
+            }
+
+            assertMinimumsAreEqual(mutablePriorityQueue, functionalPriorityQueue);
+
+            /* Delete */
+            if (random.nextInt() % 5 == 0) {
+                if (!mutablePriorityQueue.isEmpty()) { mutablePriorityQueue.poll(); }
+                if (!functionalPriorityQueue.isEmpty()) { functionalPriorityQueue = functionalPriorityQueue.tail(); }
+
+                assertMinimumsAreEqual(mutablePriorityQueue, functionalPriorityQueue);
+            }
+        }
+
+        final Collection<Integer> oldValues = mutablePriorityQueue.stream().sorted().collect(toList());
+        final Collection<Integer> newValues = functionalPriorityQueue.toJavaList();
+        assertThat(oldValues).isEqualTo(newValues);
+    }
+
+    private void assertMinimumsAreEqual(java.util.PriorityQueue<Integer> oldQueue, PriorityQueue<Integer> newQueue) {
+        assertThat(oldQueue.isEmpty()).isEqualTo(newQueue.isEmpty());
+        if (!newQueue.isEmpty()) {
+            assertThat(oldQueue.peek()).isEqualTo(newQueue.head());
+        }
+    }
+}

--- a/javaslang/src/test/java/javaslang/collection/PriorityQueueTest.java
+++ b/javaslang/src/test/java/javaslang/collection/PriorityQueueTest.java
@@ -224,35 +224,49 @@ public class PriorityQueueTest extends AbstractTraversableTest {
 
     @Test
     public void shouldBehaveExactlyLikeAnotherPriorityQueue() {
-        final Random random = new Random();
+        for (int i = 0; i < 10; i++) {
+            final Random random = getRandom(-1);
 
-        final java.util.PriorityQueue<Integer> mutablePriorityQueue = new java.util.PriorityQueue<>();
-        javaslang.collection.PriorityQueue<Integer> functionalPriorityQueue = javaslang.collection.PriorityQueue.empty();
+            final java.util.PriorityQueue<Integer> mutablePriorityQueue = new java.util.PriorityQueue<>();
+            javaslang.collection.PriorityQueue<Integer> functionalPriorityQueue = javaslang.collection.PriorityQueue.empty();
 
-        for (int i = 0; i < 1_000_000; i++) {
+            for (int j = 0; j < 100_000; j++) {
             /* Insert */
-            if (random.nextInt() % 3 == 0) {
+                if (random.nextInt() % 3 == 0) {
+                    assertMinimumsAreEqual(mutablePriorityQueue, functionalPriorityQueue);
+
+                    final int value = random.nextInt();
+                    mutablePriorityQueue.add(value);
+                    functionalPriorityQueue = functionalPriorityQueue.enqueue(value);
+                }
+
                 assertMinimumsAreEqual(mutablePriorityQueue, functionalPriorityQueue);
-
-                final int value = random.nextInt();
-                mutablePriorityQueue.add(value);
-                functionalPriorityQueue = functionalPriorityQueue.enqueue(value);
-            }
-
-            assertMinimumsAreEqual(mutablePriorityQueue, functionalPriorityQueue);
 
             /* Delete */
-            if (random.nextInt() % 5 == 0) {
-                if (!mutablePriorityQueue.isEmpty()) { mutablePriorityQueue.poll(); }
-                if (!functionalPriorityQueue.isEmpty()) { functionalPriorityQueue = functionalPriorityQueue.tail(); }
+                if (random.nextInt() % 5 == 0) {
+                    if (!mutablePriorityQueue.isEmpty()) { mutablePriorityQueue.poll(); }
+                    if (!functionalPriorityQueue.isEmpty()) { functionalPriorityQueue = functionalPriorityQueue.tail(); }
 
-                assertMinimumsAreEqual(mutablePriorityQueue, functionalPriorityQueue);
+                    assertMinimumsAreEqual(mutablePriorityQueue, functionalPriorityQueue);
+                }
             }
-        }
 
-        final Collection<Integer> oldValues = mutablePriorityQueue.stream().sorted().collect(toList());
-        final Collection<Integer> newValues = functionalPriorityQueue.toJavaList();
-        assertThat(oldValues).isEqualTo(newValues);
+            final Collection<Integer> oldValues = mutablePriorityQueue.stream().sorted().collect(toList());
+            final Collection<Integer> newValues = functionalPriorityQueue.toJavaList();
+            assertThat(oldValues).isEqualTo(newValues);
+        }
+    }
+
+    private Random getRandom(int seed) {
+        if (seed >= 0) {
+            return new Random(seed);
+        } else {
+            final Random random = new Random();
+            seed = random.nextInt();
+            System.out.println("using seed: " + seed);
+            random.setSeed(seed);
+            return random;
+        }
     }
 
     private void assertMinimumsAreEqual(java.util.PriorityQueue<Integer> oldQueue, PriorityQueue<Integer> newQueue) {

--- a/javaslang/src/test/java/javaslang/collection/PriorityQueueTest.java
+++ b/javaslang/src/test/java/javaslang/collection/PriorityQueueTest.java
@@ -209,6 +209,17 @@ public class PriorityQueueTest extends AbstractTraversableTest {
         empty().dequeue();
     }
 
+    // -- toSortedQueue
+
+    @Test
+    public void shouldKeepInstanceOfSortedQueue() {
+        final SerializableComparator<Integer> comparator = naturalComparator();
+        final PriorityQueue<Integer> queue = PriorityQueue.of(comparator, 1, 3, 2);
+        if (!queue.isSingleValued()) {
+            assertThat(queue.toSortedQueue(comparator)).isSameAs(queue);
+        }
+    }
+
     // -- property based tests
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@ Note: The maven build currently needs to be started from the javaslang root dir
         <assertj.core.version>3.3.0</assertj.core.version>
         <eclipse.lifecycle.mapping.version>1.0.0</eclipse.lifecycle.mapping.version>
         <java.version>1.8</java.version>
-        <jmh.version>1.11.3</jmh.version>
+        <jmh.version>1.12</jmh.version>
         <junit.version>4.12</junit.version>
         <maven.build-helper.version>1.9.1</maven.build-helper.version>
         <maven.bundle.version>3.0.1</maven.bundle.version>


### PR DESCRIPTION
Fixes https://github.com/javaslang/javaslang/issues/1264

TODO:
* Understand what I just implemented :p
 * http://www.brics.dk/RS/96/37/BRICS-RS-96-37.pdf
 * https://en.wikipedia.org/wiki/Binomial_heap
 * http://scottlobdell.me/2016/04/purely-functional-data-structures-python
* make the rest of the methods `O(1)` by providing a global forest root and via bootstrapping, described above 
* Add proper documentation