### PR TITLE
fixes benchmark CE

### DIFF
--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/BenchmarkPerformanceReporter.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/BenchmarkPerformanceReporter.java
@@ -390,7 +390,7 @@ public class BenchmarkPerformanceReporter {
         }
 
         public TestExecution(BenchmarkResult benchmark) {
-            Result primaryResult = benchmark.getPrimaryResult();
+            Result<?> primaryResult = benchmark.getPrimaryResult();
             fullName = benchmark.getParams().getBenchmark();
             target = extractPart(fullName, 2);
             operation = extractPart(fullName, 1);


### PR DESCRIPTION
mvn clean test -Pbenchmark

```
[WARNING] COMPILATION WARNING : 
[INFO] -------------------------------------------------------------
[WARNING] /home/ruslan/proj/javaslang/javaslang-benchmark/src/test/java/javaslang/benchmark/BenchmarkPerformanceReporter.java:[393,13] found raw type: org.openjdk.jmh.results.Result
  missing type arguments for generic class org.openjdk.jmh.results.Result<T>
[INFO] 1 warning
[INFO] -------------------------------------------------------------
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /home/ruslan/proj/javaslang/javaslang-benchmark/src/test/java/javaslang/benchmark/BenchmarkPerformanceReporter.java: warnings found and -Werror specified
[INFO] 1 error
```

My environment:

```
$ mvn -version
Apache Maven 3.3.9
Maven home: /usr/share/maven
Java version: 1.8.0_91, vendor: Oracle Corporation
Java home: /usr/lib/jvm/java-8-oracle/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "4.4.0-22-generic", arch: "amd64", family: "unix"
```

/cc @paplorinc @eduardmanas 