### PR TITLE
makes HAMT iteration 10x faster

### DIFF
--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/HashSetBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/HashSetBenchmark.java
@@ -1,0 +1,106 @@
+package javaslang.benchmark.collection;
+
+import org.openjdk.jmh.annotations.*;
+
+import static javaslang.benchmark.JmhRunner.*;
+
+public class HashSetBenchmark {
+    public static void main(String... args) { /* main is more reliable than a test */
+        run(HashSetBenchmark.class);
+    }
+
+    @State(Scope.Benchmark)
+    public static class Base {
+        @Param({"10", "100", "1000"})
+        public int CONTAINER_SIZE;
+
+        public Integer[] ELEMENTS;
+        public int SET_SIZE;
+        public int EXPECTED_AGGREGATE;
+
+        @Setup
+        public void setup() {
+            ELEMENTS = getRandomValues(CONTAINER_SIZE, 0);
+            SET_SIZE = javaslang.collection.Stream.of(ELEMENTS).distinct().size();
+            EXPECTED_AGGREGATE = javaslang.collection.Stream.of(ELEMENTS).distinct().fold(0, (i, j) -> i ^ j);
+        }
+    }
+
+    public static class AddAll extends Base {
+
+        @Benchmark
+        public void pcollections_persistent() {
+            org.pcollections.PSet<Integer> values = org.pcollections.HashTreePSet.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.plus(element);
+            }
+            assertEquals(values.size(), SET_SIZE);
+        }
+
+        @Benchmark
+        public void scala_immutable() {
+            scala.collection.immutable.HashSet<Integer> values = new scala.collection.immutable.HashSet<>();
+            for (Integer element : ELEMENTS) {
+                values = values.$plus(element);
+            }
+            assertEquals(values.size(), SET_SIZE);
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            javaslang.collection.Set<Integer> values = javaslang.collection.HashSet.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.add(element);
+            }
+            assertEquals(values.size(), SET_SIZE);
+        }
+    }
+
+    public static class Iterate extends Base {
+
+        org.pcollections.PSet<Integer> pcollectionsPersistent = org.pcollections.HashTreePSet.empty();
+        scala.collection.immutable.HashSet<Integer> scalaPersistent = new scala.collection.immutable.HashSet<>();
+        javaslang.collection.Set<Integer> slangPersistent = javaslang.collection.HashSet.empty();
+
+        @Setup
+        public void initializeImmutable(Base state) {
+            for (Integer element : state.ELEMENTS) {
+                pcollectionsPersistent = pcollectionsPersistent.plus(element);
+                scalaPersistent = scalaPersistent.$plus(element);
+                slangPersistent = slangPersistent.add(element);
+            }
+            assertEquals(pcollectionsPersistent.size(), state.SET_SIZE);
+            assertEquals(scalaPersistent.size(), state.SET_SIZE);
+            assertEquals(slangPersistent.size(), state.SET_SIZE);
+        }
+
+        @Benchmark
+        public void scala_persistent() {
+            int aggregate = 0;
+            for (final scala.collection.Iterator<Integer> iterator = scalaPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, EXPECTED_AGGREGATE);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void pcollections_persistent() {
+            int aggregate = 0;
+            for (final java.util.Iterator<Integer> iterator = pcollectionsPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, EXPECTED_AGGREGATE);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void slang_persistent() {
+            int aggregate = 0;
+            for (final javaslang.collection.Iterator<Integer> iterator = slangPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, EXPECTED_AGGREGATE);
+        }
+    }
+}

--- a/javaslang/src/main/java/javaslang/collection/HashArrayMappedTrie.java
+++ b/javaslang/src/main/java/javaslang/collection/HashArrayMappedTrie.java
@@ -51,9 +51,10 @@ interface HashArrayMappedTrieModule {
         PUT, REMOVE
     }
 
-    class It<K, V> extends AbstractIterator<LeafNode<K, V>> {
+    class LeafNodeIterator<K, V> extends AbstractIterator<LeafNode<K, V>> {
 
-        private final static int MAX_LEVELS = Integer.SIZE / AbstractNode.SIZE + 1;
+        // buckets levels + leaf level = (Integer.SIZE / AbstractNode.SIZE + 1) + 1
+        private final static int MAX_LEVELS = Integer.SIZE / AbstractNode.SIZE + 2;
 
         private final int total;
         private final Object[] nodes = new Object[MAX_LEVELS];
@@ -62,7 +63,7 @@ interface HashArrayMappedTrieModule {
         private int level;
         private int ptr = 0;
 
-        It(AbstractNode<K, V> root) {
+        LeafNodeIterator(AbstractNode<K, V> root) {
             total = root.size();
             level = downstairs(nodes, indexes, root, 0);
         }
@@ -126,7 +127,7 @@ interface HashArrayMappedTrieModule {
                 return index < subNodes.length ? (AbstractNode<K, V>) subNodes[index] : null;
             } else if (node instanceof ArrayNode) {
                 ArrayNode<K, V> arrayNode = (ArrayNode<K, V>) node;
-                return index < 32 ? (AbstractNode<K, V>) arrayNode.subNodes[index] : null;
+                return index < AbstractNode.BUCKET_SIZE ? (AbstractNode<K, V>) arrayNode.subNodes[index] : null;
             }
             return null;
         }
@@ -183,7 +184,7 @@ interface HashArrayMappedTrieModule {
         abstract AbstractNode<K, V> modify(int shift, int keyHashCode, K key, V value, Action action);
 
         Iterator<LeafNode<K, V>> nodes() {
-            return new It<>(this);
+            return new LeafNodeIterator<>(this);
         }
 
         @Override

--- a/javaslang/src/main/java/javaslang/collection/HashArrayMappedTrie.java
+++ b/javaslang/src/main/java/javaslang/collection/HashArrayMappedTrie.java
@@ -39,16 +39,97 @@ interface HashArrayMappedTrie<K, V> extends Iterable<Tuple2<K, V>> {
 
     HashArrayMappedTrie<K, V> remove(K key);
 
-    // this is a javaslang.collection.Iterator!
     @Override
     Iterator<Tuple2<K, V>> iterator();
 
+    Iterator<K> keysIterator();
 }
 
 interface HashArrayMappedTrieModule {
 
     enum Action {
         PUT, REMOVE
+    }
+
+    class It<K, V> extends AbstractIterator<LeafNode<K, V>> {
+
+        private final static int MAX_LEVELS = Integer.SIZE / AbstractNode.SIZE + 1;
+
+        private final int total;
+        private final Object[] nodes = new Object[MAX_LEVELS];
+        private final int[] indexes = new int[MAX_LEVELS];
+
+        private int level;
+        private int ptr = 0;
+
+        It(AbstractNode<K, V> root) {
+            total = root.size();
+            level = downstairs(nodes, indexes, root, 0);
+        }
+
+        @Override
+        public boolean hasNext() {
+            return ptr < total;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        protected LeafNode<K, V> getNext() {
+            Object node = nodes[level];
+            while (!(node instanceof LeafNode)) {
+                node = findNextLeaf();
+            }
+            ptr++;
+            if (node instanceof LeafList) {
+                LeafList<K, V> leaf = (LeafList<K, V>) node;
+                nodes[level] = leaf.tail;
+                return leaf;
+            } else {
+                nodes[level] = EmptyNode.instance();
+                return (LeafSingleton<K, V>) node;
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        private Object findNextLeaf() {
+            AbstractNode<K, V> node = null;
+            while (level > 0) {
+                level--;
+                indexes[level]++;
+                node = getChild((AbstractNode<K, V>) nodes[level], indexes[level]);
+                if (node != null) {
+                    break;
+                }
+            }
+            level = downstairs(nodes, indexes, node, level + 1);
+            return nodes[level];
+        }
+
+        private static <K, V> int downstairs(Object[] nodes, int[] indexes, AbstractNode<K, V> root, int level) {
+            while (true) {
+                nodes[level] = root;
+                indexes[level] = 0;
+                root = getChild(root, 0);
+                if (root == null) {
+                    break;
+                } else {
+                    level++;
+                }
+            }
+            return level;
+        }
+
+        @SuppressWarnings("unchecked")
+        private static <K, V> AbstractNode<K, V> getChild(AbstractNode<K, V> node, int index) {
+            if (node instanceof IndexedNode) {
+                Object[] subNodes = ((IndexedNode<K, V>) node).subNodes;
+                return index < subNodes.length ? (AbstractNode<K, V>) subNodes[index] : null;
+            } else if (node instanceof ArrayNode) {
+                ArrayNode<K, V> arrayNode = (ArrayNode<K, V>) node;
+                return index < 32 ? (AbstractNode<K, V>) arrayNode.subNodes[index] : null;
+            }
+            return null;
+        }
     }
 
     /**
@@ -100,6 +181,20 @@ interface HashArrayMappedTrieModule {
         abstract Option<V> lookup(int shift, int keyHashCode, K key);
 
         abstract AbstractNode<K, V> modify(int shift, int keyHashCode, K key, V value, Action action);
+
+        Iterator<LeafNode<K, V>> nodes() {
+            return new It<>(this);
+        }
+
+        @Override
+        public Iterator<Tuple2<K, V>> iterator() {
+            return nodes().map(node -> Tuple.of(node.key(), node.value()));
+        }
+
+        @Override
+        public Iterator<K> keysIterator() {
+            return nodes().map(LeafNode::key);
+        }
 
         @Override
         public Option<V> get(K key) {
@@ -184,7 +279,7 @@ interface HashArrayMappedTrieModule {
         }
 
         @Override
-        public Iterator<Tuple2<K, V>> iterator() {
+        public Iterator<LeafNode<K, V>> nodes() {
             return Iterator.empty();
         }
 
@@ -282,9 +377,8 @@ interface HashArrayMappedTrieModule {
         }
 
         @Override
-        public Iterator<Tuple2<K, V>> iterator() {
-            Tuple2<K, V> tuple = Tuple.of(key, value);
-            return Iterator.of(tuple);
+        public Iterator<LeafNode<K, V>> nodes() {
+            return Iterator.of(this);
         }
 
         @Override
@@ -398,8 +492,8 @@ interface HashArrayMappedTrieModule {
         }
 
         @Override
-        public Iterator<Tuple2<K, V>> iterator() {
-            return new AbstractIterator<Tuple2<K, V>>() {
+        public Iterator<LeafNode<K, V>> nodes() {
+            return new AbstractIterator<LeafNode<K, V>>() {
                 LeafNode<K, V> node = LeafList.this;
 
                 @Override
@@ -408,14 +502,14 @@ interface HashArrayMappedTrieModule {
                 }
 
                 @Override
-                public Tuple2<K, V> getNext() {
-                    Tuple2<K, V> tuple = Tuple.of(node.key(), node.value());
+                public LeafNode<K, V> getNext() {
+                    LeafNode<K, V> result = node;
                     if (node instanceof LeafSingleton) {
                         node = null;
                     } else {
                         node = ((LeafList<K, V>) node).tail;
                     }
-                    return tuple;
+                    return result;
                 }
             };
         }
@@ -542,11 +636,6 @@ interface HashArrayMappedTrieModule {
         }
 
         @Override
-        public Iterator<Tuple2<K, V>> iterator() {
-            return Iterator.concat(Array.wrap(subNodes));
-        }
-
-        @Override
         public int hashCode() {
             return Objects.hash(subNodes);
         }
@@ -624,11 +713,6 @@ interface HashArrayMappedTrieModule {
         @Override
         public int size() {
             return size;
-        }
-
-        @Override
-        public Iterator<Tuple2<K, V>> iterator() {
-            return Iterator.concat(Array.wrap(subNodes));
         }
 
         @Override

--- a/javaslang/src/main/java/javaslang/collection/HashSet.java
+++ b/javaslang/src/main/java/javaslang/collection/HashSet.java
@@ -619,7 +619,7 @@ public final class HashSet<T> implements Kind1<HashSet<?>, T>, Set<T>, Serializa
 
     @Override
     public Iterator<T> iterator() {
-        return tree.iterator().map(t -> t._1);
+        return tree.keysIterator();
     }
 
     @Override

--- a/javaslang/src/test/java/javaslang/collection/HashArrayMappedTrieTest.java
+++ b/javaslang/src/test/java/javaslang/collection/HashArrayMappedTrieTest.java
@@ -57,6 +57,14 @@ public class HashArrayMappedTrieTest {
     }
 
     @Test
+    public void testDeepestTree() {
+        HashArrayMappedTrie<Integer, Integer> hamt = empty();
+        List<Integer> ints = List.tabulate(Integer.SIZE, i -> 1 << i).sorted();
+        hamt = ints.foldLeft(hamt, (h, i) -> h.put(i, i));
+        assertThat(List.ofAll(hamt.keysIterator()).sorted()).isEqualTo(ints);
+    }
+
+    @Test
     public void testBigData() {
         testBigData(5000, t -> t);
     }


### PR DESCRIPTION
The HAMT iterator completely redesigned

**before**
```
Target            Operation   Impl                         Params  Count            Score  ±     Error    Unit
HashSetBenchmark  Iterate     slang_persistent               1000     18        4,299.731  ±     1.18%   ops/s
HashSetBenchmark  Iterate     slang_persistent                100     18       45,524.153  ±     1.77%   ops/s
HashSetBenchmark  Iterate     slang_persistent                 10     18      680,479.197  ±     1.31%   ops/s
HashSetBenchmark  Iterate     scala_persistent               1000     18      129,055.550  ±     0.24%   ops/s
HashSetBenchmark  Iterate     scala_persistent                100     18    1,437,694.285  ±     0.83%   ops/s
HashSetBenchmark  Iterate     scala_persistent                 10     18   22,035,129.813  ±     1.27%   ops/s
HashSetBenchmark  Iterate     pcollections_persistent        1000     18       44,336.905  ±     1.08%   ops/s
HashSetBenchmark  Iterate     pcollections_persistent         100     18      472,947.893  ±     1.33%   ops/s
HashSetBenchmark  Iterate     pcollections_persistent          10     18    3,469,540.882  ±     0.70%   ops/s

Performance Ratios
================================================================================================================
  (Outliers removed: 30.00% low end, 10.00% high end)

Ratios slang / <alternative_impl>
Target            Operation   Ratio                                                    10        100       1000 
HashSetBenchmark  Iterate     slang_persistent/pcollections_persistent              0.20x      0.10x      0.10x 
HashSetBenchmark  Iterate     slang_persistent/scala_persistent                     0.03x      0.03x      0.03x 

Ratios <alternative_impl> / slang
Target            Operation                                             Ratio          10        100       1000 
HashSetBenchmark  Iterate            pcollections_persistent/slang_persistent       5.10x     10.39x     10.31x 
HashSetBenchmark  Iterate                   scala_persistent/slang_persistent      32.38x     31.58x     30.01x 
```

**after**

```
Target            Operation   Impl                         Params  Count            Score  ±     Error    Unit
HashSetBenchmark  Iterate     slang_persistent               1000     18       49,484.074  ±     0.26%   ops/s
HashSetBenchmark  Iterate     slang_persistent                100     18      522,937.431  ±     0.98%   ops/s
HashSetBenchmark  Iterate     slang_persistent                 10     18    4,728,144.061  ±     1.99%   ops/s
HashSetBenchmark  Iterate     scala_persistent               1000     18      130,241.725  ±     0.38%   ops/s
HashSetBenchmark  Iterate     scala_persistent                100     18    1,595,782.555  ±     1.03%   ops/s
HashSetBenchmark  Iterate     scala_persistent                 10     18   22,418,589.165  ±     1.87%   ops/s
HashSetBenchmark  Iterate     pcollections_persistent        1000     18       45,362.049  ±     1.55%   ops/s
HashSetBenchmark  Iterate     pcollections_persistent         100     18      471,520.387  ±     0.25%   ops/s
HashSetBenchmark  Iterate     pcollections_persistent          10     18    3,433,121.007  ±     3.10%   ops/s

Performance Ratios
================================================================================================================
  (Outliers removed: 30.00% low end, 10.00% high end)

Ratios slang / <alternative_impl>
Target            Operation   Ratio                                                    10        100       1000 
HashSetBenchmark  Iterate     slang_persistent/pcollections_persistent              1.38x      1.11x      1.09x 
HashSetBenchmark  Iterate     slang_persistent/scala_persistent                     0.21x      0.33x      0.38x 

Ratios <alternative_impl> / slang
Target            Operation                                             Ratio          10        100       1000 
HashSetBenchmark  Iterate            pcollections_persistent/slang_persistent       0.73x      0.90x      0.92x 
HashSetBenchmark  Iterate                   scala_persistent/slang_persistent       4.74x      3.05x      2.63x 
```