### PR TITLE
Optimized front and back operations for `Vector`

### DIFF
--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/VectorBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/VectorBenchmark.java
@@ -1,0 +1,446 @@
+package javaslang.benchmark.collection;
+
+import javaslang.benchmark.JmhRunner;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import scala.compat.java8.JFunction;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static javaslang.benchmark.JmhRunner.*;
+
+public class VectorBenchmark {
+    public static void main(String... args) {
+        JmhRunner.runDev(VectorBenchmark.class);
+    }
+
+    @State(Scope.Benchmark)
+    public static class Base {
+        @Param({ "10", "100", "1000" })
+        public int CONTAINER_SIZE;
+
+        int expectedAggregate = 0;
+        public Integer[] ELEMENTS;
+
+        /* Only use these for non-mutating operations */
+        final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
+
+        fj.data.Seq<Integer> fjavaPersistent = fj.data.Seq.empty();
+        org.pcollections.PVector<Integer> pcollectionsPersistent = org.pcollections.TreePVector.empty();
+        scala.collection.immutable.Vector<Integer> scalaPersistent = scala.collection.immutable.Vector$.MODULE$.empty();
+        javaslang.collection.Vector<Integer> slangPersistent = javaslang.collection.Vector.empty();
+
+        @Setup
+        public void setup() {
+            ELEMENTS = getRandomValues(CONTAINER_SIZE, 0);
+
+            assertEquals(javaMutable.size(), 0);
+            assertEquals(fjavaPersistent.length(), 0);
+            assertEquals(pcollectionsPersistent.size(), 0);
+            assertEquals(scalaPersistent.size(), 0);
+            assertEquals(slangPersistent.size(), 0);
+            for (Integer element : ELEMENTS) {
+                expectedAggregate ^= element;
+
+                javaMutable.add(element);
+
+                fjavaPersistent = fjavaPersistent.snoc(element);
+                pcollectionsPersistent = pcollectionsPersistent.plus(element);
+                scalaPersistent = scalaPersistent.appendBack(element);
+                slangPersistent = slangPersistent.append(element);
+            }
+            assertEquals(javaMutable.size(), CONTAINER_SIZE);
+            assertEquals(fjavaPersistent.length(), CONTAINER_SIZE);
+            assertEquals(pcollectionsPersistent.size(), CONTAINER_SIZE);
+            assertEquals(scalaPersistent.size(), CONTAINER_SIZE);
+            assertEquals(slangPersistent.size(), CONTAINER_SIZE);
+        }
+    }
+
+    public static class Head extends Base {
+        @Benchmark
+        public Object java_mutable() { return javaMutable.get(0); }
+
+        @Benchmark
+        public Object scala_persistent() { return scalaPersistent.head(); }
+
+        @Benchmark
+        public Object fjava_persistent() { return fjavaPersistent.head(); }
+
+        @Benchmark
+        public Object pcollections_persistent() { return pcollectionsPersistent.get(0); }
+
+        @Benchmark
+        public Object slang_persistent() { return slangPersistent.head(); }
+    }
+
+    public static class Tail extends Base {
+        @State(Scope.Thread)
+        public static class Initialized {
+            final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
+
+            @Setup(Level.Invocation)
+            public void initializeMutable(Base state) {
+                assertEquals(javaMutable.size(), 0);
+                Collections.addAll(javaMutable, state.ELEMENTS);
+                assertEquals(javaMutable.size(), state.CONTAINER_SIZE);
+            }
+
+            @TearDown(Level.Invocation)
+            public void tearDown() {
+                javaMutable.clear();
+            }
+        }
+
+        @Benchmark
+        public void java_mutable(Initialized state) {
+            final java.util.ArrayList<Integer> values = state.javaMutable;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values.remove(0);
+            }
+            assertEquals(values, new java.util.ArrayList<>());
+        }
+
+        @Benchmark
+        public void scala_persistent() {
+            scala.collection.immutable.Vector<Integer> values = scalaPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.tail();
+            }
+            assertEquals(values, scala.collection.immutable.Vector.empty());
+        }
+
+        @Benchmark
+        public void fjava_persistent() {
+            fj.data.Seq<Integer> values = fjavaPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.tail();
+            }
+            assertEquals(values, fj.data.Seq.empty());
+        }
+
+        @Benchmark
+        public void pcollections_persistent() {
+            org.pcollections.PVector<Integer> values = pcollectionsPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.minus(0);
+            }
+            assertEquals(values, org.pcollections.TreePVector.empty());
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            javaslang.collection.Vector<Integer> values = slangPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.tail();
+            }
+            assertEquals(values, javaslang.collection.Vector.empty());
+        }
+    }
+
+    public static class Get extends Base {
+        @Benchmark
+        public void java_mutable() {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                assertEquals(javaMutable.get(i), ELEMENTS[i]);
+            }
+        }
+
+        @Benchmark
+        public void scala_persistent() {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                assertEquals(scalaPersistent.apply(i), ELEMENTS[i]);
+            }
+        }
+
+        @Benchmark
+        public void fjava_persistent() {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                assertEquals(fjavaPersistent.index(i), ELEMENTS[i]);
+            }
+        }
+
+        @Benchmark
+        public void pcollections_persistent() {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                assertEquals(pcollectionsPersistent.get(i), ELEMENTS[i]);
+            }
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                assertEquals(slangPersistent.get(i), ELEMENTS[i]);
+            }
+        }
+    }
+
+    public static class Update extends Base {
+        @State(Scope.Thread)
+        public static class Initialized {
+            final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
+
+            @Setup(Level.Invocation)
+            public void initializeMutable(Base state) {
+                assertEquals(javaMutable.size(), 0);
+                Collections.addAll(javaMutable, state.ELEMENTS);
+                assertEquals(javaMutable.size(), state.CONTAINER_SIZE);
+            }
+
+            @TearDown(Level.Invocation)
+            public void tearDown() {
+                javaMutable.clear();
+            }
+        }
+
+        @Benchmark
+        public Object java_mutable(Initialized state) {
+            final java.util.ArrayList<Integer> values = state.javaMutable;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values.set(i, 0);
+            }
+            return values;
+        }
+
+        @Benchmark
+        public Object scala_persistent() {
+            scala.collection.immutable.Vector<Integer> values = scalaPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.updateAt(i, 0);
+            }
+            return values;
+        }
+
+        @Benchmark
+        public Object fjava_persistent() {
+            fj.data.Seq<Integer> values = fjavaPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.update(i, 0);
+            }
+            return values;
+        }
+
+        @Benchmark
+        public Object pcollections_persistent() {
+            org.pcollections.PVector<Integer> values = pcollectionsPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.with(i, 0);
+            }
+            return values;
+        }
+
+        @Benchmark
+        public Object slang_persistent() {
+            javaslang.collection.Vector<Integer> values = slangPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.update(i, 0);
+            }
+            return values;
+        }
+    }
+
+    public static class Prepend extends Base {
+        @Benchmark
+        @SuppressWarnings("ManualArrayToCollectionCopy")
+        public void java_mutable() {
+            final java.util.ArrayList<Integer> values = new java.util.ArrayList<>(CONTAINER_SIZE);
+            for (Integer element : ELEMENTS) {
+                values.add(0, element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void scala_persistent() {
+            scala.collection.immutable.Vector<Integer> values = scala.collection.immutable.Vector$.MODULE$.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.appendFront(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void fjava_persistent() {
+            fj.data.Seq<Integer> values = fj.data.Seq.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.cons(element);
+            }
+            assertEquals(values.length(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void pcollections_persistent() {
+            org.pcollections.PVector<Integer> values = org.pcollections.TreePVector.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.plus(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            javaslang.collection.Vector<Integer> values = javaslang.collection.Vector.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.prepend(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+    }
+
+    public static class Append extends Base {
+        @Benchmark
+        @SuppressWarnings("ManualArrayToCollectionCopy")
+        public void java_mutable() {
+            final java.util.ArrayList<Integer> values = new java.util.ArrayList<>(CONTAINER_SIZE);
+            for (Integer element : ELEMENTS) {
+                values.add(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void scala_persistent() {
+            scala.collection.immutable.Vector<Integer> values = scala.collection.immutable.Vector$.MODULE$.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.appendBack(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void fjava_persistent() {
+            fj.data.Seq<Integer> values = fj.data.Seq.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.snoc(element);
+            }
+            assertEquals(values.length(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void pcollections_persistent() {
+            org.pcollections.PVector<Integer> values = org.pcollections.TreePVector.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.plus(values.size(), element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            javaslang.collection.Vector<Integer> values = javaslang.collection.Vector.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.append(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+    }
+
+    public static class GroupBy extends Base {
+        @Benchmark
+        public Object java_mutable() { return javaMutable.stream().collect(Collectors.groupingBy(Integer::bitCount)); }
+
+        @Benchmark
+        public Object scala_persistent() { return scalaPersistent.groupBy(JFunction.func(Integer::bitCount)); }
+
+        @Benchmark
+        public Object slang_persistent() { return slangPersistent.groupBy(Integer::bitCount); }
+    }
+
+    public static class Slice extends Base {
+        @Benchmark
+        public void java_mutable(Blackhole bh) {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                for (int j = i; j < CONTAINER_SIZE; j++) {
+                    bh.consume(javaMutable.subList(i, j));
+                }
+            }
+        }
+
+        @Benchmark
+        public void scala_persistent(Blackhole bh) {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                for (int j = i; j < CONTAINER_SIZE; j++) {
+                    bh.consume(scalaPersistent.slice(i, j));
+                }
+            }
+        }
+
+        @Benchmark
+        public void slang_persistent(Blackhole bh) {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                for (int j = i; j < CONTAINER_SIZE; j++) {
+                    bh.consume(slangPersistent.slice(i, j));
+                }
+            }
+        }
+    }
+
+    public static class Iterate extends Base {
+        @State(Scope.Thread)
+        public static class Initialized {
+            final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
+
+            @Setup(Level.Invocation)
+            public void initializeMutable(Base state) {
+                assertEquals(javaMutable.size(), 0);
+                Collections.addAll(javaMutable, state.ELEMENTS);
+                assertEquals(javaMutable.size(), state.CONTAINER_SIZE);
+            }
+
+            @TearDown(Level.Invocation)
+            public void tearDown() {
+                javaMutable.clear();
+            }
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void java_mutable(Initialized state) {
+            int aggregate = 0;
+            for (final Iterator<Integer> iterator = state.javaMutable.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, expectedAggregate);
+        }
+
+        @Benchmark
+        public void scala_persistent() {
+            int aggregate = 0;
+            for (final scala.collection.Iterator<Integer> iterator = scalaPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void fjava_persistent() {
+            int aggregate = 0;
+            for (final Iterator<Integer> iterator = fjavaPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void pcollections_persistent() {
+            int aggregate = 0;
+            for (final Iterator<Integer> iterator = pcollectionsPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void slang_persistent() {
+            int aggregate = 0;
+            for (final Iterator<Integer> iterator = slangPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, expectedAggregate);
+        }
+    }
+}

--- a/javaslang/src/test/java/javaslang/collection/AbstractSeqTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractSeqTest.java
@@ -139,7 +139,30 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldMixAppendAndPrepend() {
-        assertThat(of(1).append(2).prepend(0).prepend(-1).append(3).append(4)).isEqualTo(of(-1, 0, 1, 2, 3, 4));
+        final Seq<Integer> append = of(1).append(2).prepend(0).prepend(-1).append(3).append(4);
+        assertThat(append).isEqualTo(of(-1, 0, 1, 2, 3, 4));
+    }
+
+    @Test
+    public void shouldAppend() {
+        final Seq<Integer> actual = Stream.range(4, 100).foldLeft(of(1, 2, 3),
+                (v, i) -> v.append(i).tail()
+        );
+        assertThat(actual).isEqualTo(of(97, 98, 99));
+    }
+
+    @Test
+    public void shouldPrepend() {
+        final Seq<Integer> actual = Stream.range(4, 100).foldLeft(of(3, 2, 1),
+                (v, i) -> v.prepend(i).init()
+        );
+        assertThat(actual).isEqualTo(of(99, 98, 97));
+    }
+
+    @Test
+    public void shouldMixAppendAndPrependAndDrop() {
+        final Seq<Integer> append = of(1).append(2).prepend(-1).prepend(-2).append(4).dropRight(1).append(3).drop(2).prepend(0);
+        assertThat(append).isEqualTo(of(0, 1, 2, 3));
     }
 
     // -- appendAll
@@ -594,8 +617,8 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldInsertIntoSeq() {
-        final Seq<Integer> actual = of(1, 2, 3).insert(2, 4);
-        final Seq<Integer> expected = of(1, 2, 4, 3);
+        final Seq<Integer> actual = of(1, 2, 4).insert(2, 3);
+        final Seq<Integer> expected = of(1, 2, 3, 4);
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -1271,7 +1294,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldReturnSliceWhenIndicesAreWithinRange() {
-        final Seq<Integer> actual = of(1, 2, 3).slice(1, 3);
+        final Seq<Integer> actual = of(1, 2, 3, 4).slice(1, 3);
         assertThat(actual).isEqualTo(of(2, 3));
     }
 
@@ -1293,7 +1316,8 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldComputeSliceOnNonNilWhenBeginIndexExceedsLowerBound() {
-        assertThat(of(1, 2, 3).slice(-1, 2)).isEqualTo(of(1, 2));
+        final Seq<Integer> actual = of(1, 2, 3).slice(-1, 2);
+        assertThat(actual).isEqualTo(of(1, 2));
     }
 
     @Test

--- a/javaslang/src/test/java/javaslang/collection/ArrayTest.java
+++ b/javaslang/src/test/java/javaslang/collection/ArrayTest.java
@@ -188,11 +188,23 @@ public class ArrayTest extends AbstractIndexedSeqTest {
         assertThat(actual).isEqualTo(3);
     }
 
+    // -- delegate
+
+    @Test
+    public void shouldPeriodicallyTrimExcess() {
+        for (Array<Integer> values = range(0, 100); !values.isEmpty(); values = values.tail()) {
+            final int length = values.length(), delegateLength = values.delegate.length;
+            if (length != delegateLength) {
+                assertThat(List.of(100, 50, 25, 13, 7, 4, 2)).contains(delegateLength);
+            }
+        }
+    }
+
     // -- transform()
 
     @Test
     public void shouldTransform() {
-        String transformed = of(42).transform(v -> String.valueOf(v.get()));
+        final String transformed = of(42).transform(v -> String.valueOf(v.get()));
         assertThat(transformed).isEqualTo("42");
     }
 


### PR DESCRIPTION
Fixes: https://github.com/javaslang/javaslang/issues/1348

> Vector

```java
Ratios slang / <alternative_impl>
Target           Operation   Ratio                                                    10        100       1000 
VectorBenchmark  Head        slang_persistent/fjava_persistent                     0.27x      0.25x      0.24x 
VectorBenchmark  Head        slang_persistent/java_mutable                         0.24x      0.22x      0.21x 
VectorBenchmark  Head        slang_persistent/pcollections_persistent              0.62x      1.02x      1.48x 
VectorBenchmark  Head        slang_persistent/scala_persistent                     0.28x      0.34x      0.32x 

VectorBenchmark  Tail        slang_persistent/fjava_persistent                    61.34x    114.41x    128.79x 
VectorBenchmark  Tail        slang_persistent/java_mutable                         7.01x      7.24x     15.55x 
VectorBenchmark  Tail        slang_persistent/pcollections_persistent              8.33x     14.09x     21.29x 
VectorBenchmark  Tail        slang_persistent/scala_persistent                     5.08x      8.90x     12.61x 

VectorBenchmark  Get         slang_persistent/fjava_persistent                     9.46x      7.46x     10.37x 
VectorBenchmark  Get         slang_persistent/java_mutable                         0.14x      0.03x      0.02x 
VectorBenchmark  Get         slang_persistent/pcollections_persistent              1.40x      0.95x      1.51x 
VectorBenchmark  Get         slang_persistent/scala_persistent                     0.27x      0.14x      0.09x 

VectorBenchmark  Update      slang_persistent/fjava_persistent                    47.86x     88.49x    103.10x 
VectorBenchmark  Update      slang_persistent/java_mutable                         0.11x      0.05x      0.03x 
VectorBenchmark  Update      slang_persistent/pcollections_persistent              1.30x      1.72x      2.09x 
VectorBenchmark  Update      slang_persistent/scala_persistent                     0.94x      0.60x      0.40x 

VectorBenchmark  Prepend     slang_persistent/fjava_persistent                     1.87x      2.46x      2.20x 
VectorBenchmark  Prepend     slang_persistent/java_mutable                         0.48x      0.47x      0.84x 
VectorBenchmark  Prepend     slang_persistent/pcollections_persistent              0.87x      1.75x      2.32x 
VectorBenchmark  Prepend     slang_persistent/scala_persistent                     0.44x      0.39x      0.29x 

VectorBenchmark  Append      slang_persistent/fjava_persistent                     2.53x      2.94x      2.63x 
VectorBenchmark  Append      slang_persistent/java_mutable                         0.13x      0.09x      0.08x 
VectorBenchmark  Append      slang_persistent/pcollections_persistent              1.13x      2.30x      3.53x 
VectorBenchmark  Append      slang_persistent/scala_persistent                     0.53x      0.42x      0.37x 

VectorBenchmark  GroupBy     slang_persistent/java_mutable                         0.21x      0.18x      0.25x 
VectorBenchmark  GroupBy     slang_persistent/scala_persistent                     0.85x      0.43x      0.30x 

VectorBenchmark  Iterate     slang_persistent/fjava_persistent                    30.15x     51.62x     37.36x 
VectorBenchmark  Iterate     slang_persistent/java_mutable                         0.18x      0.07x      0.04x 
VectorBenchmark  Iterate     slang_persistent/pcollections_persistent              2.11x      1.72x      1.15x 
VectorBenchmark  Iterate     slang_persistent/scala_persistent                     0.34x      0.19x      0.12x 

VectorBenchmark  Slice       slang_persistent/java_mutable                         0.90x      0.91x      0.79x
VectorBenchmark  Slice       slang_persistent/scala_persistent                     6.24x     14.79x     15.39x
```