### PR TITLE
BitSet benchmark

### DIFF
--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/JmhRunner.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/JmhRunner.java
@@ -85,11 +85,15 @@ public class JmhRunner {
     }
 
     public static Integer[] getRandomValues(int size, int seed) {
+        return getRandomValues(size, seed, false);
+    }
+
+    public static Integer[] getRandomValues(int size, int seed, boolean nonNegative) {
         final Random random = new Random(seed);
 
         final Integer[] results = new Integer[size];
         for (int i = 0; i < size; i++) {
-            final int value = random.nextInt(size) - (size / 2);
+            final int value = random.nextInt(size) - (nonNegative ? 0 : (size / 2));
             results[i] = value;
         }
         return results;

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/BitSetBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/BitSetBenchmark.java
@@ -1,0 +1,91 @@
+package javaslang.benchmark.collection;
+
+import org.openjdk.jmh.annotations.*;
+
+import static javaslang.benchmark.JmhRunner.*;
+
+public class BitSetBenchmark {
+    public static void main(String... args) { /* main is more reliable than a test */
+        run(BitSetBenchmark.class);
+    }
+
+    @State(Scope.Benchmark)
+    public static class Base {
+        @Param({"10", "100", "1000"})
+        public int CONTAINER_SIZE;
+
+        public Integer[] ELEMENTS;
+        public int[] PRIMITIVES;
+        public int SET_SIZE;
+        public int EXPECTED_AGGREGATE;
+
+        @Setup
+        public void setup() {
+            ELEMENTS = getRandomValues(CONTAINER_SIZE, 0, true);
+            SET_SIZE = javaslang.collection.Stream.of(ELEMENTS).distinct().size();
+            EXPECTED_AGGREGATE = javaslang.collection.Stream.of(ELEMENTS).distinct().fold(0, (i, j) -> i ^ j);
+            PRIMITIVES = new int[ELEMENTS.length];
+            for (int i = 0; i < ELEMENTS.length; i++) {
+                PRIMITIVES[i] = ELEMENTS[i];
+            }
+        }
+    }
+
+    public static class AddAll extends Base {
+
+        @Benchmark
+        public void scala_persistent() {
+            scala.collection.immutable.BitSet values = new scala.collection.immutable.BitSet.BitSet1(0L);
+            for (int element : PRIMITIVES) {
+                values = values.$plus(element);
+            }
+            assertEquals(values.size(), SET_SIZE);
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            javaslang.collection.Set<Integer> values = javaslang.collection.BitSet.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.add(element);
+            }
+            assertEquals(values.size(), SET_SIZE);
+        }
+    }
+
+    public static class Iterate extends Base {
+
+        scala.collection.immutable.BitSet scalaPersistent = new scala.collection.immutable.BitSet.BitSet1(0L);
+        javaslang.collection.Set<Integer> slangPersistent = javaslang.collection.BitSet.empty();
+
+        @Setup
+        public void initializeImmutable(Base state) {
+            for (Integer element : state.ELEMENTS) {
+                slangPersistent = slangPersistent.add(element);
+            }
+            for (int element : state.ELEMENTS) {
+                scalaPersistent = scalaPersistent.$plus(element);
+            }
+            assertEquals(scalaPersistent.size(), state.SET_SIZE);
+            assertEquals(slangPersistent.size(), state.SET_SIZE);
+        }
+
+        @Benchmark
+        public void scala_persistent() {
+            int aggregate = 0;
+            for (final scala.collection.Iterator<Object> iterator = scalaPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= (int) iterator.next();
+            }
+            assertEquals(aggregate, EXPECTED_AGGREGATE);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void slang_persistent() {
+            int aggregate = 0;
+            for (final javaslang.collection.Iterator<Integer> iterator = slangPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, EXPECTED_AGGREGATE);
+        }
+    }
+}


### PR DESCRIPTION
*  benchmark added
* `BitSet::add()` and `BitSet::iterator()` improved

Iteration looks good :)

```
Target           Operation   Impl                  Params  Count            Score  ±     Error    Unit
BitSetBenchmark  Iterate     slang_persistent        1000     18      239,144.881  ±     1.70%   ops/s
BitSetBenchmark  Iterate     slang_persistent         100     18    5,883,522.914  ±     0.19%   ops/s
BitSetBenchmark  Iterate     slang_persistent          10     18   44,422,598.204  ±     1.02%   ops/s
BitSetBenchmark  Iterate     scala_persistent        1000     18      178,306.935  ±     0.71%   ops/s
BitSetBenchmark  Iterate     scala_persistent         100     18    1,523,338.724  ±     1.08%   ops/s
BitSetBenchmark  Iterate     scala_persistent          10     18    5,945,297.885  ±     0.66%   ops/s
BitSetBenchmark  AddAll      slang_persistent        1000     18       43,657.963  ±     1.47%   ops/s
BitSetBenchmark  AddAll      slang_persistent         100     18    1,485,753.189  ±     1.10%   ops/s
BitSetBenchmark  AddAll      slang_persistent          10     18   11,637,192.098  ±     1.36%   ops/s
BitSetBenchmark  AddAll      scala_persistent        1000     18       29,501.872  ±     0.89%   ops/s
BitSetBenchmark  AddAll      scala_persistent         100     18    1,797,459.162  ±     1.04%   ops/s
BitSetBenchmark  AddAll      scala_persistent          10     18   19,959,807.260  ±     2.02%   ops/s

Performance Ratios
=================================================================================================
  (Outliers removed: 30.00% low end, 10.00% high end)

Ratios slang / <alternative_impl>
Target           Operation   Ratio                                      10        100       1000 
BitSetBenchmark  AddAll      slang_persistent/scala_persistent       0.58x      0.83x      1.48x 
BitSetBenchmark  Iterate     slang_persistent/scala_persistent       7.47x      3.86x      1.34x 

Ratios <alternative_impl> / slang
Target           Operation                               Ratio          10        100       1000 
BitSetBenchmark  AddAll      scala_persistent/slang_persistent       1.72x      1.21x      0.68x 
BitSetBenchmark  Iterate     scala_persistent/slang_persistent       0.13x      0.26x      0.75x 
```