### PR TITLE
Benchmarks

### DIFF
--- a/javaslang-benchmark/pom.xml
+++ b/javaslang-benchmark/pom.xml
@@ -33,6 +33,21 @@
             <version>7.3.0-M1</version>
         </dependency>
         <dependency>
+            <groupId>org.pcollections</groupId>
+            <artifactId>pcollections</artifactId>
+            <version>2.1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.functionaljava</groupId>
+            <artifactId>functionaljava</artifactId>
+            <version>4.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>15.0</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/ArrayBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/ArrayBenchmark.java
@@ -1,0 +1,129 @@
+package javaslang.benchmark;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.*;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static javaslang.benchmark.BenchmarkResultAggregator.displayRatios;
+
+public class ArrayBenchmark {
+    public static void main(String... args) throws Exception { /* main is more reliable than a test */
+        final Options opts = new OptionsBuilder()
+                .include(ArrayBenchmark.class.getSimpleName())
+                .shouldDoGC(false)
+                .shouldFailOnError(true)
+                .build();
+
+        final Collection<RunResult> results = new Runner(opts).run();
+        displayRatios(results, "^.*slang.*$");
+    }
+
+    @State(Scope.Benchmark)
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Fork(value = 1, jvmArgsAppend = { "-XX:+UseG1GC", "-Xss100m", "-Xms1g", "-Xmx1g", "-disableassertions" }) /* set fork to 0 if you want to debug */
+    public static class Base {
+        @Param({ "10", "100", "1000" })
+        public int CONTAINER_SIZE;
+
+        public Integer[] ELEMENTS;
+
+        @Setup
+        public void setup() {
+            final Random random = new Random(0);
+
+            ELEMENTS = new Integer[CONTAINER_SIZE];
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                final int value = random.nextInt(CONTAINER_SIZE) - (CONTAINER_SIZE / 2);
+                ELEMENTS[i] = value;
+            }
+        }
+
+        protected static <T> void assertEquals(T a, T b) {
+            if (!Objects.equals(a, b)) {
+                throw new IllegalStateException(a + " != " + b);
+            }
+        }
+    }
+
+    public static class AddAll extends Base {
+        @Benchmark
+        @SuppressWarnings("ManualArrayCopy")
+        public void java_mutable() {
+            final Integer[] values = new Integer[ELEMENTS.length];
+            for (int i = 0; i < ELEMENTS.length; i++) {
+                values[i] = ELEMENTS[i];
+            }
+            assertEquals(values.length, CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            javaslang.collection.Array<Integer> values = javaslang.collection.Array.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.append(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+    }
+
+    public static class Iterate extends Base {
+        @State(Scope.Thread)
+        public static class Initialized {
+            Integer[] javaMutable;
+
+            int expectedAggregate = 0;
+            javaslang.collection.Array<Integer> slangPersistent = javaslang.collection.Array.empty();
+
+            @Setup(Level.Invocation)
+            public void initializeMutable(Base state) {
+                assertEquals(javaMutable, null);
+                javaMutable = state.ELEMENTS.clone();
+                assertEquals(javaMutable.length, state.CONTAINER_SIZE);
+
+                if (expectedAggregate == 0) {
+                    for (Integer element : state.ELEMENTS) {
+                        expectedAggregate ^= element;
+                    }
+
+                    assertEquals(slangPersistent.size(), 0);
+                    for (Integer element : state.ELEMENTS) {
+                        slangPersistent = slangPersistent.prepend(element);
+                    }
+                    assertEquals(slangPersistent.size(), state.CONTAINER_SIZE);
+                }
+            }
+
+            @TearDown(Level.Invocation)
+            public void tearDown() {
+                javaMutable = null;
+            }
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void java_mutable(Initialized state) {
+            int aggregate = 0;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                aggregate ^= state.javaMutable[i];
+            }
+            assertEquals(aggregate, state.expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void slang_persistent(Initialized state) {
+            int aggregate = 0;
+            for (javaslang.collection.Array<Integer> values = state.slangPersistent; !values.isEmpty(); values = values.tail()) {
+                aggregate ^= values.head();
+            }
+            assertEquals(aggregate, state.expectedAggregate);
+        }
+    }
+}

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/ListBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/ListBenchmark.java
@@ -1,0 +1,249 @@
+package javaslang.benchmark;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.*;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static javaslang.benchmark.BenchmarkResultAggregator.displayRatios;
+
+public class ListBenchmark {
+    public static void main(String... args) throws Exception { /* main is more reliable than a test */
+        final Options opts = new OptionsBuilder()
+                .include(ListBenchmark.class.getSimpleName())
+                .shouldDoGC(false)
+                .shouldFailOnError(true)
+                .build();
+
+        final Collection<RunResult> results = new Runner(opts).run();
+        displayRatios(results, "^.*slang.*$");
+    }
+
+    @State(Scope.Benchmark)
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Warmup(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Fork(value = 1, jvmArgsAppend = { "-XX:+UseG1GC", "-Xss100m", "-Xms1g", "-Xmx1g", "-disableassertions" }) /* set fork to 0 if you want to debug */
+    public static class Base {
+        @Param({ "10", "100", "1000", "10000" })
+        public int CONTAINER_SIZE;
+
+        public Integer[] ELEMENTS;
+
+        @Setup
+        public void setup() {
+            final Random random = new Random(0);
+
+            ELEMENTS = new Integer[CONTAINER_SIZE];
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                final int value = random.nextInt(CONTAINER_SIZE) - (CONTAINER_SIZE / 2);
+                ELEMENTS[i] = value;
+            }
+        }
+
+        protected static <T> void assertEquals(T a, T b) {
+            if (!Objects.equals(a, b)) {
+                throw new IllegalStateException(a + " != " + b);
+            }
+        }
+    }
+
+    public static class AddAll extends Base {
+        @Benchmark
+        @SuppressWarnings("ManualArrayToCollectionCopy")
+        public void java_mutable() {
+            final java.util.ArrayList<Integer> values = new java.util.ArrayList<>(ELEMENTS.length);
+            for (Integer element : ELEMENTS) {
+                values.add(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ManualArrayToCollectionCopy")
+        public void java_mutable_linked() {
+            final java.util.LinkedList<Integer> values = new java.util.LinkedList<>();
+            for (Integer element : ELEMENTS) {
+                values.add(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void scala_mutable() {
+            final scala.collection.mutable.MutableList<Integer> values = new scala.collection.mutable.MutableList<>();
+            for (Integer element : ELEMENTS) {
+                values.prependElem(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void scala_persistent() {
+            scala.collection.immutable.List<Integer> values = scala.collection.immutable.List$.MODULE$.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.$colon$colon(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void fjava_persistent() {
+            fj.data.List<Integer> values = fj.data.List.list();
+            for (Integer element : ELEMENTS) {
+                values = values.cons(element);
+            }
+            assertEquals(values.length(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void pcollections_persistent() {
+            org.pcollections.PStack<Integer> values = org.pcollections.ConsPStack.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.plus(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            javaslang.collection.List<Integer> values = javaslang.collection.List.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.prepend(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+    }
+
+    public static class Iterate extends Base {
+        @State(Scope.Thread)
+        public static class Initialized {
+            final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
+            final java.util.LinkedList<Integer> javaMutableLinked = new java.util.LinkedList<>();
+            final scala.collection.mutable.MutableList<Integer> scalaMutable = new scala.collection.mutable.MutableList<>();
+
+            int expectedAggregate = 0;
+            fj.data.List<Integer> fjavaPersistent = fj.data.List.list();
+            org.pcollections.PStack<Integer> pcollectionsPersistent = org.pcollections.ConsPStack.empty();
+            scala.collection.immutable.List<Integer> scalaPersistent = scala.collection.immutable.List$.MODULE$.empty();
+            javaslang.collection.List<Integer> slangPersistent = javaslang.collection.List.empty();
+
+            @Setup(Level.Invocation)
+            public void initializeMutable(Base state) {
+                assertEquals(javaMutable.size(), 0);
+                Collections.addAll(javaMutable, state.ELEMENTS);
+                assertEquals(javaMutable.size(), state.CONTAINER_SIZE);
+
+                assertEquals(javaMutableLinked.size(), 0);
+                Collections.addAll(javaMutableLinked, state.ELEMENTS);
+                assertEquals(javaMutableLinked.size(), state.CONTAINER_SIZE);
+
+                assertEquals(scalaMutable.size(), 0);
+                for (Integer element : state.ELEMENTS) {
+                    scalaMutable.prependElem(element);
+                }
+                assertEquals(scalaMutable.size(), state.CONTAINER_SIZE);
+
+                if (expectedAggregate == 0) {
+                    for (Integer element : state.ELEMENTS) {
+                        expectedAggregate ^= element;
+                    }
+
+                    assertEquals(fjavaPersistent.length(), 0);
+                    assertEquals(pcollectionsPersistent.size(), 0);
+                    assertEquals(scalaPersistent.size(), 0);
+                    assertEquals(slangPersistent.size(), 0);
+                    for (Integer element : state.ELEMENTS) {
+                        fjavaPersistent = fjavaPersistent.cons(element);
+                        pcollectionsPersistent = pcollectionsPersistent.plus(element);
+                        scalaPersistent = scalaPersistent.$colon$colon(element);
+                        slangPersistent = slangPersistent.prepend(element);
+                    }
+                    assertEquals(fjavaPersistent.length(), state.CONTAINER_SIZE);
+                    assertEquals(pcollectionsPersistent.size(), state.CONTAINER_SIZE);
+                    assertEquals(scalaPersistent.size(), state.CONTAINER_SIZE);
+                    assertEquals(slangPersistent.size(), state.CONTAINER_SIZE);
+                }
+            }
+
+            @TearDown(Level.Invocation)
+            public void tearDown() {
+                javaMutable.clear();
+                javaMutableLinked.clear();
+                scalaMutable.clear();
+            }
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void java_mutable(Initialized state) {
+            int aggregate = 0;
+            for (final Iterator<Integer> iterator = state.javaMutable.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, state.expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void java_mutable_linked(Initialized state) {
+            int aggregate = 0;
+            for (final Iterator<Integer> iterator = state.javaMutableLinked.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, state.expectedAggregate);
+        }
+
+        @Benchmark
+        public void scala_mutable(Initialized state) {
+            int aggregate = 0;
+            for (final scala.collection.Iterator<Integer> iterator = state.scalaMutable.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, state.expectedAggregate);
+        }
+
+        @Benchmark
+        public void scala_persistent(Initialized state) {
+            int aggregate = 0;
+            for (final scala.collection.Iterator<Integer> iterator = state.scalaPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, state.expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void fjava_persistent(Initialized state) {
+            int aggregate = 0;
+            for (final Iterator<Integer> iterator = state.fjavaPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, state.expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void pcollections_persistent(Initialized state) {
+            int aggregate = 0;
+            for (final Iterator<Integer> iterator = state.pcollectionsPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, state.expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void slang_persistent(Initialized state) {
+            int aggregate = 0;
+            for (final Iterator<Integer> iterator = state.slangPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, state.expectedAggregate);
+        }
+    }
+}

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/PriorityQueueBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/PriorityQueueBenchmark.java
@@ -1,10 +1,11 @@
 package javaslang.benchmark;
 
 import javaslang.Tuple2;
+import javaslang.collection.Traversable;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.results.RunResult;
-import org.openjdk.jmh.runner.*;
+import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.*;
 import scala.math.Ordering;
 import scala.math.Ordering$;
@@ -16,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 import static javaslang.benchmark.BenchmarkResultAggregator.displayRatios;
 
 public class PriorityQueueBenchmark {
-    public static void main(String... args) throws Exception { // main is more reliable than a test
+    public static void main(String... args) throws Exception { /* main is more reliable than a test */
         final Options opts = new OptionsBuilder()
                 .include(PriorityQueueBenchmark.class.getSimpleName())
                 .shouldDoGC(false)
@@ -24,14 +25,14 @@ public class PriorityQueueBenchmark {
                 .build();
 
         final Collection<RunResult> results = new Runner(opts).run();
-        displayRatios(results);
+        displayRatios(results, "^.*slang.*$");
     }
 
     @State(Scope.Benchmark)
     @BenchmarkMode(Mode.Throughput)
     @OutputTimeUnit(TimeUnit.SECONDS)
     @Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
-    @Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
     @Fork(value = 1, jvmArgsAppend = { "-XX:+UseG1GC", "-Xss100m", "-Xms1g", "-Xmx1g", "-disableassertions" }) /* set fork to 0 if you want to debug */
     public static class Base {
         protected static final Ordering<Integer> SCALA_ORDERING = Ordering$.MODULE$.comparatorToOrdering(Integer::compareTo);
@@ -40,20 +41,19 @@ public class PriorityQueueBenchmark {
         @Param({ "10", "1000", "100000" })
         public int CONTAINER_SIZE;
 
-        public List<Integer> ELEMENTS;
+        public Integer[] ELEMENTS;
+        int expectedAggregate = 0;
 
         @Setup
         public void setup() {
             final Random random = new Random(0);
 
-            final List<Integer> copy = new ArrayList<>(CONTAINER_SIZE);
+            ELEMENTS = new Integer[CONTAINER_SIZE];
             for (int i = 0; i < CONTAINER_SIZE; i++) {
                 final int value = random.nextInt(CONTAINER_SIZE) - (CONTAINER_SIZE / 2);
-                copy.add(value);
+                ELEMENTS[i] = value;
+                expectedAggregate ^= value;
             }
-
-            ELEMENTS = Collections.unmodifiableList(copy);
-            assertEquals(ELEMENTS.size(), CONTAINER_SIZE);
         }
 
         protected static <T> void assertEquals(T a, T b) {
@@ -65,31 +65,41 @@ public class PriorityQueueBenchmark {
 
     public static class Enqueue extends Base {
         @Benchmark
-        @SuppressWarnings("Convert2streamapi")
+        @SuppressWarnings({ "Convert2streamapi", "ManualArrayToCollectionCopy" })
         public void java_mutable() {
-            final java.util.PriorityQueue<Integer> q = new java.util.PriorityQueue<>(ELEMENTS.size());
+            final java.util.PriorityQueue<Integer> values = new java.util.PriorityQueue<>(ELEMENTS.length);
             for (Integer element : ELEMENTS) {
-                q.add(element);
+                values.add(element);
             }
-            assertEquals(q.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        @SuppressWarnings({ "Convert2streamapi", "ManualArrayToCollectionCopy" })
+        public void java_blocking_mutable() {
+            final java.util.concurrent.PriorityBlockingQueue<Integer> values = new java.util.concurrent.PriorityBlockingQueue<>(ELEMENTS.length);
+            for (Integer element : ELEMENTS) {
+                values.add(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
         }
 
         @Benchmark
         public void scala_mutable() {
-            scala.collection.mutable.PriorityQueue<Integer> q = new scala.collection.mutable.PriorityQueue<>(SCALA_ORDERING);
+            final scala.collection.mutable.PriorityQueue<Integer> values = new scala.collection.mutable.PriorityQueue<>(SCALA_ORDERING);
             for (Integer element : ELEMENTS) {
-                q = q.$plus$eq(element);
+                values.$plus$eq(element);
             }
-            assertEquals(q.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), CONTAINER_SIZE);
         }
 
         @Benchmark
         public void scalaz_persistent() {
-            scalaz.Heap<Integer> q = scalaz.Heap.Empty$.MODULE$.apply();
+            scalaz.Heap<Integer> values = scalaz.Heap.Empty$.MODULE$.apply();
             for (Integer element : ELEMENTS) {
-                q = q.insert(element, SCALAZ_ORDER);
+                values = values.insert(element, SCALAZ_ORDER);
             }
-            assertEquals(q.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), CONTAINER_SIZE);
         }
 
         @Benchmark
@@ -104,35 +114,40 @@ public class PriorityQueueBenchmark {
 
     public static class Dequeue extends Base {
         @State(Scope.Thread)
-        public static class InitializedQueues {
-            java.util.PriorityQueue<Integer> javaQueueMutable = new java.util.PriorityQueue<>();
-            scala.collection.mutable.PriorityQueue<Integer> scalaQueueMutable = new scala.collection.mutable.PriorityQueue<>(SCALA_ORDERING);
+        public static class Initialized {
+            java.util.PriorityQueue<Integer> javaMutable = new java.util.PriorityQueue<>();
+            java.util.concurrent.PriorityBlockingQueue<Integer> javaBlockingMutable = new java.util.concurrent.PriorityBlockingQueue<>();
+            scala.collection.mutable.PriorityQueue<Integer> scalaMutable = new scala.collection.mutable.PriorityQueue<>(SCALA_ORDERING);
 
             boolean initializedPersistent = false;
-            scalaz.Heap<Integer> scalazQueuePersistent = scalaz.Heap.Empty$.MODULE$.apply();
-            javaslang.collection.PriorityQueue<Integer> slangQueuePersistent = javaslang.collection.PriorityQueue.empty();
+            scalaz.Heap<Integer> scalazPersistent = scalaz.Heap.Empty$.MODULE$.apply();
+            javaslang.collection.PriorityQueue<Integer> slangPersistent = javaslang.collection.PriorityQueue.empty();
 
             @Setup(Level.Invocation)
             public void initializeMutable(Base state) {
-                assertEquals(javaQueueMutable.size(), 0);
-                javaQueueMutable.addAll(state.ELEMENTS);
-                assertEquals(javaQueueMutable.size(), state.CONTAINER_SIZE);
+                assertEquals(javaMutable.size(), 0);
+                Collections.addAll(javaMutable, state.ELEMENTS);
+                assertEquals(javaMutable.size(), state.CONTAINER_SIZE);
 
-                assertEquals(scalaQueueMutable.size(), 0);
+                assertEquals(javaBlockingMutable.size(), 0);
+                Collections.addAll(javaBlockingMutable, state.ELEMENTS);
+                assertEquals(javaBlockingMutable.size(), state.CONTAINER_SIZE);
+
+                assertEquals(scalaMutable.size(), 0);
                 for (Integer element : state.ELEMENTS) {
-                    scalaQueueMutable = scalaQueueMutable.$plus$eq(element);
+                    scalaMutable.$plus$eq(element);
                 }
-                assertEquals(scalaQueueMutable.size(), state.CONTAINER_SIZE);
+                assertEquals(scalaMutable.size(), state.CONTAINER_SIZE);
 
                 if (!initializedPersistent) {
-                    assertEquals(scalazQueuePersistent.size(), 0);
-                    assertEquals(slangQueuePersistent.size(), 0);
+                    assertEquals(scalazPersistent.size(), 0);
+                    assertEquals(slangPersistent.size(), 0);
                     for (Integer element : state.ELEMENTS) {
-                        scalazQueuePersistent = scalazQueuePersistent.insert(element, SCALAZ_ORDER);
-                        slangQueuePersistent = slangQueuePersistent.enqueue(element);
+                        scalazPersistent = scalazPersistent.insert(element, SCALAZ_ORDER);
+                        slangPersistent = slangPersistent.enqueue(element);
                     }
-                    assertEquals(scalazQueuePersistent.size(), state.CONTAINER_SIZE);
-                    assertEquals(slangQueuePersistent.size(), state.CONTAINER_SIZE);
+                    assertEquals(scalazPersistent.size(), state.CONTAINER_SIZE);
+                    assertEquals(slangPersistent.size(), state.CONTAINER_SIZE);
 
                     initializedPersistent = true;
                 }
@@ -140,126 +155,184 @@ public class PriorityQueueBenchmark {
 
             @TearDown(Level.Invocation)
             public void tearDown() {
-                javaQueueMutable.clear();
-                scalaQueueMutable.clear();
+                javaMutable.clear();
+                javaBlockingMutable.clear();
+                scalaMutable.clear();
             }
         }
 
         @Benchmark
-        public void java_mutable(InitializedQueues state) {
-            final java.util.PriorityQueue<Integer> q = state.javaQueueMutable;
+        public void java_mutable(Initialized state) {
+            final java.util.PriorityQueue<Integer> values = state.javaMutable;
 
-            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-            for (; !q.isEmpty(); q.poll()) {
-                result.add(q.peek());
+            int aggregate = 0;
+            for (; !values.isEmpty(); values.poll()) {
+                aggregate ^= values.peek();
             }
-            assertEquals(q.size(), 0);
-            assertEquals(result.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
-        public void scala_mutable(InitializedQueues state) {
-            final scala.collection.mutable.PriorityQueue<Integer> q = state.scalaQueueMutable;
+        public void java_blocking_mutable(Initialized state) {
+            final java.util.concurrent.PriorityBlockingQueue<Integer> values = state.javaBlockingMutable;
 
-            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-            while (!q.isEmpty()) {
-                result.add(q.dequeue());
+            int aggregate = 0;
+            for (; !values.isEmpty(); values.poll()) {
+                aggregate ^= values.peek();
             }
-            assertEquals(q.size(), 0);
-            assertEquals(result.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
-        public void scalaz_persistent(InitializedQueues state) {
-            scalaz.Heap<Integer> q = state.scalazQueuePersistent;
+        public void scala_mutable(Initialized state) {
+            final scala.collection.mutable.PriorityQueue<Integer> values = state.scalaMutable;
 
-            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-            while (!q.isEmpty()) {
-                final scala.Tuple2<Integer, Heap<Integer>> uncons = q.uncons().get();
-                result.add(uncons._1);
-                q = uncons._2;
+            int aggregate = 0;
+            while (!values.isEmpty()) {
+                aggregate ^= values.dequeue();
             }
-            assertEquals(q.size(), 0);
-            assertEquals(result.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
-        public void slang_persistent(InitializedQueues state) {
-            javaslang.collection.PriorityQueue<Integer> q = state.slangQueuePersistent;
+        public void scalaz_persistent(Initialized state) {
+            scalaz.Heap<Integer> values = state.scalazPersistent;
 
-            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-            while (!q.isEmpty()) {
-                final Tuple2<Integer, javaslang.collection.PriorityQueue<Integer>> dequeue = q.dequeue();
-                result.add(dequeue._1);
-                q = dequeue._2;
+            int aggregate = 0;
+            while (!values.isEmpty()) {
+                final scala.Tuple2<Integer, scalaz.Heap<Integer>> uncons = values.uncons().get();
+                aggregate ^= uncons._1;
+                values = uncons._2;
             }
-            assertEquals(q.size(), 0);
-            assertEquals(result.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
         }
 
+        @Benchmark
+        public void slang_persistent(Initialized state) {
+            javaslang.collection.PriorityQueue<Integer> values = state.slangPersistent;
+
+            int aggregate = 0;
+            while (!values.isEmpty()) {
+                final Tuple2<Integer, javaslang.collection.PriorityQueue<Integer>> dequeue = values.dequeue();
+                aggregate ^= dequeue._1;
+                values = dequeue._2;
+            }
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
+        }
     }
 
     public static class Sort extends Base {
         @Benchmark
+        @SuppressWarnings("ManualArrayToCollectionCopy")
         public void java_mutable() {
-            final java.util.PriorityQueue<Integer> q = new java.util.PriorityQueue<>(ELEMENTS);
-            assertEquals(q.size(), CONTAINER_SIZE);
-
-            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-            for (; !q.isEmpty(); q.poll()) {
-                result.add(q.peek());
+            final java.util.PriorityQueue<Integer> values = new java.util.PriorityQueue<>(CONTAINER_SIZE);
+            for (Integer element : ELEMENTS) {
+                values.add(element);
             }
-            assertEquals(q.size(), 0);
-            assertEquals(result.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), CONTAINER_SIZE);
+
+            int aggregate = 0;
+            for (; !values.isEmpty(); values.poll()) {
+                aggregate ^= values.peek();
+            }
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ManualArrayToCollectionCopy")
+        public void java_blocking_mutable() {
+            final java.util.concurrent.PriorityBlockingQueue<Integer> values = new java.util.concurrent.PriorityBlockingQueue<>(CONTAINER_SIZE);
+            for (Integer element : ELEMENTS) {
+                values.add(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+
+            int aggregate = 0;
+            for (; !values.isEmpty(); values.poll()) {
+                aggregate ^= values.peek();
+            }
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
         public void scala_mutable() {
-            scala.collection.mutable.PriorityQueue<Integer> q = new scala.collection.mutable.PriorityQueue<>(SCALA_ORDERING);
+            scala.collection.mutable.PriorityQueue<Integer> values = new scala.collection.mutable.PriorityQueue<>(SCALA_ORDERING);
             for (Integer element : ELEMENTS) {
-                q = q.$plus$eq(element);
+                values = values.$plus$eq(element);
             }
-            assertEquals(q.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), CONTAINER_SIZE);
 
-            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-            while (!q.isEmpty()) {
-                result.add(q.dequeue());
+            int aggregate = 0;
+            while (!values.isEmpty()) {
+                aggregate ^= values.dequeue();
             }
-            assertEquals(q.size(), 0);
-            assertEquals(result.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
         public void scalaz_persistent() {
-            scalaz.Heap<Integer> q = scalaz.Heap.Empty$.MODULE$.apply();
+            scalaz.Heap<Integer> values = scalaz.Heap.Empty$.MODULE$.apply();
             for (Integer element : ELEMENTS) {
-                q = q.insert(element, SCALAZ_ORDER);
+                values = values.insert(element, SCALAZ_ORDER);
             }
-            assertEquals(q.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), CONTAINER_SIZE);
 
-            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-            while (!q.isEmpty()) {
-                final scala.Tuple2<Integer, Heap<Integer>> uncons = q.uncons().get();
-                result.add(uncons._1);
-                q = uncons._2;
+            int aggregate = 0;
+            while (!values.isEmpty()) {
+                final scala.Tuple2<Integer, Heap<Integer>> uncons = values.uncons().get();
+                aggregate ^= uncons._1;
+                values = uncons._2;
             }
-            assertEquals(q.size(), 0);
-            assertEquals(result.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ManualArrayToCollectionCopy")
+        public void java_treeset() {
+            javaslang.collection.TreeMap<Integer, javaslang.collection.List<Integer>> values = javaslang.collection.TreeMap.empty();
+            for (Integer element : ELEMENTS) {
+                final javaslang.collection.List<Integer> vs = values.get(element).getOrElse(javaslang.collection.List.empty()).prepend(element);
+                values = values.put(element, vs);
+            }
+            assertEquals(values.values().map(Traversable::size).sum().intValue(), CONTAINER_SIZE);
+
+            int aggregate = 0;
+            while (!values.isEmpty()) {
+                final Tuple2<Integer, javaslang.collection.List<Integer>> min = values.head();
+                for (Integer integer : min._2) {
+                    aggregate ^= integer;
+                }
+                values = values.remove(min._1);
+            }
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
         public void slang_persistent() {
-            javaslang.collection.PriorityQueue<Integer> q = javaslang.collection.PriorityQueue.ofAll(ELEMENTS);
-            assertEquals(q.size(), CONTAINER_SIZE);
-
-            final Collection<Integer> result = new ArrayList<>(CONTAINER_SIZE);
-            while (!q.isEmpty()) {
-                final Tuple2<Integer, javaslang.collection.PriorityQueue<Integer>> dequeue = q.dequeue();
-                result.add(dequeue._1);
-                q = dequeue._2;
+            javaslang.collection.PriorityQueue<Integer> values = javaslang.collection.PriorityQueue.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.enqueue(element);
             }
-            assertEquals(q.size(), 0);
-            assertEquals(result.size(), CONTAINER_SIZE);
+            assertEquals(values.size(), CONTAINER_SIZE);
+
+            int aggregate = 0;
+            while (!values.isEmpty()) {
+                final Tuple2<Integer, javaslang.collection.PriorityQueue<Integer>> dequeue = values.dequeue();
+                aggregate ^= dequeue._1;
+                values = dequeue._2;
+            }
+            assertEquals(values.size(), 0);
+            assertEquals(aggregate, expectedAggregate);
         }
     }
 }

--- a/javaslang/src/main/java/javaslang/collection/PriorityQueue.java
+++ b/javaslang/src/main/java/javaslang/collection/PriorityQueue.java
@@ -7,7 +7,7 @@ package javaslang.collection;
 
 import javaslang.*;
 import javaslang.collection.Comparators.SerializableComparator;
-import javaslang.collection.PriorityQueue.PriorityQueueHelper.*;
+import javaslang.collection.PriorityQueue.PriorityQueueBase.*;
 
 import java.io.Serializable;
 import java.util.*;
@@ -15,7 +15,7 @@ import java.util.function.*;
 import java.util.stream.Collector;
 
 import static javaslang.collection.Comparators.naturalComparator;
-import static javaslang.collection.PriorityQueue.PriorityQueueHelper.*;
+import static javaslang.collection.PriorityQueue.PriorityQueueBase.*;
 
 /**
  * @author Pap Lőrinc
@@ -25,16 +25,16 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
     private static final long serialVersionUID = 1L;
 
     private final SerializableComparator<? super T> comparator;
-    private final List<Node<T>> forest;
+    private final Seq<Node<T>> forest;
     private final int size;
 
-    private PriorityQueue(SerializableComparator<? super T> comparator, List<Node<T>> forest, int size) {
+    private PriorityQueue(SerializableComparator<? super T> comparator, Seq<Node<T>> forest, int size) {
         this.comparator = comparator;
         this.forest = forest;
         this.size = size;
     }
 
-    private PriorityQueue<T> with(List<Node<T>> forest, int size) {
+    private PriorityQueue<T> with(Seq<Node<T>> forest, int size) {
         return new PriorityQueue<>(this.comparator, forest, size);
     }
 
@@ -46,7 +46,7 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
      */
     @Override
     public PriorityQueue<T> enqueue(T element) {
-        final List<Node<T>> result = insert(comparator, element, forest);
+        final Seq<Node<T>> result = insert(comparator, element, forest);
         return with(result, size + 1);
     }
 
@@ -97,13 +97,13 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
         if (isEmpty()) {
             throw new NoSuchElementException("dequeue of empty " + stringPrefix());
         } else {
-            final Tuple2<T, List<Node<T>>> dequeue = deleteMin(comparator, this.forest);
+            final Tuple2<T, Seq<Node<T>>> dequeue = deleteMin(comparator, this.forest);
             return Tuple.of(dequeue._1, with(dequeue._2, this.size - 1));
         }
     }
 
     public PriorityQueue<T> merge(PriorityQueue<T> target) {
-        final List<Node<T>> meld = meld(comparator, this.forest, target.forest);
+        final Seq<Node<T>> meld = meld(comparator, this.forest, target.forest);
         return with(meld, this.size + target.size);
     }
 
@@ -186,7 +186,7 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
         final SerializableComparator<? super T> serializableComparator = SerializableComparator.of(comparator);
 
         int size = 0;
-        List<Node<T>> forest = List.empty();
+        Seq<Node<T>> forest = List.empty();
         for (T value : elements) {
             forest = insert(serializableComparator, value, forest);
             size++;
@@ -244,13 +244,13 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
     @Override
     public PriorityQueue<T> distinctBy(Comparator<? super T> comparator) {
         Objects.requireNonNull(comparator, "comparator is null");
-        return ofAll(comparator, toList().distinctBy(comparator));
+        return ofAll(comparator, iterator().distinctBy(comparator));
     }
 
     @Override
     public <U> PriorityQueue<T> distinctBy(Function<? super T, ? extends U> keyExtractor) {
         Objects.requireNonNull(keyExtractor, "keyExtractor is null");
-        return ofAll(comparator, toList().distinctBy(keyExtractor));
+        return ofAll(comparator, iterator().distinctBy(keyExtractor));
     }
 
     @Override
@@ -518,16 +518,16 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
         return o == this || o instanceof PriorityQueue && Collections.equals(this, (Iterable) o);
     }
 
-    protected static class PriorityQueueHelper {
+    protected static class PriorityQueueBase {
         /* Based on http://www.brics.dk/RS/96/37/BRICS-RS-96-37.pdf */
         protected static class Node<T> implements Serializable {
             private static final long serialVersionUID = 1L;
 
             protected final T root;
             protected final int rank;
-            protected final List<Node<T>> children;
+            protected final Seq<Node<T>> children;
 
-            private Node(T root, int rank, List<Node<T>> children) {
+            private Node(T root, int rank, Seq<Node<T>> children) {
                 this.root = root;
                 this.rank = rank;
                 this.children = children;
@@ -535,12 +535,8 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
                 assert children.forAll(c -> c.rank < this.rank);
             }
 
-            protected static <T> Node<T> of(T value, int rank, List<Node<T>> children) {
+            protected static <T> Node<T> of(T value, int rank, Seq<Node<T>> children) {
                 return new Node<>(value, rank, children);
-            }
-
-            protected static <T> Node<T> of(T value) {
-                return of(value, 0, List.empty());
             }
 
             /**
@@ -552,8 +548,8 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
                 assert rank == tree.rank;
 
                 return comparator.isLessOrEqual(this.root, tree.root)
-                        ? of(this.root, this.rank + 1, tree.append(this.children))
-                        : of(tree.root, tree.rank + 1, this.append(tree.children));
+                        ? of(this.root, this.rank + 1, tree.appendTo(this.children))
+                        : of(tree.root, tree.rank + 1, this.appendTo(tree.children));
             }
 
             /**
@@ -566,19 +562,17 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
                 assert rank == 0 && left.rank == right.rank;
 
                 if (comparator.isLessOrEqual(left.root, root) && comparator.isLessOrEqual(left.root, right.root)) {
-                    return of(left.root, left.rank + 1, append(right.append(left.children)));
+                    return of(left.root, left.rank + 1, appendTo(right.appendTo(left.children)));
+                } else if (comparator.isLessOrEqual(right.root, root)) {
+                    assert comparator.isLessOrEqual(right.root, left.root);
+                    return of(right.root, right.rank + 1, appendTo(left.appendTo(right.children)));
                 } else {
-                    if (comparator.isLessOrEqual(right.root, root)) {
-                        assert comparator.isLessOrEqual(right.root, left.root);
-                        return of(right.root, right.rank + 1, append(left.append(right.children)));
-                    } else {
-                        assert children.isEmpty();
-                        return of(root, left.rank + 1, List.of(left, right));
-                    }
+                    assert children.isEmpty();
+                    return of(root, left.rank + 1, List.of(left, right));
                 }
             }
 
-            protected List<Node<T>> append(List<Node<T>> forest) {
+            protected Seq<Node<T>> appendTo(Seq<Node<T>> forest) {
                 return forest.prepend(this);
             }
 
@@ -595,15 +589,15 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
          * *     val (ts',xs') = split ([],[],c)
          * *     in fold insert xs' (meld (ts, ts')) end
          **/
-        static <T> Tuple2<T, List<Node<T>>> deleteMin(SerializableComparator<? super T> comparator, List<Node<T>> forest) {
+        static <T> Tuple2<T, Seq<Node<T>>> deleteMin(SerializableComparator<? super T> comparator, Seq<Node<T>> forest) {
             if (forest.isEmpty()) {
                 throw new NoSuchElementException();
             } else {
-            /* get the minimum tree and the rest of the forest */
+                /* get the minimum tree and the rest of the forest */
                 final Node<T> minTree = findMin(comparator, forest);
-                final List<Node<T>> forestTail = (minTree == forest.head()) ? forest.tail() : forest.remove(minTree);
+                final Seq<Node<T>> forestTail = (minTree == forest.head()) ? forest.tail() : forest.remove(minTree);
 
-                final List<Node<T>> newForest = rebuild(comparator, minTree.children);
+                final Seq<Node<T>> newForest = rebuild(comparator, minTree.children);
                 return Tuple.of(minTree.root, meld(comparator, newForest, forestTail));
             }
         }
@@ -616,14 +610,14 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
          * *     if rank t = 0 then split (ts,root t :: xs,c)
          * *     else               split (t :: ts,xs,c)
          */
-        static <T> List<Node<T>> rebuild(SerializableComparator<? super T> comparator, List<Node<T>> forest) {
-            List<Node<T>> nonZeroRank = List.empty(), zeroRank = List.empty();
+        static <T> Seq<Node<T>> rebuild(SerializableComparator<? super T> comparator, Seq<Node<T>> forest) {
+            Seq<Node<T>> nonZeroRank = List.empty(), zeroRank = List.empty();
             for (; !forest.isEmpty(); forest = forest.tail()) {
                 final Node<T> initialForestHead = forest.head();
                 if (initialForestHead.rank == 0) {
                     zeroRank = insert(comparator, initialForestHead.root, zeroRank);
                 } else {
-                    nonZeroRank = initialForestHead.append(nonZeroRank);
+                    nonZeroRank = initialForestHead.appendTo(nonZeroRank);
                 }
             }
             return meld(comparator, nonZeroRank, zeroRank);
@@ -635,20 +629,20 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
          * *     else                      Node (x,0,[]) :: ts
          * * | insert (x, ts) =            Node (x,0,[]) :: ts
          **/
-        static <T> List<Node<T>> insert(SerializableComparator<? super T> comparator, T element, List<Node<T>> forest) {
-            final Node<T> tree = Node.of(element);
+        static <T> Seq<Node<T>> insert(SerializableComparator<? super T> comparator, T element, Seq<Node<T>> forest) {
+            final Node<T> tree = Node.of(element, 0, List.empty());
             if (forest.size() >= 2) {
-                final List<Node<T>> tail = forest.tail();
+                final Seq<Node<T>> tail = forest.tail();
                 final Node<T> t1 = forest.head(), t2 = tail.head();
                 if (t1.rank == t2.rank) {
-                    return tree.skewLink(comparator, t1, t2).append(tail.tail());
+                    return tree.skewLink(comparator, t1, t2).appendTo(tail.tail());
                 }
             }
-            return tree.append(forest);
+            return tree.appendTo(forest);
         }
 
         /** fun meld (ts, ts') = meldUniq (uniqify ts, uniqify ts') */
-        static <T> List<Node<T>> meld(SerializableComparator<? super T> comparator, List<Node<T>> source, List<Node<T>> target) {
+        static <T> Seq<Node<T>> meld(SerializableComparator<? super T> comparator, Seq<Node<T>> source, Seq<Node<T>> target) {
             return meldUnique(comparator, uniqify(comparator, source), uniqify(comparator, target));
         }
 
@@ -656,7 +650,7 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
          * fun uniqify [] = []
          * *  | uniqify (t :: ts) = ins (t, ts) (∗ eliminate initial duplicate ∗)
          **/
-        static <T> List<Node<T>> uniqify(SerializableComparator<? super T> comparator, List<Node<T>> forest) {
+        static <T> Seq<Node<T>> uniqify(SerializableComparator<? super T> comparator, Seq<Node<T>> forest) {
             return forest.isEmpty()
                     ? forest
                     : ins(comparator, forest.head(), forest.tail());
@@ -668,11 +662,12 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
          * *     if rank t < rank t' then t :: t' :: ts
          * *     else                     ins (link (t, t'), ts)
          */
-        static <T> List<Node<T>> ins(SerializableComparator<? super T> comparator, Node<T> tree, List<Node<T>> forest) {
-            for (; !forest.isEmpty() && tree.rank >= forest.head().rank; forest = forest.tail()) {
+        static <T> Seq<Node<T>> ins(SerializableComparator<? super T> comparator, Node<T> tree, Seq<Node<T>> forest) {
+            while (!forest.isEmpty() && tree.rank == forest.head().rank) {
                 tree = tree.link(comparator, forest.head());
+                forest = forest.tail();
             }
-            return tree.append(forest);
+            return tree.appendTo(forest);
         }
 
         /**
@@ -683,7 +678,7 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
          * *      else if rank t2 < rank t1 then t2 :: meldUniq (t1 :: ts1, ts2)
          * *      else                           ins (link (t1, t2), meldUniq (ts1, ts2))
          **/
-        static <T> List<Node<T>> meldUnique(SerializableComparator<? super T> comparator, List<Node<T>> forest1, List<Node<T>> forest2) { // TODO eliminate recursion somehow
+        static <T> Seq<Node<T>> meldUnique(SerializableComparator<? super T> comparator, Seq<Node<T>> forest1, Seq<Node<T>> forest2) {
             if (forest1.isEmpty()) {
                 return forest2;
             } else if (forest2.isEmpty()) {
@@ -691,23 +686,21 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
             } else {
                 final Node<T> tree1 = forest1.head(), tree2 = forest2.head();
 
-                final Node<T> tree;
-                final List<Node<T>> forest;
                 if (tree1.rank == tree2.rank) {
-                    tree = tree1.link(comparator, tree2);
-                    forest = meldUnique(comparator, forest1.tail(), forest2.tail());
+                    final Node<T> tree = tree1.link(comparator, tree2);
+                    final Seq<Node<T>> forest = meldUnique(comparator, forest1.tail(), forest2.tail());
+                    return ins(comparator, tree, forest);
                 } else {
                     if (tree1.rank < tree2.rank) {
-                        tree = tree1;
-                        forest = meldUnique(comparator, forest1.tail(), forest2);
+                        final Seq<Node<T>> forest = meldUnique(comparator, forest1.tail(), forest2);
                         assert forest.isEmpty() || tree1.rank < forest.head().rank;
+                        return tree1.appendTo(forest);
                     } else {
-                        tree = tree2;
-                        forest = meldUnique(comparator, forest1, forest2.tail());
+                        final Seq<Node<T>> forest = meldUnique(comparator, forest1, forest2.tail());
                         assert forest.isEmpty() || tree2.rank < forest.head().rank;
+                        return tree2.appendTo(forest);
                     }
                 }
-                return ins(comparator, tree, forest);
             }
         }
 
@@ -720,7 +713,7 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
          * *     let val x = findMin ts
          * *     in if Elem.leq (root t, x) then root t else x end
          */
-        static <T> Node<T> findMin(SerializableComparator<? super T> comparator, List<Node<T>> forest) {
+        static <T> Node<T> findMin(SerializableComparator<? super T> comparator, Seq<Node<T>> forest) {
             final Iterator<Node<T>> iterator = forest.iterator();
             Node<T> min = iterator.next();
             for (Node<T> node : iterator) {

--- a/javaslang/src/test/java/javaslang/collection/PriorityQueueTest.java
+++ b/javaslang/src/test/java/javaslang/collection/PriorityQueueTest.java
@@ -230,19 +230,20 @@ public class PriorityQueueTest extends AbstractTraversableTest {
             final java.util.PriorityQueue<Integer> mutablePriorityQueue = new java.util.PriorityQueue<>();
             javaslang.collection.PriorityQueue<Integer> functionalPriorityQueue = javaslang.collection.PriorityQueue.empty();
 
-            for (int j = 0; j < 100_000; j++) {
-            /* Insert */
+            final int size = 100_000;
+            for (int j = 0; j < size; j++) {
+                /* Insert */
                 if (random.nextInt() % 3 == 0) {
                     assertMinimumsAreEqual(mutablePriorityQueue, functionalPriorityQueue);
 
-                    final int value = random.nextInt();
+                    final int value = random.nextInt(size) - (size / 2);
                     mutablePriorityQueue.add(value);
                     functionalPriorityQueue = functionalPriorityQueue.enqueue(value);
                 }
 
                 assertMinimumsAreEqual(mutablePriorityQueue, functionalPriorityQueue);
 
-            /* Delete */
+                /* Delete */
                 if (random.nextInt() % 5 == 0) {
                     if (!mutablePriorityQueue.isEmpty()) { mutablePriorityQueue.poll(); }
                     if (!functionalPriorityQueue.isEmpty()) { functionalPriorityQueue = functionalPriorityQueue.tail(); }


### PR DESCRIPTION
Unified and added new benchmarks for `List` and `Array` also.
The updated result aggregator displays the results like:

> PriorityQueueBenchmark

```java
Group 'Enqueue'                         :     10 |  1000 | 100000 |
java_blocking_mutable / slang_persistent:  0.84x | 0.97x |  1.01x |
java_mutable / slang_persistent         :  2.71x | 1.69x |  1.69x |
scala_mutable / slang_persistent        :  1.78x | 1.15x |  0.86x |
scalaz_persistent / slang_persistent    :  0.21x | 0.19x |  0.23x |
slang_persistent / java_blocking_mutable:  1.19x | 1.04x |  0.99x |
slang_persistent / java_mutable         :  0.37x | 0.59x |  0.59x |
slang_persistent / scala_mutable        :  0.56x | 0.87x |  1.16x |
slang_persistent / scalaz_persistent    :  4.87x | 5.18x |  4.30x |

Group 'Dequeue'                         :     10 |   1000 | 100000 |
java_blocking_mutable / slang_persistent:  1.54x |  3.99x |  4.71x |
java_mutable / slang_persistent         :  7.22x |  5.17x |  5.12x |
scala_mutable / slang_persistent        :  4.73x |  4.16x |  3.87x |
scalaz_persistent / slang_persistent    :  0.11x |  0.09x |  0.13x |
slang_persistent / java_blocking_mutable:  0.65x |  0.25x |  0.21x |
slang_persistent / java_mutable         :  0.14x |  0.19x |  0.20x |
slang_persistent / scala_mutable        :  0.21x |  0.24x |  0.26x |
slang_persistent / scalaz_persistent    :  9.10x | 10.95x |  7.46x |

Group 'Sort'                            :     10 |   1000 | 100000 |
java_blocking_mutable / slang_persistent:  1.52x |  3.08x |  4.65x |
java_mutable / slang_persistent         :  6.70x |  4.44x |  5.05x |
java_treeset / slang_persistent         :  0.46x |  0.75x |  0.75x |
scala_mutable / slang_persistent        :  4.19x |  3.52x |  3.57x |
scalaz_persistent / slang_persistent    :  0.08x |  0.08x |  0.11x |
slang_persistent / java_blocking_mutable:  0.66x |  0.32x |  0.22x |
slang_persistent / java_mutable         :  0.15x |  0.23x |  0.20x |
slang_persistent / java_treeset         :  2.15x |  1.34x |  1.34x |
slang_persistent / scala_mutable        :  0.24x |  0.28x |  0.28x |
slang_persistent / scalaz_persistent    : 12.20x | 12.48x |  8.76x |
```

> ListBenchmark

```java
Group 'AddAll'                            :    10 |   100 |  1000 | 10000 |
fjava_persistent / slang_persistent       : 0.63x | 0.64x | 0.69x | 0.48x |
java_mutable / slang_persistent           : 0.82x | 1.09x | 0.92x | 0.80x |
java_mutable_linked / slang_persistent    : 0.84x | 0.85x | 0.87x | 0.64x |
pcollections_persistent / slang_persistent: 1.09x | 1.18x | 1.11x | 0.67x |
scala_mutable / slang_persistent          : 0.83x | 0.90x | 0.86x | 0.80x |
scala_persistent / slang_persistent       : 1.06x | 0.97x | 0.92x | 0.73x |
slang_persistent / fjava_persistent       : 1.59x | 1.56x | 1.46x | 2.10x |
slang_persistent / java_mutable           : 1.22x | 0.92x | 1.08x | 1.25x |
slang_persistent / java_mutable_linked    : 1.20x | 1.18x | 1.14x | 1.56x |
slang_persistent / pcollections_persistent: 0.92x | 0.85x | 0.90x | 1.48x |
slang_persistent / scala_mutable          : 1.20x | 1.12x | 1.17x | 1.25x |
slang_persistent / scala_persistent       : 0.95x | 1.03x | 1.09x | 1.37x |

Group 'Iterate'                           :    10 |   100 |  1000 | 10000 |
fjava_persistent / slang_persistent       : 0.81x | 0.98x | 1.01x | 0.98x |
java_mutable / slang_persistent           : 1.22x | 2.52x | 2.68x | 1.84x |
java_mutable_linked / slang_persistent    : 1.26x | 1.57x | 1.50x | 0.78x |
pcollections_persistent / slang_persistent: 1.17x | 1.45x | 1.18x | 0.99x |
scala_mutable / slang_persistent          : 0.86x | 1.31x | 0.80x | 1.06x |
scala_persistent / slang_persistent       : 0.97x | 0.98x | 1.07x | 0.96x |
slang_persistent / fjava_persistent       : 1.23x | 1.02x | 0.99x | 1.02x |
slang_persistent / java_mutable           : 0.82x | 0.40x | 0.37x | 0.54x |
slang_persistent / java_mutable_linked    : 0.79x | 0.64x | 0.67x | 1.28x |
slang_persistent / pcollections_persistent: 0.86x | 0.69x | 0.85x | 1.01x |
slang_persistent / scala_mutable          : 1.17x | 0.76x | 1.24x | 0.95x |
slang_persistent / scala_persistent       : 1.03x | 1.02x | 0.93x | 1.04x |
```

> ArrayBenchmark

```java
Group 'AddAll'                 :    10 |    100 |   1000 |
java_mutable / slang_persistent: 6.30x | 13.17x | 97.02x |
slang_persistent / java_mutable: 0.16x |  0.08x |  0.01x |

Group 'Iterate'                :    10 |    100 |    1000 |
java_mutable / slang_persistent: 4.19x | 27.39x | 448.73x |
slang_persistent / java_mutable: 0.24x |  0.04x |   0.00x |
```