### PR TITLE
Added benchmarks for `List` and `Array`

### DIFF
--- a/javaslang-benchmark/pom.xml
+++ b/javaslang-benchmark/pom.xml
@@ -33,6 +33,21 @@
             <version>7.3.0-M1</version>
         </dependency>
         <dependency>
+            <groupId>org.pcollections</groupId>
+            <artifactId>pcollections</artifactId>
+            <version>2.1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.functionaljava</groupId>
+            <artifactId>functionaljava</artifactId>
+            <version>4.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>15.0</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/ArrayBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/ArrayBenchmark.java
@@ -1,0 +1,129 @@
+package javaslang.benchmark;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.*;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static javaslang.benchmark.BenchmarkResultAggregator.displayRatios;
+
+public class ArrayBenchmark {
+    public static void main(String... args) throws Exception { /* main is more reliable than a test */
+        final Options opts = new OptionsBuilder()
+                .include(ArrayBenchmark.class.getSimpleName())
+                .shouldDoGC(false)
+                .shouldFailOnError(true)
+                .build();
+
+        final Collection<RunResult> results = new Runner(opts).run();
+        displayRatios(results, "^slang.+$");
+    }
+
+    @State(Scope.Benchmark)
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Fork(value = 1, jvmArgsAppend = { "-XX:+UseG1GC", "-Xss100m", "-Xms1g", "-Xmx1g", "-disableassertions" }) /* set fork to 0 if you want to debug */
+    public static class Base {
+        @Param({ "10", "100", "1000" })
+        public int CONTAINER_SIZE;
+
+        public Integer[] ELEMENTS;
+
+        @Setup
+        public void setup() {
+            final Random random = new Random(0);
+
+            ELEMENTS = new Integer[CONTAINER_SIZE];
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                final int value = random.nextInt(CONTAINER_SIZE) - (CONTAINER_SIZE / 2);
+                ELEMENTS[i] = value;
+            }
+        }
+
+        protected static <T> void assertEquals(T a, T b) {
+            if (!Objects.equals(a, b)) {
+                throw new IllegalStateException(a + " != " + b);
+            }
+        }
+    }
+
+    public static class AddAll extends Base {
+        @Benchmark
+        @SuppressWarnings("ManualArrayCopy")
+        public void java_mutable() {
+            final Integer[] values = new Integer[ELEMENTS.length];
+            for (int i = 0; i < ELEMENTS.length; i++) {
+                values[i] = ELEMENTS[i];
+            }
+            assertEquals(values.length, CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            javaslang.collection.Array<Integer> values = javaslang.collection.Array.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.append(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+    }
+
+    public static class Iterate extends Base {
+        @State(Scope.Thread)
+        public static class Initialized {
+            Integer[] javaMutable;
+
+            int expectedAggregate = 0;
+            javaslang.collection.Array<Integer> slangPersistent = javaslang.collection.Array.empty();
+
+            @Setup(Level.Invocation)
+            public void initializeMutable(Base state) {
+                assertEquals(javaMutable, null);
+                javaMutable = state.ELEMENTS.clone();
+                assertEquals(javaMutable.length, state.CONTAINER_SIZE);
+
+                if (expectedAggregate == 0) {
+                    for (Integer element : state.ELEMENTS) {
+                        expectedAggregate ^= element;
+                    }
+
+                    assertEquals(slangPersistent.size(), 0);
+                    for (Integer element : state.ELEMENTS) {
+                        slangPersistent = slangPersistent.prepend(element);
+                    }
+                    assertEquals(slangPersistent.size(), state.CONTAINER_SIZE);
+                }
+            }
+
+            @TearDown(Level.Invocation)
+            public void tearDown() {
+                javaMutable = null;
+            }
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void java_mutable(Initialized state) {
+            int aggregate = 0;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                aggregate ^= state.javaMutable[i];
+            }
+            assertEquals(aggregate, state.expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void slang_persistent(Initialized state) {
+            int aggregate = 0;
+            for (javaslang.collection.Array<Integer> values = state.slangPersistent; !values.isEmpty(); values = values.tail()) {
+                aggregate ^= values.head();
+            }
+            assertEquals(aggregate, state.expectedAggregate);
+        }
+    }
+}

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/ListBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/ListBenchmark.java
@@ -1,0 +1,249 @@
+package javaslang.benchmark;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.*;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static javaslang.benchmark.BenchmarkResultAggregator.displayRatios;
+
+public class ListBenchmark {
+    public static void main(String... args) throws Exception { /* main is more reliable than a test */
+        final Options opts = new OptionsBuilder()
+                .include(ListBenchmark.class.getSimpleName())
+                .shouldDoGC(false)
+                .shouldFailOnError(true)
+                .build();
+
+        final Collection<RunResult> results = new Runner(opts).run();
+        displayRatios(results, "^slang.+$");
+    }
+
+    @State(Scope.Benchmark)
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Warmup(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Fork(value = 1, jvmArgsAppend = { "-XX:+UseG1GC", "-Xss100m", "-Xms1g", "-Xmx1g", "-disableassertions" }) /* set fork to 0 if you want to debug */
+    public static class Base {
+        @Param({ "10", "100", "1000", "10000" })
+        public int CONTAINER_SIZE;
+
+        public Integer[] ELEMENTS;
+
+        @Setup
+        public void setup() {
+            final Random random = new Random(0);
+
+            ELEMENTS = new Integer[CONTAINER_SIZE];
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                final int value = random.nextInt(CONTAINER_SIZE) - (CONTAINER_SIZE / 2);
+                ELEMENTS[i] = value;
+            }
+        }
+
+        protected static <T> void assertEquals(T a, T b) {
+            if (!Objects.equals(a, b)) {
+                throw new IllegalStateException(a + " != " + b);
+            }
+        }
+    }
+
+    public static class AddAll extends Base {
+        @Benchmark
+        @SuppressWarnings("ManualArrayToCollectionCopy")
+        public void java_mutable() {
+            final java.util.ArrayList<Integer> values = new java.util.ArrayList<>(ELEMENTS.length);
+            for (Integer element : ELEMENTS) {
+                values.add(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ManualArrayToCollectionCopy")
+        public void java_mutable_linked() {
+            final java.util.LinkedList<Integer> values = new java.util.LinkedList<>();
+            for (Integer element : ELEMENTS) {
+                values.add(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void scala_mutable() {
+            final scala.collection.mutable.MutableList<Integer> values = new scala.collection.mutable.MutableList<>();
+            for (Integer element : ELEMENTS) {
+                values.prependElem(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void scala_persistent() {
+            scala.collection.immutable.List<Integer> values = scala.collection.immutable.List$.MODULE$.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.$colon$colon(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void fjava_persistent() {
+            fj.data.List<Integer> values = fj.data.List.list();
+            for (Integer element : ELEMENTS) {
+                values = values.cons(element);
+            }
+            assertEquals(values.length(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void pcollections_persistent() {
+            org.pcollections.PStack<Integer> values = org.pcollections.ConsPStack.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.plus(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            javaslang.collection.List<Integer> values = javaslang.collection.List.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.prepend(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+    }
+
+    public static class Iterate extends Base {
+        @State(Scope.Thread)
+        public static class Initialized {
+            final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
+            final java.util.LinkedList<Integer> javaMutableLinked = new java.util.LinkedList<>();
+            final scala.collection.mutable.MutableList<Integer> scalaMutable = new scala.collection.mutable.MutableList<>();
+
+            int expectedAggregate = 0;
+            fj.data.List<Integer> fjavaPersistent = fj.data.List.list();
+            org.pcollections.PStack<Integer> pcollectionsPersistent = org.pcollections.ConsPStack.empty();
+            scala.collection.immutable.List<Integer> scalaPersistent = scala.collection.immutable.List$.MODULE$.empty();
+            javaslang.collection.List<Integer> slangPersistent = javaslang.collection.List.empty();
+
+            @Setup(Level.Invocation)
+            public void initializeMutable(Base state) {
+                assertEquals(javaMutable.size(), 0);
+                Collections.addAll(javaMutable, state.ELEMENTS);
+                assertEquals(javaMutable.size(), state.CONTAINER_SIZE);
+
+                assertEquals(javaMutableLinked.size(), 0);
+                Collections.addAll(javaMutableLinked, state.ELEMENTS);
+                assertEquals(javaMutableLinked.size(), state.CONTAINER_SIZE);
+
+                assertEquals(scalaMutable.size(), 0);
+                for (Integer element : state.ELEMENTS) {
+                    scalaMutable.prependElem(element);
+                }
+                assertEquals(scalaMutable.size(), state.CONTAINER_SIZE);
+
+                if (expectedAggregate == 0) {
+                    for (Integer element : state.ELEMENTS) {
+                        expectedAggregate ^= element;
+                    }
+
+                    assertEquals(fjavaPersistent.length(), 0);
+                    assertEquals(pcollectionsPersistent.size(), 0);
+                    assertEquals(scalaPersistent.size(), 0);
+                    assertEquals(slangPersistent.size(), 0);
+                    for (Integer element : state.ELEMENTS) {
+                        fjavaPersistent = fjavaPersistent.cons(element);
+                        pcollectionsPersistent = pcollectionsPersistent.plus(element);
+                        scalaPersistent = scalaPersistent.$colon$colon(element);
+                        slangPersistent = slangPersistent.prepend(element);
+                    }
+                    assertEquals(fjavaPersistent.length(), state.CONTAINER_SIZE);
+                    assertEquals(pcollectionsPersistent.size(), state.CONTAINER_SIZE);
+                    assertEquals(scalaPersistent.size(), state.CONTAINER_SIZE);
+                    assertEquals(slangPersistent.size(), state.CONTAINER_SIZE);
+                }
+            }
+
+            @TearDown(Level.Invocation)
+            public void tearDown() {
+                javaMutable.clear();
+                javaMutableLinked.clear();
+                scalaMutable.clear();
+            }
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void java_mutable(Initialized state) {
+            int aggregate = 0;
+            for (final Iterator<Integer> iterator = state.javaMutable.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, state.expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void java_mutable_linked(Initialized state) {
+            int aggregate = 0;
+            for (final Iterator<Integer> iterator = state.javaMutableLinked.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, state.expectedAggregate);
+        }
+
+        @Benchmark
+        public void scala_mutable(Initialized state) {
+            int aggregate = 0;
+            for (final scala.collection.Iterator<Integer> iterator = state.scalaMutable.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, state.expectedAggregate);
+        }
+
+        @Benchmark
+        public void scala_persistent(Initialized state) {
+            int aggregate = 0;
+            for (final scala.collection.Iterator<Integer> iterator = state.scalaPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, state.expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void fjava_persistent(Initialized state) {
+            int aggregate = 0;
+            for (final Iterator<Integer> iterator = state.fjavaPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, state.expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void pcollections_persistent(Initialized state) {
+            int aggregate = 0;
+            for (final Iterator<Integer> iterator = state.pcollectionsPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, state.expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void slang_persistent(Initialized state) {
+            int aggregate = 0;
+            for (final Iterator<Integer> iterator = state.slangPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, state.expectedAggregate);
+        }
+    }
+}

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/PriorityQueueBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/PriorityQueueBenchmark.java
@@ -4,7 +4,7 @@ import javaslang.Tuple2;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.results.RunResult;
-import org.openjdk.jmh.runner.*;
+import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.*;
 import scala.math.Ordering;
 import scala.math.Ordering$;
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 import static javaslang.benchmark.BenchmarkResultAggregator.displayRatios;
 
 public class PriorityQueueBenchmark {
-    public static void main(String... args) throws Exception { // main is more reliable than a test
+    public static void main(String... args) throws Exception { /* main is more reliable than a test */
         final Options opts = new OptionsBuilder()
                 .include(PriorityQueueBenchmark.class.getSimpleName())
                 .shouldDoGC(false)
@@ -24,14 +24,14 @@ public class PriorityQueueBenchmark {
                 .build();
 
         final Collection<RunResult> results = new Runner(opts).run();
-        displayRatios(results);
+        displayRatios(results, "^.+/slang.+$");
     }
 
     @State(Scope.Benchmark)
     @BenchmarkMode(Mode.Throughput)
     @OutputTimeUnit(TimeUnit.SECONDS)
-    @Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
-    @Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Warmup(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
     @Fork(value = 1, jvmArgsAppend = { "-XX:+UseG1GC", "-Xss100m", "-Xms1g", "-Xmx1g", "-disableassertions" }) /* set fork to 0 if you want to debug */
     public static class Base {
         protected static final Ordering<Integer> SCALA_ORDERING = Ordering$.MODULE$.comparatorToOrdering(Integer::compareTo);
@@ -40,20 +40,19 @@ public class PriorityQueueBenchmark {
         @Param({ "10", "1000", "100000" })
         public int CONTAINER_SIZE;
 
-        public List<Integer> ELEMENTS;
+        public Integer[] ELEMENTS;
+        int expectedAggregate = 0;
 
         @Setup
         public void setup() {
             final Random random = new Random(0);
 
-            final List<Integer> copy = new ArrayList<>(CONTAINER_SIZE);
+            ELEMENTS = new Integer[CONTAINER_SIZE];
             for (int i = 0; i < CONTAINER_SIZE; i++) {
                 final int value = random.nextInt(CONTAINER_SIZE) - (CONTAINER_SIZE / 2);
-                copy.add(value);
+                ELEMENTS[i] = value;
+                expectedAggregate ^= value;
             }
-
-            ELEMENTS = Collections.unmodifiableList(copy);
-            assertEquals(ELEMENTS.size(), CONTAINER_SIZE);
         }
 
         protected static <T> void assertEquals(T a, T b) {
@@ -65,31 +64,41 @@ public class PriorityQueueBenchmark {
 
     public static class Enqueue extends Base {
         @Benchmark
-        @SuppressWarnings("Convert2streamapi")
+        @SuppressWarnings({ "Convert2streamapi", "ManualArrayToCollectionCopy" })
         public void java_mutable() {
-            final java.util.PriorityQueue<Integer> q = new java.util.PriorityQueue<>(ELEMENTS.size());
+            final java.util.PriorityQueue<Integer> values = new java.util.PriorityQueue<>(ELEMENTS.length);
             for (Integer element : ELEMENTS) {
-                q.add(element);
+                values.add(element);
             }
-            assertEquals(q.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        @SuppressWarnings({ "Convert2streamapi", "ManualArrayToCollectionCopy" })
+        public void java_blocking_mutable() {
+            final java.util.concurrent.PriorityBlockingQueue<Integer> values = new java.util.concurrent.PriorityBlockingQueue<>(ELEMENTS.length);
+            for (Integer element : ELEMENTS) {
+                values.add(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
         }
 
         @Benchmark
         public void scala_mutable() {
-            scala.collection.mutable.PriorityQueue<Integer> q = new scala.collection.mutable.PriorityQueue<>(SCALA_ORDERING);
+            final scala.collection.mutable.PriorityQueue<Integer> values = new scala.collection.mutable.PriorityQueue<>(SCALA_ORDERING);
             for (Integer element : ELEMENTS) {
-                q = q.$plus$eq(element);
+                values.$plus$eq(element);
             }
-            assertEquals(q.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), CONTAINER_SIZE);
         }
 
         @Benchmark
         public void scalaz_persistent() {
-            scalaz.Heap<Integer> q = scalaz.Heap.Empty$.MODULE$.apply();
+            scalaz.Heap<Integer> values = scalaz.Heap.Empty$.MODULE$.apply();
             for (Integer element : ELEMENTS) {
-                q = q.insert(element, SCALAZ_ORDER);
+                values = values.insert(element, SCALAZ_ORDER);
             }
-            assertEquals(q.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), CONTAINER_SIZE);
         }
 
         @Benchmark
@@ -104,35 +113,40 @@ public class PriorityQueueBenchmark {
 
     public static class Dequeue extends Base {
         @State(Scope.Thread)
-        public static class InitializedQueues {
-            java.util.PriorityQueue<Integer> javaQueueMutable = new java.util.PriorityQueue<>();
-            scala.collection.mutable.PriorityQueue<Integer> scalaQueueMutable = new scala.collection.mutable.PriorityQueue<>(SCALA_ORDERING);
+        public static class Initialized {
+            java.util.PriorityQueue<Integer> javaMutable = new java.util.PriorityQueue<>();
+            java.util.concurrent.PriorityBlockingQueue<Integer> javaBlockingMutable = new java.util.concurrent.PriorityBlockingQueue<>();
+            scala.collection.mutable.PriorityQueue<Integer> scalaMutable = new scala.collection.mutable.PriorityQueue<>(SCALA_ORDERING);
 
             boolean initializedPersistent = false;
-            scalaz.Heap<Integer> scalazQueuePersistent = scalaz.Heap.Empty$.MODULE$.apply();
-            javaslang.collection.PriorityQueue<Integer> slangQueuePersistent = javaslang.collection.PriorityQueue.empty();
+            scalaz.Heap<Integer> scalazPersistent = scalaz.Heap.Empty$.MODULE$.apply();
+            javaslang.collection.PriorityQueue<Integer> slangPersistent = javaslang.collection.PriorityQueue.empty();
 
             @Setup(Level.Invocation)
             public void initializeMutable(Base state) {
-                assertEquals(javaQueueMutable.size(), 0);
-                javaQueueMutable.addAll(state.ELEMENTS);
-                assertEquals(javaQueueMutable.size(), state.CONTAINER_SIZE);
+                assertEquals(javaMutable.size(), 0);
+                Collections.addAll(javaMutable, state.ELEMENTS);
+                assertEquals(javaMutable.size(), state.CONTAINER_SIZE);
 
-                assertEquals(scalaQueueMutable.size(), 0);
+                assertEquals(javaBlockingMutable.size(), 0);
+                Collections.addAll(javaBlockingMutable, state.ELEMENTS);
+                assertEquals(javaBlockingMutable.size(), state.CONTAINER_SIZE);
+
+                assertEquals(scalaMutable.size(), 0);
                 for (Integer element : state.ELEMENTS) {
-                    scalaQueueMutable = scalaQueueMutable.$plus$eq(element);
+                    scalaMutable.$plus$eq(element);
                 }
-                assertEquals(scalaQueueMutable.size(), state.CONTAINER_SIZE);
+                assertEquals(scalaMutable.size(), state.CONTAINER_SIZE);
 
                 if (!initializedPersistent) {
-                    assertEquals(scalazQueuePersistent.size(), 0);
-                    assertEquals(slangQueuePersistent.size(), 0);
+                    assertEquals(scalazPersistent.size(), 0);
+                    assertEquals(slangPersistent.size(), 0);
                     for (Integer element : state.ELEMENTS) {
-                        scalazQueuePersistent = scalazQueuePersistent.insert(element, SCALAZ_ORDER);
-                        slangQueuePersistent = slangQueuePersistent.enqueue(element);
+                        scalazPersistent = scalazPersistent.insert(element, SCALAZ_ORDER);
+                        slangPersistent = slangPersistent.enqueue(element);
                     }
-                    assertEquals(scalazQueuePersistent.size(), state.CONTAINER_SIZE);
-                    assertEquals(slangQueuePersistent.size(), state.CONTAINER_SIZE);
+                    assertEquals(scalazPersistent.size(), state.CONTAINER_SIZE);
+                    assertEquals(slangPersistent.size(), state.CONTAINER_SIZE);
 
                     initializedPersistent = true;
                 }
@@ -140,126 +154,162 @@ public class PriorityQueueBenchmark {
 
             @TearDown(Level.Invocation)
             public void tearDown() {
-                javaQueueMutable.clear();
-                scalaQueueMutable.clear();
+                javaMutable.clear();
+                javaBlockingMutable.clear();
+                scalaMutable.clear();
             }
         }
 
         @Benchmark
-        public void java_mutable(InitializedQueues state) {
-            final java.util.PriorityQueue<Integer> q = state.javaQueueMutable;
+        public void java_mutable(Initialized state) {
+            final java.util.PriorityQueue<Integer> values = state.javaMutable;
 
-            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-            for (; !q.isEmpty(); q.poll()) {
-                result.add(q.peek());
+            int aggregate = 0;
+            for (; !values.isEmpty(); values.poll()) {
+                aggregate ^= values.peek();
             }
-            assertEquals(q.size(), 0);
-            assertEquals(result.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
-        public void scala_mutable(InitializedQueues state) {
-            final scala.collection.mutable.PriorityQueue<Integer> q = state.scalaQueueMutable;
+        public void java_blocking_mutable(Initialized state) {
+            final java.util.concurrent.PriorityBlockingQueue<Integer> values = state.javaBlockingMutable;
 
-            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-            while (!q.isEmpty()) {
-                result.add(q.dequeue());
+            int aggregate = 0;
+            for (; !values.isEmpty(); values.poll()) {
+                aggregate ^= values.peek();
             }
-            assertEquals(q.size(), 0);
-            assertEquals(result.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
-        public void scalaz_persistent(InitializedQueues state) {
-            scalaz.Heap<Integer> q = state.scalazQueuePersistent;
+        public void scala_mutable(Initialized state) {
+            final scala.collection.mutable.PriorityQueue<Integer> values = state.scalaMutable;
 
-            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-            while (!q.isEmpty()) {
-                final scala.Tuple2<Integer, Heap<Integer>> uncons = q.uncons().get();
-                result.add(uncons._1);
-                q = uncons._2;
+            int aggregate = 0;
+            while (!values.isEmpty()) {
+                aggregate ^= values.dequeue();
             }
-            assertEquals(q.size(), 0);
-            assertEquals(result.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
-        public void slang_persistent(InitializedQueues state) {
-            javaslang.collection.PriorityQueue<Integer> q = state.slangQueuePersistent;
+        public void scalaz_persistent(Initialized state) {
+            scalaz.Heap<Integer> values = state.scalazPersistent;
 
-            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-            while (!q.isEmpty()) {
-                final Tuple2<Integer, javaslang.collection.PriorityQueue<Integer>> dequeue = q.dequeue();
-                result.add(dequeue._1);
-                q = dequeue._2;
+            int aggregate = 0;
+            while (!values.isEmpty()) {
+                final scala.Tuple2<Integer, scalaz.Heap<Integer>> uncons = values.uncons().get();
+                aggregate ^= uncons._1;
+                values = uncons._2;
             }
-            assertEquals(q.size(), 0);
-            assertEquals(result.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
         }
 
+        @Benchmark
+        public void slang_persistent(Initialized state) {
+            javaslang.collection.PriorityQueue<Integer> values = state.slangPersistent;
+
+            int aggregate = 0;
+            while (!values.isEmpty()) {
+                final Tuple2<Integer, javaslang.collection.PriorityQueue<Integer>> dequeue = values.dequeue();
+                aggregate ^= dequeue._1;
+                values = dequeue._2;
+            }
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
+        }
     }
 
     public static class Sort extends Base {
         @Benchmark
+        @SuppressWarnings("ManualArrayToCollectionCopy")
         public void java_mutable() {
-            final java.util.PriorityQueue<Integer> q = new java.util.PriorityQueue<>(ELEMENTS);
-            assertEquals(q.size(), CONTAINER_SIZE);
-
-            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-            for (; !q.isEmpty(); q.poll()) {
-                result.add(q.peek());
+            final java.util.PriorityQueue<Integer> values = new java.util.PriorityQueue<>(CONTAINER_SIZE);
+            for (Integer element : ELEMENTS) {
+                values.add(element);
             }
-            assertEquals(q.size(), 0);
-            assertEquals(result.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), CONTAINER_SIZE);
+
+            int aggregate = 0;
+            for (; !values.isEmpty(); values.poll()) {
+                aggregate ^= values.peek();
+            }
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ManualArrayToCollectionCopy")
+        public void java_blocking_mutable() {
+            final java.util.concurrent.PriorityBlockingQueue<Integer> values = new java.util.concurrent.PriorityBlockingQueue<>(CONTAINER_SIZE);
+            for (Integer element : ELEMENTS) {
+                values.add(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+
+            int aggregate = 0;
+            for (; !values.isEmpty(); values.poll()) {
+                aggregate ^= values.peek();
+            }
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
         public void scala_mutable() {
-            scala.collection.mutable.PriorityQueue<Integer> q = new scala.collection.mutable.PriorityQueue<>(SCALA_ORDERING);
+            scala.collection.mutable.PriorityQueue<Integer> values = new scala.collection.mutable.PriorityQueue<>(SCALA_ORDERING);
             for (Integer element : ELEMENTS) {
-                q = q.$plus$eq(element);
+                values = values.$plus$eq(element);
             }
-            assertEquals(q.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), CONTAINER_SIZE);
 
-            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-            while (!q.isEmpty()) {
-                result.add(q.dequeue());
+            int aggregate = 0;
+            while (!values.isEmpty()) {
+                aggregate ^= values.dequeue();
             }
-            assertEquals(q.size(), 0);
-            assertEquals(result.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
         public void scalaz_persistent() {
-            scalaz.Heap<Integer> q = scalaz.Heap.Empty$.MODULE$.apply();
+            scalaz.Heap<Integer> values = scalaz.Heap.Empty$.MODULE$.apply();
             for (Integer element : ELEMENTS) {
-                q = q.insert(element, SCALAZ_ORDER);
+                values = values.insert(element, SCALAZ_ORDER);
             }
-            assertEquals(q.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), CONTAINER_SIZE);
 
-            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-            while (!q.isEmpty()) {
-                final scala.Tuple2<Integer, Heap<Integer>> uncons = q.uncons().get();
-                result.add(uncons._1);
-                q = uncons._2;
+            int aggregate = 0;
+            while (!values.isEmpty()) {
+                final scala.Tuple2<Integer, Heap<Integer>> uncons = values.uncons().get();
+                aggregate ^= uncons._1;
+                values = uncons._2;
             }
-            assertEquals(q.size(), 0);
-            assertEquals(result.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
         public void slang_persistent() {
-            javaslang.collection.PriorityQueue<Integer> q = javaslang.collection.PriorityQueue.ofAll(ELEMENTS);
-            assertEquals(q.size(), CONTAINER_SIZE);
-
-            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-            while (!q.isEmpty()) {
-                final Tuple2<Integer, javaslang.collection.PriorityQueue<Integer>> dequeue = q.dequeue();
-                result.add(dequeue._1);
-                q = dequeue._2;
+            javaslang.collection.PriorityQueue<Integer> values = javaslang.collection.PriorityQueue.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.enqueue(element);
             }
-            assertEquals(q.size(), 0);
-            assertEquals(result.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), CONTAINER_SIZE);
+
+            int aggregate = 0;
+            while (!values.isEmpty()) {
+                final Tuple2<Integer, javaslang.collection.PriorityQueue<Integer>> dequeue = values.dequeue();
+                aggregate ^= dequeue._1;
+                values = dequeue._2;
+            }
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
         }
     }
 }

--- a/javaslang/src/main/java/javaslang/$.java
+++ b/javaslang/src/main/java/javaslang/$.java
@@ -33,8 +33,7 @@ import javaslang.match.annotation.Patterns;
     // -- javaslang.collection
 
     // List
-    @Unapply static <T> Tuple2<T, List<T>> List(List.Cons<T> cons) { return Tuple.of(cons.head(), cons.tail()); }
-    @Unapply static <T> Tuple0 List(List.Nil<T> nil) { return Tuple.empty(); }
+    @Unapply static <T> Tuple2<T, List<T>> List(List<T> cons) { return Tuple.of(cons.head(), cons.tail()); }
 
     // Stream
     @Unapply static <T> Tuple2<T, Stream<T>> Stream(Stream.Cons<T> cons) { return Tuple.of(cons.head(), cons.tail()); }

--- a/javaslang/src/main/java/javaslang/collection/CharSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/CharSeq.java
@@ -572,18 +572,16 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
     public IndexedSeq<CharSeq> permutations() {
         if (isEmpty()) {
             return Vector.empty();
+        } else if (length() == 1) {
+            return Vector.of(this);
         } else {
-            if (length() == 1) {
-                return Vector.of(this);
-            } else {
-                IndexedSeq<CharSeq> result = Vector.empty();
-                for (Character t : distinct()) {
-                    for (CharSeq ts : remove(t).permutations()) {
-                        result = result.append(CharSeq.of(t).appendAll(ts));
-                    }
+            IndexedSeq<CharSeq> result = Vector.empty();
+            for (Character t : distinct()) {
+                for (CharSeq ts : remove(t).permutations()) {
+                    result = result.append(of(t).appendAll(ts));
                 }
-                return result;
             }
+            return result;
         }
     }
 

--- a/javaslang/src/main/java/javaslang/collection/Traversable.java
+++ b/javaslang/src/main/java/javaslang/collection/Traversable.java
@@ -526,10 +526,8 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      */
     @Override
     default Iterator<T> iterator() {
-        final Traversable<T> that = this;
         return new AbstractIterator<T>() {
-
-            Traversable<T> traversable = that;
+            Traversable<T> traversable = Traversable.this;
 
             @Override
             public boolean hasNext() {

--- a/javaslang/src/main/java/javaslang/collection/Tree.java
+++ b/javaslang/src/main/java/javaslang/collection/Tree.java
@@ -6,7 +6,6 @@
 package javaslang.collection;
 
 import javaslang.*;
-import javaslang.collection.List.Nil;
 import javaslang.collection.Tree.*;
 import javaslang.collection.TreeModule.*;
 import javaslang.control.Option;
@@ -905,7 +904,7 @@ public interface Tree<T> extends Traversable<T> {
 
         @Override
         public List<Node<T>> getChildren() {
-            return Nil.instance();
+            return List.empty();
         }
 
         @Override

--- a/javaslang/src/test/java/javaslang/collection/ListTest.java
+++ b/javaslang/src/test/java/javaslang/collection/ListTest.java
@@ -188,7 +188,7 @@ public class ListTest extends AbstractLinearSeqTest {
 
     @Test
     public void shouldAcceptNavigableSet() {
-        java.util.TreeSet<Integer> javaSet = new java.util.TreeSet<>();
+        final java.util.TreeSet<Integer> javaSet = new java.util.TreeSet<>();
         javaSet.add(2);
         javaSet.add(1);
         assertThat(List.ofAll(javaSet)).isEqualTo(List.of(1, 2));
@@ -276,7 +276,7 @@ public class ListTest extends AbstractLinearSeqTest {
 
     @Test
     public void shouldTransform() {
-        String transformed = of(42).transform(v -> String.valueOf(v.get()));
+        final String transformed = of(42).transform(v -> String.valueOf(v.get()));
         assertThat(transformed).isEqualTo("42");
     }
 
@@ -290,47 +290,6 @@ public class ListTest extends AbstractLinearSeqTest {
     @Test
     public void shouldStringifyNonNil() {
         assertThat(of(1, 2, 3).toString()).isEqualTo("List(1, 2, 3)");
-    }
-
-    // -- Cons test
-
-    @Test(expected = InvalidObjectException.class)
-    public void shouldNotSerializeEnclosingClass() throws Throwable {
-        Serializables.callReadObject(List.of(1));
-    }
-
-    @Test(expected = InvalidObjectException.class)
-    public void shouldNotDeserializeListWithSizeLessThanOne() throws Throwable {
-        try {
-            /*
-             * This implementation is stable regarding jvm impl changes of object serialization. The index of the number
-             * of List elements is gathered dynamically.
-             */
-            final byte[] listWithOneElement = Serializables.serialize(List.of(0));
-            final byte[] listWithTwoElements = Serializables.serialize(List.of(0, 0));
-            int index = -1;
-            for (int i = 0; i < listWithOneElement.length && index == -1; i++) {
-                final byte b1 = listWithOneElement[i];
-                final byte b2 = listWithTwoElements[i];
-                if (b1 != b2) {
-                    if (b1 != 1 || b2 != 2) {
-                        throw new IllegalStateException("Difference does not indicate number of elements.");
-                    } else {
-                        index = i;
-                    }
-                }
-            }
-            if (index == -1) {
-                throw new IllegalStateException("Hack incomplete - index not found");
-            }
-            /*
-             * Hack the serialized data and fake zero elements.
-             */
-            listWithOneElement[index] = 0;
-            Serializables.deserialize(listWithOneElement);
-        } catch (IllegalStateException x) {
-            throw (x.getCause() != null) ? x.getCause() : x;
-        }
     }
 
     @Override

--- a/javaslang/src/test/java/javaslang/collection/PriorityQueueTest.java
+++ b/javaslang/src/test/java/javaslang/collection/PriorityQueueTest.java
@@ -231,7 +231,7 @@ public class PriorityQueueTest extends AbstractTraversableTest {
             javaslang.collection.PriorityQueue<Integer> functionalPriorityQueue = javaslang.collection.PriorityQueue.empty();
 
             for (int j = 0; j < 100_000; j++) {
-            /* Insert */
+                /* Insert */
                 if (random.nextInt() % 3 == 0) {
                     assertMinimumsAreEqual(mutablePriorityQueue, functionalPriorityQueue);
 
@@ -242,7 +242,7 @@ public class PriorityQueueTest extends AbstractTraversableTest {
 
                 assertMinimumsAreEqual(mutablePriorityQueue, functionalPriorityQueue);
 
-            /* Delete */
+                /* Delete */
                 if (random.nextInt() % 5 == 0) {
                     if (!mutablePriorityQueue.isEmpty()) { mutablePriorityQueue.poll(); }
                     if (!functionalPriorityQueue.isEmpty()) { functionalPriorityQueue = functionalPriorityQueue.tail(); }

--- a/javaslang/src/test/java/javaslang/collection/VectorTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorTest.java
@@ -202,46 +202,4 @@ public class VectorTest extends AbstractIndexedSeqTest {
     public void shouldStringifyNonNil() {
         assertThat(of(null, 1, 2, 3).toString()).isEqualTo("Vector(null, 1, 2, 3)");
     }
-
-    // -- Cons test
-
-    @Test(expected = InvalidObjectException.class)
-    public void shouldNotSerializeEnclosingClass() throws Throwable {
-        Serializables.callReadObject(List.of(1));
-    }
-
-    @Test(expected = InvalidObjectException.class)
-    public void shouldNotDeserializeListWithSizeLessThanOne() throws Throwable {
-        try {
-            /*
-             * This implementation is stable regarding jvm impl changes of object serialization. The index of the number
-             * of List elements is gathered dynamically.
-             */
-            final byte[] listWithOneElement = Serializables.serialize(List.of(0));
-            final byte[] listWithTwoElements = Serializables.serialize(List.of(0, 0));
-            int index = -1;
-            for (int i = 0; i < listWithOneElement.length && index == -1; i++) {
-                final byte b1 = listWithOneElement[i];
-                final byte b2 = listWithTwoElements[i];
-                if (b1 != b2) {
-                    if (b1 != 1 || b2 != 2) {
-                        throw new IllegalStateException("Difference does not indicate number of elements.");
-                    } else {
-                        index = i;
-                    }
-                }
-            }
-            if (index == -1) {
-                throw new IllegalStateException("Hack incomplete - index not found");
-            }
-            /*
-             * Hack the serialized data and fake zero elements.
-			 */
-            listWithOneElement[index] = 0;
-            Serializables.deserialize(listWithOneElement);
-        } catch (IllegalStateException x) {
-            throw (x.getCause() != null) ? x.getCause() : x;
-        }
-    }
-
 }


### PR DESCRIPTION
Contributes to https://github.com/javaslang/javaslang/issues/725 and resolves https://github.com/javaslang/javaslang/issues/1322.

Included `PCollections` and `Functional Java` also

The results are interesting for adding and iterating elements:
```Groovy
Ratios for: [10, 1000, 100000]

Group 'AddAll':
slang_persistent/fjava_persistent      : [1.37, 1.87, 2.14]
slang_persistent/java_mutable          : [1.08, 1.07, 0.81]
slang_persistent/pcollectins_persistent: [0.79, 0.88, 1.14]
slang_persistent/scala_mutable         : [1.02, 1.10, 1.40]
slang_persistent/scala_persistent      : [0.80, 1.05, 1.48]

Group 'Iterate':
slang_persistent/fjava_persistent      : [1.14, 1.01, 1.62]
slang_persistent/java_mutable          : [0.76, 0.39, 0.68]
slang_persistent/pcollectins_persistent: [0.81, 1.01, 1.62]
slang_persistent/scala_mutable         : [1.11, 1.07, 1.57]
slang_persistent/scala_persistent      : [1.08, 1.00, 1.26]
```

* `fjava` seems to be always slower
* Mutable and persistent Scala seem to be slower in most cases
* `pcollection` seems to be faster for a few elements (maybe they're delegating everything to an array for small sizes, will investigate)
* `ArrayList` is always faster for iteration, but often slower for insertion