### PR TITLE
New static method Stream.ofString

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/Stream.java
+++ b/javaslang/src/main/java/javaslang/collection/Stream.java
@@ -351,6 +351,17 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
     }
 
     /**
+     * Creates a Stream based on the string characters.
+     *
+     * @param value string value
+     * @return A new Stream of Character values
+     */
+    static Stream<Character> ofString(String value) {
+        Objects.requireNonNull(value, "string value is null");
+        return Stream.ofAll(value.toCharArray());
+    }
+
+    /**
      * Creates a Stream based on the elements of a double array.
      *
      * @param array a double array

--- a/javaslang/src/test/java/javaslang/collection/StreamTest.java
+++ b/javaslang/src/test/java/javaslang/collection/StreamTest.java
@@ -586,6 +586,11 @@ public class StreamTest extends AbstractLinearSeqTest {
 
     }
 
+    @Test
+    public void shouldReturnStringAsStreamOfCharacterValues() {
+        assertThat(Stream.ofString("123qazWER")).containsExactly('1', '2', '3', 'q', 'a', 'z', 'W', 'E', 'R');
+    }
+
     private boolean hiddenThrow(final int i) {
         if (i == 0) {
             return true;


### PR DESCRIPTION
Right now for creating Stream object from String object we need to use something like this:
```
Stream.ofAll(s.toCharArray());
```
But it may be a little bit easier with one new static method like this:
```
Stream.ofString(s);
```