### PR TITLE
Optimized `groupBy` operations

### DIFF
--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/BenchmarkPerformanceReporter.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/BenchmarkPerformanceReporter.java
@@ -224,11 +224,11 @@ public class BenchmarkPerformanceReporter {
             if (!alternativeResult.isDefined()) {
                 return "";
             }
-            double alternativeScore = alternativeResult.get().getScore();
+            final double alternativeScore = alternativeResult.get().getScore();
             if (alternativeScore == 0.0) {
                 return "";
             }
-            double ratio = baseResult.getScore() / alternativeScore;
+            final double ratio = baseResult.getScore() / alternativeScore;
             return ratio == 1.0 ? "" : PERFORMANCE_FORMAT.format(ratio) + "x";
         }
     }
@@ -390,14 +390,14 @@ public class BenchmarkPerformanceReporter {
         }
 
         public TestExecution(BenchmarkResult benchmark) {
-            Result primaryResult = benchmark.getPrimaryResult();
+            final Result<?> primaryResult = benchmark.getPrimaryResult();
             fullName = benchmark.getParams().getBenchmark();
             target = extractPart(fullName, 2);
             operation = extractPart(fullName, 1);
             implementation = extractPart(fullName, 0);
             paramKey = getParameterKey(benchmark);
 
-            ListStatistics statistics = createStatisticsWithoutOutliers(benchmark, outlierLowPct, outlierHighPct);
+            final ListStatistics statistics = createStatisticsWithoutOutliers(benchmark, outlierLowPct, outlierHighPct);
             sampleCount = statistics.getN();
             score = statistics.getMean();
             scoreError = statistics.getMeanErrorAt(0.999);
@@ -409,15 +409,15 @@ public class BenchmarkPerformanceReporter {
                     .map(r -> r.getPrimaryResult().getScore())
                     .sorted()
                     .collect(Vector.collector());
-            int size = results.size();
-            int outliersLow = (int) (size * outlierLowPct);
-            int outliersHigh = (int) (size * outlierHighPct);
+            final int size = results.size();
+            final int outliersLow = (int) (size * outlierLowPct);
+            final int outliersHigh = (int) (size * outlierHighPct);
             results = results.drop(outliersLow).dropRight(outliersHigh);
             return new ListStatistics(results.toJavaList().stream().mapToDouble(r -> r).toArray());
         }
 
         private String getParameterKey(BenchmarkResult benchmarkResult) {
-            BenchmarkParams params = benchmarkResult.getParams();
+            final BenchmarkParams params = benchmarkResult.getParams();
             return params.getParamsKeys().stream().map(params::getParam).collect(Collectors.joining(","));
         }
 

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/JmhRunner.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/JmhRunner.java
@@ -3,70 +3,95 @@ package javaslang.benchmark;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.runner.Runner;
-import org.openjdk.jmh.runner.options.Options;
-import org.openjdk.jmh.runner.options.OptionsBuilder;
-import org.openjdk.jmh.runner.options.TimeValue;
+import org.openjdk.jmh.runner.options.*;
 
-import java.util.Collection;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 public class JmhRunner {
-    private static final int WARMUP_ITERATIONS = 10;
-    private static final int MEASUREMENT_ITERATIONS = 40;
+    private static final int WARMUP_ITERATIONS = 20;
+    private static final int MEASUREMENT_ITERATIONS = 30;
 
-    private static final int QUICK_WARMUP_ITERATIONS = 5;
+    private static final int QUICK_WARMUP_ITERATIONS = 10;
     private static final int QUICK_MEASUREMENT_ITERATIONS = 10;
 
     public static void run(Class<?> benchmarkClass) {
-        runAndReport(benchmarkClass, WARMUP_ITERATIONS, MEASUREMENT_ITERATIONS, Assertions.Disable);
+        runAndReport(benchmarkClass, WARMUP_ITERATIONS, MEASUREMENT_ITERATIONS, 500, PrintGc.Enable, Assertions.Disable);
     }
 
     public static void devRun(Class<?> benchmarkClass) {
-        runAndReport(benchmarkClass, QUICK_WARMUP_ITERATIONS, QUICK_MEASUREMENT_ITERATIONS, Assertions.Disable);
+        runAndReport(benchmarkClass, QUICK_WARMUP_ITERATIONS, QUICK_MEASUREMENT_ITERATIONS, 200, PrintGc.Disable, Assertions.Disable);
     }
 
     public static void devRunWithAssertions(Class<?> benchmarkClass) {
-        runAndReport(benchmarkClass, QUICK_WARMUP_ITERATIONS, QUICK_MEASUREMENT_ITERATIONS, Assertions.Enable);
+        runAndReport(benchmarkClass, QUICK_WARMUP_ITERATIONS, QUICK_MEASUREMENT_ITERATIONS, 200, PrintGc.Disable, Assertions.Enable);
     }
 
-    private static void runAndReport(Class<?> benchmarkClass, int warmupIterations, int measurementIterations, Assertions assertions) {
-        Collection<RunResult> results = run(benchmarkClass, warmupIterations, measurementIterations, assertions);
+    private static void runAndReport(Class<?> benchmarkClass, int warmupIterations, int measurementIterations, int millis, PrintGc printGc, Assertions assertions) {
+        final Collection<RunResult> results = run(benchmarkClass, warmupIterations, measurementIterations, millis, printGc, assertions);
         BenchmarkPerformanceReporter.of(results).print();
     }
 
-    private static Collection<RunResult> run(Class<?> benchmarkClass, int warmupIterations, int measurementIterations, Assertions assertions) {
+    private static Collection<RunResult> run(Class<?> benchmarkClass, int warmupIterations, int measurementIterations, int millis, PrintGc printGc, Assertions assertions) {
         final Options opts = new OptionsBuilder()
                 .include(benchmarkClass.getSimpleName())
                 .shouldDoGC(true)
                 .shouldFailOnError(true)
                 .mode(Mode.Throughput)
                 .timeUnit(TimeUnit.SECONDS)
-                .warmupTime(TimeValue.milliseconds(500))
+                .warmupTime(TimeValue.milliseconds(millis))
                 .warmupIterations(warmupIterations)
-                .measurementTime(TimeValue.milliseconds(500))
+                .measurementTime(TimeValue.milliseconds(millis))
                 .measurementIterations(measurementIterations)
                 .forks(1)
                 // We are using 4Gb and setting NewGen to 100% to avoid GC during testing.
                 // Any GC during testing will destroy the iteration, which should get ignored as an outlier
-                .jvmArgsAppend("-XX:+UseG1GC", "-Xss100m", "-Xms4g", "-Xmx4g", "-XX:+PrintGC", "-XX:MaxGCPauseMillis=1000", "-XX:+UnlockExperimentalVMOptions", "-XX:G1NewSizePercent=100", "-XX:G1MaxNewSizePercent=100", assertions.vmArg)
+                .jvmArgsAppend("-XX:+UseG1GC", "-Xss100m", "-Xms4g", "-Xmx4g", "-XX:MaxGCPauseMillis=1000", "-XX:+UnlockExperimentalVMOptions", "-XX:G1NewSizePercent=100", "-XX:G1MaxNewSizePercent=100", printGc.vmArg, assertions.vmArg)
                 .build();
 
         try {
             return new Runner(opts).run();
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
         }
     }
 
-    private static enum Assertions {
+    private enum Assertions {
         Enable("-enableassertions"),
-        Disable("-disableassertions")
-        ;
+        Disable("-disableassertions");
 
         final String vmArg;
+
         Assertions(String vmArg) {
             this.vmArg = vmArg;
         }
+    }
+
+    private enum PrintGc {
+        Enable("-XX:+PrintGC"),
+        Disable("-XX:-PrintGC");
+
+        final String vmArg;
+
+        PrintGc(String vmArg) {
+            this.vmArg = vmArg;
+        }
+    }
+
+    public static <T> void assertEquals(T a, T b) {
+        if (!Objects.equals(a, b)) {
+            throw new IllegalStateException(a + " != " + b);
+        }
+    }
+
+    public static Integer[] getRandomValues(int size, int seed) {
+        final Random random = new Random(seed);
+
+        final Integer[] results = new Integer[size];
+        for (int i = 0; i < size; i++) {
+            final int value = random.nextInt(size) - (size / 2);
+            results[i] = value;
+        }
+        return results;
     }
 }

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/ArrayBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/ArrayBenchmark.java
@@ -1,45 +1,25 @@
 package javaslang.benchmark.collection;
 
-import javaslang.benchmark.JmhRunner;
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.Level;
-import org.openjdk.jmh.annotations.Param;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.*;
 
-import java.util.Objects;
-import java.util.Random;
+import static javaslang.benchmark.JmhRunner.*;
 
 public class ArrayBenchmark {
 
     public static void main(String... args) { /* main is more reliable than a test */
-        JmhRunner.run(ArrayBenchmark.class);
+        run(ArrayBenchmark.class);
     }
 
     @State(Scope.Benchmark)
     public static class Base {
-        @Param({ "10", "100", "1000", "10000"})
+        @Param({ "10", "100", "1000", "10000" })
         public int CONTAINER_SIZE;
 
         public Integer[] ELEMENTS;
 
         @Setup
         public void setup() {
-            final Random random = new Random(0);
-
-            ELEMENTS = new Integer[CONTAINER_SIZE];
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                final int value = random.nextInt(CONTAINER_SIZE) - (CONTAINER_SIZE / 2);
-                ELEMENTS[i] = value;
-            }
-        }
-
-        protected static <T> void assertEquals(T a, T b) {
-            if (!Objects.equals(a, b)) {
-                throw new IllegalStateException(a + " != " + b);
-            }
+            ELEMENTS = getRandomValues(CONTAINER_SIZE, 0);
         }
     }
 

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/PriorityQueueBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/PriorityQueueBenchmark.java
@@ -1,29 +1,21 @@
 package javaslang.benchmark.collection;
 
 import javaslang.Tuple2;
-import javaslang.benchmark.JmhRunner;
 import javaslang.collection.Traversable;
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.Level;
-import org.openjdk.jmh.annotations.Param;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import scala.math.Ordering;
 import scala.math.Ordering$;
-import scalaz.Heap;
-import scalaz.Order;
-import scalaz.Order$;
+import scalaz.*;
 
 import java.util.Collections;
-import java.util.Objects;
-import java.util.Random;
+
+import static javaslang.benchmark.JmhRunner.*;
 
 public class PriorityQueueBenchmark {
 
     public static void main(String... args) { /* main is more reliable than a test */
-        JmhRunner.run(PriorityQueueBenchmark.class);
+        run(PriorityQueueBenchmark.class);
     }
 
     @State(Scope.Benchmark)
@@ -31,7 +23,7 @@ public class PriorityQueueBenchmark {
         protected static final Ordering<Integer> SCALA_ORDERING = Ordering$.MODULE$.comparatorToOrdering(Integer::compareTo);
         protected static final Order<Integer> SCALAZ_ORDER = Order$.MODULE$.fromScalaOrdering(SCALA_ORDERING);
 
-        @Param({ "10", "100", "1000", "10000"})
+        @Param({ "10", "100", "1000", "10000" })
         public int CONTAINER_SIZE;
 
         public Integer[] ELEMENTS;
@@ -39,19 +31,10 @@ public class PriorityQueueBenchmark {
 
         @Setup
         public void setup() {
-            final Random random = new Random(0);
+            ELEMENTS = getRandomValues(CONTAINER_SIZE, 0);
 
-            ELEMENTS = new Integer[CONTAINER_SIZE];
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                final int value = random.nextInt(CONTAINER_SIZE) - (CONTAINER_SIZE / 2);
-                ELEMENTS[i] = value;
-                expectedAggregate ^= value;
-            }
-        }
-
-        protected static <T> void assertEquals(T a, T b) {
-            if (!Objects.equals(a, b)) {
-                throw new IllegalStateException(a + " != " + b);
+            for (int element : ELEMENTS) {
+                expectedAggregate ^= element;
             }
         }
     }

--- a/javaslang/src/main/java/javaslang/collection/Collections.java
+++ b/javaslang/src/main/java/javaslang/collection/Collections.java
@@ -7,7 +7,7 @@ package javaslang.collection;
 
 import javaslang.control.Option;
 
-import java.util.Objects;
+import java.util.*;
 import java.util.function.*;
 
 /**
@@ -37,14 +37,32 @@ final class Collections {
         return (C) collection.filter(removed::contains);
     }
 
+    public static <T, C, R extends Iterable<T>> Map<C, R> groupBy(Traversable<T> collection, Function<? super T, ? extends C> classifier, Function<? super Iterable<T>, R> mapper) {
+        Objects.requireNonNull(collection, "collection is null");
+        Objects.requireNonNull(classifier, "classifier is null");
+        Objects.requireNonNull(mapper, "mapper is null");
+
+        final java.util.Map<C, Collection<T>> mutableResults = new java.util.HashMap<>();
+        for (T value : collection) {
+            final C key = classifier.apply(value);
+            mutableResults.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+        }
+
+        HashMap<C, R> results = HashMap.empty();
+        for (java.util.Map.Entry<C, Collection<T>> entry : mutableResults.entrySet()) {
+            results = results.put(entry.getKey(), mapper.apply(entry.getValue()));
+        }
+        return results;
+    }
+
     static Option<Integer> indexOption(int index) {
         return Option.when(index >= 0, index);
     }
 
     // checks, if the *elements* of the given iterables are equal
     static boolean equals(Iterable<?> iterable1, Iterable<?> iterable2) {
-        java.util.Iterator<?> iter1 = iterable1.iterator();
-        java.util.Iterator<?> iter2 = iterable2.iterator();
+        final java.util.Iterator<?> iter1 = iterable1.iterator();
+        final java.util.Iterator<?> iter2 = iterable2.iterator();
         while (iter1.hasNext() && iter2.hasNext()) {
             if (!Objects.equals(iter1.next(), iter2.next())) {
                 return false;
@@ -101,7 +119,7 @@ final class Collections {
             return empty;
         } else {
             @SuppressWarnings("unchecked")
-            T[] elements = (T[]) new Object[n];
+            final T[] elements = (T[]) new Object[n];
             for (int i = 0; i < n; i++) {
                 elements[i] = f.apply(i);
             }

--- a/javaslang/src/main/java/javaslang/collection/Iterator.java
+++ b/javaslang/src/main/java/javaslang/collection/Iterator.java
@@ -1389,17 +1389,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
 
     @Override
     default <C> Map<C, Iterator<T>> groupBy(Function<? super T, ? extends C> classifier) {
-        Objects.requireNonNull(classifier, "classifier is null");
-        if (!hasNext()) {
-            return HashMap.empty();
-        } else {
-            final Map<C, Stream<T>> streams = foldLeft(HashMap.empty(), (map, entry) -> {
-                final C key = classifier.apply(entry);
-                final Stream<T> values = map.get(key).map(entries -> entries.append(entry)).getOrElse(Stream.of(entry));
-                return map.put(key, values);
-            });
-            return streams.map((c, ts) -> Tuple.of(c, ts.iterator()));
-        }
+        return Collections.groupBy(this, classifier, Iterator::ofAll);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/List.java
+++ b/javaslang/src/main/java/javaslang/collection/List.java
@@ -669,8 +669,7 @@ public interface List<T> extends Kind1<List<?>, T>, LinearSeq<T>, Stack<T> {
 
     @Override
     default <C> Map<C, List<T>> groupBy(Function<? super T, ? extends C> classifier) {
-        Objects.requireNonNull(classifier, "classifier is null");
-        return iterator().groupBy(classifier).map((c, it) -> Tuple.of(c, ofAll(it)));
+        return Collections.groupBy(this, classifier, List::ofAll);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/Queue.java
+++ b/javaslang/src/main/java/javaslang/collection/Queue.java
@@ -626,8 +626,7 @@ public final class Queue<T> extends AbstractsQueue<T, Queue<T>> implements Linea
 
     @Override
     public <C> Map<C, Queue<T>> groupBy(Function<? super T, ? extends C> classifier) {
-        Objects.requireNonNull(classifier, "classifier is null");
-        return iterator().groupBy(classifier).map((c, it) -> Tuple.of(c, ofAll(it)));
+        return Collections.groupBy(this, classifier, Queue::ofAll);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/Stream.java
+++ b/javaslang/src/main/java/javaslang/collection/Stream.java
@@ -862,8 +862,7 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
 
     @Override
     default <C> Map<C, Stream<T>> groupBy(Function<? super T, ? extends C> classifier) {
-        Objects.requireNonNull(classifier, "classifier is null");
-        return iterator().groupBy(classifier).map((c, it) -> Tuple.of(c, Stream.ofAll(it)));
+        return Collections.groupBy(this, classifier, Stream::ofAll);
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/javaslang/javaslang/issues/1345

Before:
```java
Target         Operation                               Ratio          10        100       1000 
ListBenchmark  GroupBy     fjava_persistent/slang_persistent       0.90x      0.13x      0.05x 
ListBenchmark  GroupBy         java_mutable/slang_persistent      19.23x     20.13x     15.16x 
ListBenchmark  GroupBy     scala_persistent/slang_persistent       4.96x      8.49x     10.34x 
```
i.e. it was `~10x` slower than `Scala`

After:
```java
Target         Operation                               Ratio          10        100       1000 
ListBenchmark  GroupBy     fjava_persistent/slang_persistent       0.11x      0.01x      0.00x 
ListBenchmark  GroupBy         java_mutable/slang_persistent       2.55x      2.00x      1.19x 
ListBenchmark  GroupBy     scala_persistent/slang_persistent       0.66x      0.83x      1.04x
```
i.e. it's usually faster than `Scala`