### PR TITLE
Added benchmarks for `Array` and `CharSeq`'s `head`, `tail`, `get`, `update`, `prepend`, `append` and `iterate`

### DIFF
--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/JmhRunner.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/JmhRunner.java
@@ -9,30 +9,38 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 public class JmhRunner {
+    public static final int FORKS = 1;
+
     private static final int WARMUP_ITERATIONS = 20;
     private static final int MEASUREMENT_ITERATIONS = 30;
+    public static final int DURATION_MILLIS = 500;
 
     private static final int QUICK_WARMUP_ITERATIONS = 10;
     private static final int QUICK_MEASUREMENT_ITERATIONS = 10;
+    public static final int QUICK_DURATION_MILLIS = 200;
 
     public static void run(Class<?> benchmarkClass) {
-        runAndReport(benchmarkClass, WARMUP_ITERATIONS, MEASUREMENT_ITERATIONS, 500, PrintGc.Enable, Assertions.Disable);
+        runAndReport(benchmarkClass, WARMUP_ITERATIONS, MEASUREMENT_ITERATIONS, DURATION_MILLIS, PrintGc.Enable, Assertions.Disable, FORKS);
     }
 
-    public static void devRun(Class<?> benchmarkClass) {
-        runAndReport(benchmarkClass, QUICK_WARMUP_ITERATIONS, QUICK_MEASUREMENT_ITERATIONS, 200, PrintGc.Disable, Assertions.Disable);
+    public static void runDebug(Class<?> benchmarkClass) {
+        runAndReport(benchmarkClass, 1, 1, 1, PrintGc.Disable, Assertions.Disable, 0);
     }
 
-    public static void devRunWithAssertions(Class<?> benchmarkClass) {
-        runAndReport(benchmarkClass, QUICK_WARMUP_ITERATIONS, QUICK_MEASUREMENT_ITERATIONS, 200, PrintGc.Disable, Assertions.Enable);
+    public static void runDev(Class<?> benchmarkClass) {
+        runAndReport(benchmarkClass, QUICK_WARMUP_ITERATIONS, QUICK_MEASUREMENT_ITERATIONS, QUICK_DURATION_MILLIS, PrintGc.Disable, Assertions.Disable, FORKS);
     }
 
-    private static void runAndReport(Class<?> benchmarkClass, int warmupIterations, int measurementIterations, int millis, PrintGc printGc, Assertions assertions) {
-        final Collection<RunResult> results = run(benchmarkClass, warmupIterations, measurementIterations, millis, printGc, assertions);
+    public static void runDevWithAssertions(Class<?> benchmarkClass) {
+        runAndReport(benchmarkClass, QUICK_WARMUP_ITERATIONS, QUICK_MEASUREMENT_ITERATIONS, QUICK_DURATION_MILLIS, PrintGc.Disable, Assertions.Enable, FORKS);
+    }
+
+    private static void runAndReport(Class<?> benchmarkClass, int warmupIterations, int measurementIterations, int millis, PrintGc printGc, Assertions assertions, int forks) {
+        final Collection<RunResult> results = run(benchmarkClass, warmupIterations, measurementIterations, millis, printGc, assertions, forks);
         BenchmarkPerformanceReporter.of(results).print();
     }
 
-    private static Collection<RunResult> run(Class<?> benchmarkClass, int warmupIterations, int measurementIterations, int millis, PrintGc printGc, Assertions assertions) {
+    private static Collection<RunResult> run(Class<?> benchmarkClass, int warmupIterations, int measurementIterations, int millis, PrintGc printGc, Assertions assertions, int forks) {
         final Options opts = new OptionsBuilder()
                 .include(benchmarkClass.getSimpleName())
                 .shouldDoGC(true)
@@ -43,7 +51,7 @@ public class JmhRunner {
                 .warmupIterations(warmupIterations)
                 .measurementTime(TimeValue.milliseconds(millis))
                 .measurementIterations(measurementIterations)
-                .forks(1)
+                .forks(forks)
                 // We are using 4Gb and setting NewGen to 100% to avoid GC during testing.
                 // Any GC during testing will destroy the iteration, which should get ignored as an outlier
                 .jvmArgsAppend("-XX:+UseG1GC", "-Xss100m", "-Xms4g", "-Xmx4g", "-XX:MaxGCPauseMillis=1000", "-XX:+UnlockExperimentalVMOptions", "-XX:G1NewSizePercent=100", "-XX:G1MaxNewSizePercent=100", printGc.vmArg, assertions.vmArg)

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/BitSetBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/BitSetBenchmark.java
@@ -1,17 +1,18 @@
 package javaslang.benchmark.collection;
 
+import javaslang.benchmark.JmhRunner;
 import org.openjdk.jmh.annotations.*;
 
 import static javaslang.benchmark.JmhRunner.*;
 
 public class BitSetBenchmark {
-    public static void main(String... args) { /* main is more reliable than a test */
-        run(BitSetBenchmark.class);
+    public static void main(String... args) {
+        JmhRunner.runDev(BitSetBenchmark.class);
     }
 
     @State(Scope.Benchmark)
     public static class Base {
-        @Param({"10", "100", "1000"})
+        @Param({ "10", "100", "1000" })
         public int CONTAINER_SIZE;
 
         public Integer[] ELEMENTS;

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/CharSeqBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/CharSeqBenchmark.java
@@ -1,0 +1,188 @@
+package javaslang.benchmark.collection;
+
+import javaslang.benchmark.JmhRunner;
+import javaslang.collection.CharSeq;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.Random;
+
+import static java.lang.String.valueOf;
+import static javaslang.benchmark.JmhRunner.assertEquals;
+
+public class CharSeqBenchmark {
+    public static void main(java.lang.String... args) {
+        JmhRunner.runDebug(CharSeqBenchmark.class);
+    }
+
+    @State(Scope.Benchmark)
+    public static class Base {
+        @Param({ "10", "100", "1000" })
+        public int CONTAINER_SIZE;
+
+        int expectedAggregate = 0;
+        char[] ELEMENTS;
+
+        java.lang.String javaPersistent;
+        fj.data.LazyString fjavaPersistent;
+        javaslang.collection.CharSeq slangPersistent;
+
+        @Setup
+        public void setup() {
+            final Random random = new Random(0);
+
+            final StringBuilder results = new StringBuilder(CONTAINER_SIZE);
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                final char value = (char) random.nextInt(Character.MAX_VALUE);
+                results.append(value);
+
+                expectedAggregate ^= value;
+            }
+            ELEMENTS = results.toString().toCharArray();
+
+            assertEquals(javaPersistent, null);
+            javaPersistent = results.toString();
+            assertEquals(javaPersistent.length(), CONTAINER_SIZE);
+
+            assertEquals(fjavaPersistent, null);
+            fjavaPersistent = fj.data.LazyString.str(results.toString());
+            assertEquals(fjavaPersistent.length(), CONTAINER_SIZE);
+
+            assertEquals(slangPersistent, null);
+            slangPersistent = CharSeq.of(results);
+            assertEquals(slangPersistent.size(), CONTAINER_SIZE);
+        }
+    }
+
+    public static class Head extends Base {
+        @Benchmark
+        public Object java_persistent() { return javaPersistent.charAt(0); }
+
+        @Benchmark
+        public Object fjava_persistent() { return fjavaPersistent.head(); }
+
+        @Benchmark
+        public Object slang_persistent() { return slangPersistent.head(); }
+    }
+
+    public static class Tail extends Base {
+        @Benchmark
+        public Object java_persistent() { return javaPersistent.substring(1); }
+
+        @Benchmark
+        public Object fjava_persistent() { return fjavaPersistent.tail(); }
+
+        @Benchmark
+        public Object slang_persistent() { return slangPersistent.tail(); }
+    }
+
+    public static class Get extends Base {
+        final int index = CONTAINER_SIZE / 2;
+
+        @Benchmark
+        public Object java_persistent() { return javaPersistent.charAt(index); }
+
+        @Benchmark
+        public Object fjava_persistent() { return fjavaPersistent.charAt(index); }
+
+        @Benchmark
+        public Object slang_persistent() { return slangPersistent.charAt(index); }
+    }
+
+    public static class Update extends Base {
+        final int index = CONTAINER_SIZE / 2;
+        final char replacement = '-';
+
+        @Benchmark
+        public Object java_persistent() { return javaPersistent.substring(0, index) + replacement + javaPersistent.substring(index + 1); }
+
+        @Benchmark
+        public Object slang_persistent() { return slangPersistent.update(index, replacement); }
+    }
+
+    public static class Prepend extends Base {
+        @Benchmark
+        public void java_persistent() {
+            java.lang.String values = "";
+            for (int i = CONTAINER_SIZE - 1; i >= 0; i--) {
+                values = ELEMENTS[i] + values;
+            }
+            assertEquals(values.length(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void fjava_persistent() {
+            fj.data.LazyString values = fj.data.LazyString.empty;
+            for (int i = CONTAINER_SIZE - 1; i >= 0; i--) {
+                values = fj.data.LazyString.str(valueOf(ELEMENTS[i])).append(values);
+            }
+            assertEquals(values.length(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            javaslang.collection.CharSeq values = javaslang.collection.CharSeq.empty();
+            for (int i = CONTAINER_SIZE - 1; i >= 0; i--) {
+                values = values.prepend(ELEMENTS[i]);
+            }
+            assertEquals(values.length(), CONTAINER_SIZE);
+        }
+    }
+
+    public static class Append extends Base {
+        @Benchmark
+        public void java_persistent() {
+            java.lang.String values = "";
+            for (char c : ELEMENTS) {
+                values = values + c;
+            }
+            assertEquals(values.length(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void fjava_persistent() {
+            fj.data.LazyString values = fj.data.LazyString.empty;
+            for (char c : ELEMENTS) {
+                values = values.append(valueOf(c));
+            }
+            assertEquals(values.length(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            javaslang.collection.CharSeq values = javaslang.collection.CharSeq.empty();
+            for (char c : ELEMENTS) {
+                values = values.append(c);
+            }
+            assertEquals(values.length(), CONTAINER_SIZE);
+        }
+    }
+
+    public static class Iterate extends Base {
+        @Benchmark
+        public void java_persistent() {
+            int aggregate = 0;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                aggregate ^= javaPersistent.charAt(i);
+            }
+            assertEquals(aggregate, expectedAggregate);
+        }
+
+        @Benchmark
+        public void fjava_persistent() {
+            int aggregate = 0;
+            for (fj.data.LazyString iterable = fjavaPersistent; !iterable.isEmpty(); iterable = iterable.tail()) {
+                aggregate ^= iterable.head();
+            }
+            assertEquals(aggregate, expectedAggregate);
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            int aggregate = 0;
+            for (Character c : slangPersistent) {
+                aggregate ^= c;
+            }
+            assertEquals(aggregate, expectedAggregate);
+        }
+    }
+}

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/HashSetBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/HashSetBenchmark.java
@@ -1,17 +1,18 @@
 package javaslang.benchmark.collection;
 
+import javaslang.benchmark.JmhRunner;
 import org.openjdk.jmh.annotations.*;
 
 import static javaslang.benchmark.JmhRunner.*;
 
 public class HashSetBenchmark {
-    public static void main(String... args) { /* main is more reliable than a test */
-        run(HashSetBenchmark.class);
+    public static void main(String... args) {
+        JmhRunner.runDev(HashSetBenchmark.class);
     }
 
     @State(Scope.Benchmark)
     public static class Base {
-        @Param({"10", "100", "1000"})
+        @Param({ "10", "100", "1000" })
         public int CONTAINER_SIZE;
 
         public Integer[] ELEMENTS;

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/ListBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/ListBenchmark.java
@@ -1,5 +1,6 @@
 package javaslang.benchmark.collection;
 
+import javaslang.benchmark.JmhRunner;
 import org.openjdk.jmh.annotations.*;
 import scala.compat.java8.JFunction;
 
@@ -9,8 +10,8 @@ import java.util.stream.Collectors;
 import static javaslang.benchmark.JmhRunner.*;
 
 public class ListBenchmark {
-    public static void main(String... args) { /* main is more reliable than a test */
-        run(ListBenchmark.class);
+    public static void main(String... args) {
+        JmhRunner.runDev(ListBenchmark.class);
     }
 
     @State(Scope.Benchmark)

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/PriorityQueueBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/PriorityQueueBenchmark.java
@@ -1,6 +1,7 @@
 package javaslang.benchmark.collection;
 
 import javaslang.Tuple2;
+import javaslang.benchmark.JmhRunner;
 import javaslang.collection.Traversable;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.annotations.State;
@@ -13,9 +14,8 @@ import java.util.Collections;
 import static javaslang.benchmark.JmhRunner.*;
 
 public class PriorityQueueBenchmark {
-
-    public static void main(String... args) { /* main is more reliable than a test */
-        run(PriorityQueueBenchmark.class);
+    public static void main(String... args) {
+        JmhRunner.runDev(PriorityQueueBenchmark.class);
     }
 
     @State(Scope.Benchmark)


### PR DESCRIPTION
Compared it against `Java` and `Functional Java`, wherever applicable:

> Array

```java
Ratios slang / <alternative_impl>
Target          Operation   Ratio                                      10        100       1000      10000 
ArrayBenchmark  Append      slang_persistent/fjava_persistent       1.18x      0.95x      0.90x      0.98x 
ArrayBenchmark  Append      slang_persistent/java_mutable           0.16x      0.09x      0.02x      0.00x 
ArrayBenchmark  Get         slang_persistent/fjava_persistent       0.86x      0.86x      0.85x      0.80x 
ArrayBenchmark  Get         slang_persistent/java_mutable           0.92x      0.93x      0.93x      0.87x 
ArrayBenchmark  Head        slang_persistent/fjava_persistent       1.05x      1.33x      1.27x      1.28x 
ArrayBenchmark  Head        slang_persistent/java_mutable           0.94x      1.31x      1.32x      1.16x 
ArrayBenchmark  Iterate     slang_persistent/java_mutable           4.99x      5.24x      8.53x      8.09x 
ArrayBenchmark  Prepend     slang_persistent/java_mutable           0.64x      0.55x      0.27x      0.19x 
ArrayBenchmark  Tail        slang_persistent/java_mutable           0.32x      0.12x      0.11x      0.16x 
ArrayBenchmark  Update      slang_persistent/fjava_persistent       0.05x      0.01x      0.00x      0.00x 
ArrayBenchmark  Update      slang_persistent/java_mutable           0.05x      0.01x      0.00x      0.00x 
```

> CharSeq

```java
Ratios slang / <alternative_impl>
Target            Operation   Ratio                                      10        100       1000 
CharSeqBenchmark  Append      slang_persistent/fjava_persistent      10.23x     40.34x     59.29x 
CharSeqBenchmark  Append      slang_persistent/java_persistent        0.28x      0.22x      0.23x 
CharSeqBenchmark  Get         slang_persistent/fjava_persistent       7.38x     69.84x    579.34x 
CharSeqBenchmark  Get         slang_persistent/java_persistent        0.97x      0.98x      0.70x 
CharSeqBenchmark  Head        slang_persistent/fjava_persistent       1.19x      1.09x      1.08x 
CharSeqBenchmark  Head        slang_persistent/java_persistent        0.91x      0.90x      0.95x 
CharSeqBenchmark  Iterate     slang_persistent/fjava_persistent       5.48x     21.86x      3.60x 
CharSeqBenchmark  Iterate     slang_persistent/java_persistent        0.47x      0.66x      0.09x 
CharSeqBenchmark  Prepend     slang_persistent/fjava_persistent       3.80x      2.32x      0.53x 
CharSeqBenchmark  Prepend     slang_persistent/java_persistent        0.50x      0.75x      0.98x 
CharSeqBenchmark  Tail        slang_persistent/fjava_persistent       0.52x      0.32x      0.04x 
CharSeqBenchmark  Tail        slang_persistent/java_persistent        0.77x      1.00x      0.99x 
CharSeqBenchmark  Update      slang_persistent/java_persistent        0.78x      0.93x      0.98x
```