### PR TITLE
Added benchmarks for `head`, `tail`, `get`, `update`, `prepend`, `append`, `groupBy` and `iterate` from `List` and `Vector`

### DIFF
--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/JmhRunner.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/JmhRunner.java
@@ -9,38 +9,34 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 public class JmhRunner {
-    public static final int FORKS = 1;
+    private static final int FORKS = 1;
 
     private static final int WARMUP_ITERATIONS = 20;
     private static final int MEASUREMENT_ITERATIONS = 30;
-    public static final int DURATION_MILLIS = 500;
+    private static final int DURATION_MILLIS = 500;
 
-    private static final int QUICK_WARMUP_ITERATIONS = 10;
-    private static final int QUICK_MEASUREMENT_ITERATIONS = 10;
-    public static final int QUICK_DURATION_MILLIS = 200;
-
-    public static void run(Class<?> benchmarkClass) {
-        runAndReport(benchmarkClass, WARMUP_ITERATIONS, MEASUREMENT_ITERATIONS, DURATION_MILLIS, PrintGc.Enable, Assertions.Disable, FORKS);
-    }
+    private static final int QUICK_WARMUP_ITERATIONS = 5;
+    private static final int QUICK_MEASUREMENT_ITERATIONS = 5;
+    private static final int QUICK_DURATION_MILLIS = 100;
 
     public static void runDebug(Class<?> benchmarkClass) {
-        runAndReport(benchmarkClass, 1, 1, 1, PrintGc.Disable, Assertions.Disable, 0);
+        runAndReport(benchmarkClass, 1, 1, 1, PrintGc.Disable, 0);
     }
 
-    public static void runDev(Class<?> benchmarkClass) {
-        runAndReport(benchmarkClass, QUICK_WARMUP_ITERATIONS, QUICK_MEASUREMENT_ITERATIONS, QUICK_DURATION_MILLIS, PrintGc.Disable, Assertions.Disable, FORKS);
+    public static void runQuick(Class<?> benchmarkClass) {
+        runAndReport(benchmarkClass, QUICK_WARMUP_ITERATIONS, QUICK_MEASUREMENT_ITERATIONS, QUICK_DURATION_MILLIS, PrintGc.Disable, FORKS);
     }
 
-    public static void runDevWithAssertions(Class<?> benchmarkClass) {
-        runAndReport(benchmarkClass, QUICK_WARMUP_ITERATIONS, QUICK_MEASUREMENT_ITERATIONS, QUICK_DURATION_MILLIS, PrintGc.Disable, Assertions.Enable, FORKS);
+    public static void runSlow(Class<?> benchmarkClass) {
+        runAndReport(benchmarkClass, WARMUP_ITERATIONS, MEASUREMENT_ITERATIONS, DURATION_MILLIS, PrintGc.Enable, FORKS);
     }
 
-    private static void runAndReport(Class<?> benchmarkClass, int warmupIterations, int measurementIterations, int millis, PrintGc printGc, Assertions assertions, int forks) {
-        final Collection<RunResult> results = run(benchmarkClass, warmupIterations, measurementIterations, millis, printGc, assertions, forks);
-        BenchmarkPerformanceReporter.of(results).print();
+    private static void runAndReport(Class<?> benchmarkClass, int warmupIterations, int measurementIterations, int millis, PrintGc printGc, int forks) {
+        final Collection<RunResult> results = run(benchmarkClass, warmupIterations, measurementIterations, millis, printGc, forks);
+        BenchmarkPerformanceReporter.of(benchmarkClass, results).print();
     }
 
-    private static Collection<RunResult> run(Class<?> benchmarkClass, int warmupIterations, int measurementIterations, int millis, PrintGc printGc, Assertions assertions, int forks) {
+    private static Collection<RunResult> run(Class<?> benchmarkClass, int warmupIterations, int measurementIterations, int millis, PrintGc printGc, int forks) {
         final Options opts = new OptionsBuilder()
                 .include(benchmarkClass.getSimpleName())
                 .shouldDoGC(true)
@@ -54,24 +50,13 @@ public class JmhRunner {
                 .forks(forks)
                 // We are using 4Gb and setting NewGen to 100% to avoid GC during testing.
                 // Any GC during testing will destroy the iteration, which should get ignored as an outlier
-                .jvmArgsAppend("-XX:+UseG1GC", "-Xss100m", "-Xms4g", "-Xmx4g", "-XX:MaxGCPauseMillis=1000", "-XX:+UnlockExperimentalVMOptions", "-XX:G1NewSizePercent=100", "-XX:G1MaxNewSizePercent=100", printGc.vmArg, assertions.vmArg)
+                .jvmArgsAppend("-XX:+UseG1GC", "-Xss100m", "-Xms4g", "-Xmx4g", "-XX:MaxGCPauseMillis=1000", "-XX:+UnlockExperimentalVMOptions", "-XX:G1NewSizePercent=100", "-XX:G1MaxNewSizePercent=100", "-disableassertions", printGc.vmArg)
                 .build();
 
         try {
             return new Runner(opts).run();
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
-        }
-    }
-
-    private enum Assertions {
-        Enable("-enableassertions"),
-        Disable("-disableassertions");
-
-        final String vmArg;
-
-        Assertions(String vmArg) {
-            this.vmArg = vmArg;
         }
     }
 

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/ArrayBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/ArrayBenchmark.java
@@ -1,8 +1,6 @@
 package javaslang.benchmark.collection;
 
-import fj.data.Array;
 import javaslang.benchmark.JmhRunner;
-import javaslang.collection.Iterator;
 import org.openjdk.jmh.annotations.*;
 
 import java.util.*;
@@ -11,7 +9,7 @@ import static javaslang.benchmark.JmhRunner.*;
 
 public class ArrayBenchmark {
     public static void main(String... args) {
-        JmhRunner.runDev(ArrayBenchmark.class);
+        JmhRunner.runQuick(ArrayBenchmark.class);
     }
 
     @State(Scope.Benchmark)
@@ -19,24 +17,29 @@ public class ArrayBenchmark {
         @Param({ "10", "100", "1000", "10000" })
         public int CONTAINER_SIZE;
 
+        int expectedAggregate = 0;
         public Integer[] ELEMENTS;
 
         java.util.ArrayList<Integer> javaMutable;
-        fj.data.Array<Integer> fjavaPersistent;
+        fj.data.Array<Integer> fjavaMutable;
         javaslang.collection.Array<Integer> slangPersistent;
 
         @Setup
         public void setup() {
             ELEMENTS = getRandomValues(CONTAINER_SIZE, 0);
 
+            for (Integer element : ELEMENTS) {
+                expectedAggregate ^= element;
+            }
+
             assertEquals(javaMutable, null);
             javaMutable = new ArrayList<>(CONTAINER_SIZE);
             Collections.addAll(javaMutable, ELEMENTS);
             assertEquals(javaMutable.size(), CONTAINER_SIZE);
 
-            assertEquals(fjavaPersistent, null);
-            fjavaPersistent = Array.array(ELEMENTS);
-            assertEquals(fjavaPersistent.length(), CONTAINER_SIZE);
+            assertEquals(fjavaMutable, null);
+            fjavaMutable = fj.data.Array.array(ELEMENTS);
+            assertEquals(fjavaMutable.length(), CONTAINER_SIZE);
 
             assertEquals(slangPersistent, null);
             slangPersistent = javaslang.collection.Array.of(ELEMENTS);
@@ -49,7 +52,7 @@ public class ArrayBenchmark {
         public Object java_mutable() { return javaMutable.get(0); }
 
         @Benchmark
-        public Object fjava_persistent() { return fjavaPersistent.get(0); }
+        public Object fjava_mutable() { return fjavaMutable.get(0); }
 
         @Benchmark
         public Object slang_persistent() { return slangPersistent.head(); }
@@ -58,68 +61,90 @@ public class ArrayBenchmark {
     public static class Tail extends Base {
         @State(Scope.Thread)
         public static class Initialized {
-            java.util.ArrayList<Integer> javaMutable;
-            javaslang.collection.Array<Integer> slangPersistent = javaslang.collection.Array.empty();
+            final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
 
             @Setup(Level.Invocation)
             public void initializeMutable(Base state) {
-                assertEquals(javaMutable, null);
-                javaMutable = new java.util.ArrayList<>(state.CONTAINER_SIZE);
+                assertEquals(javaMutable.size(), 0);
                 Collections.addAll(javaMutable, state.ELEMENTS);
                 assertEquals(javaMutable.size(), state.CONTAINER_SIZE);
-
-                if (slangPersistent.isEmpty()) {
-                    slangPersistent = slangPersistent.appendAll(Iterator.of(state.ELEMENTS));
-                    assertEquals(slangPersistent.size(), state.CONTAINER_SIZE);
-                }
             }
 
             @TearDown(Level.Invocation)
             public void tearDown() {
-                javaMutable = null;
+                javaMutable.clear();
             }
         }
 
         @Benchmark
-        public Object java_mutable(Initialized state) {
-            state.javaMutable.remove(0);
-            return state.javaMutable;
+        public void java_mutable(Initialized state) {
+            final java.util.ArrayList<Integer> values = state.javaMutable;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values.remove(0);
+            }
+            assertEquals(values, new java.util.ArrayList<>());
         }
 
         @Benchmark
-        public Object slang_persistent(Initialized state) { return state.slangPersistent.tail(); }
+        public void slang_persistent() {
+            javaslang.collection.Array<Integer> values = slangPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.tail();
+            }
+            assertEquals(values, javaslang.collection.Array.empty());
+        }
     }
 
     public static class Get extends Base {
-        final int index = CONTAINER_SIZE / 2;
+        @Benchmark
+        public void java_mutable() {
+            for (int i = 0; i < ELEMENTS.length; i++) {
+                assertEquals(javaMutable.get(i), ELEMENTS[i]);
+            }
+        }
 
         @Benchmark
-        public Object java_mutable() { return javaMutable.get(index); }
+        public void fjava_mutable() {
+            for (int i = 0; i < ELEMENTS.length; i++) {
+                assertEquals(fjavaMutable.get(i), ELEMENTS[i]);
+            }
+        }
 
         @Benchmark
-        public Object fjava_persistent() { return fjavaPersistent.get(index); }
-
-        @Benchmark
-        public Object slang_persistent() { return slangPersistent.get(index); }
+        public void slang_persistent() {
+            for (int i = 0; i < ELEMENTS.length; i++) {
+                assertEquals(slangPersistent.get(i), ELEMENTS[i]);
+            }
+        }
     }
 
     public static class Update extends Base {
-        final int index = CONTAINER_SIZE / 2, replacement = 0;
-
         @Benchmark
         public Object java_mutable() {
-            javaMutable.set(index, replacement);
+            final java.util.ArrayList<Integer> values = javaMutable;
+            for (int i = 0; i < ELEMENTS.length; i++) {
+                values.set(i, 0);
+            }
             return javaMutable;
         }
 
         @Benchmark
-        public Object fjava_persistent() {
-            fjavaPersistent.set(index, replacement);
-            return fjavaPersistent;
+        public Object fjava_mutable() {
+            final fj.data.Array<Integer> values = fjavaMutable;
+            for (int i = 0; i < ELEMENTS.length; i++) {
+                values.set(i, 0);
+            }
+            return fjavaMutable;
         }
 
         @Benchmark
-        public Object slang_persistent() { return slangPersistent.update(index, replacement); }
+        public Object slang_persistent() {
+            javaslang.collection.Array<Integer> values = slangPersistent;
+            for (int i = 0; i < ELEMENTS.length; i++) {
+                values = values.update(i, 0);
+            }
+            return values;
+        }
     }
 
     public static class Prepend extends Base {
@@ -130,6 +155,15 @@ public class ArrayBenchmark {
                 values.add(0, element);
             }
             assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void fjava_mutable() {
+            fj.data.Array<Integer> values = fj.data.Array.empty();
+            for (Integer element : ELEMENTS) {
+                values = fj.data.Array.array(element).append(values);
+            }
+            assertEquals(values.length(), CONTAINER_SIZE);
         }
 
         @Benchmark
@@ -154,10 +188,10 @@ public class ArrayBenchmark {
         }
 
         @Benchmark
-        public void fjava_persistent() {
+        public void fjava_mutable() {
             fj.data.Array<Integer> values = fj.data.Array.empty();
             for (Integer element : ELEMENTS) {
-                values = values.append(Array.array(element));
+                values = values.append(fj.data.Array.array(element));
             }
             assertEquals(values.length(), CONTAINER_SIZE);
         }
@@ -173,53 +207,31 @@ public class ArrayBenchmark {
     }
 
     public static class Iterate extends Base {
-        @State(Scope.Thread)
-        public static class Initialized {
-            java.util.ArrayList<Integer> javaMutable;
-
-            int expectedAggregate = 0;
-            javaslang.collection.Array<Integer> slangPersistent = javaslang.collection.Array.empty();
-
-            @Setup(Level.Invocation)
-            public void initializeMutable(Base state) {
-                assertEquals(javaMutable, null);
-                javaMutable = new java.util.ArrayList<>(state.CONTAINER_SIZE);
-                Collections.addAll(javaMutable, state.ELEMENTS);
-                assertEquals(javaMutable.size(), state.CONTAINER_SIZE);
-
-                if (expectedAggregate == 0) {
-                    for (Integer element : state.ELEMENTS) {
-                        expectedAggregate ^= element;
-                    }
-
-                    assertEquals(slangPersistent.size(), 0);
-                    slangPersistent = slangPersistent.appendAll(Iterator.of(state.ELEMENTS));
-                    assertEquals(slangPersistent.size(), state.CONTAINER_SIZE);
-                }
-            }
-
-            @TearDown(Level.Invocation)
-            public void tearDown() {
-                javaMutable = null;
-            }
-        }
-
         @Benchmark
-        public void java_mutable(Initialized state) {
+        public void java_mutable() {
             int aggregate = 0;
             for (int i = 0; i < CONTAINER_SIZE; i++) {
-                aggregate ^= state.javaMutable.get(i);
+                aggregate ^= javaMutable.get(i);
             }
-            assertEquals(aggregate, state.expectedAggregate);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
-        public void slang_persistent(Initialized state) {
+        public void fjava_mutable() {
             int aggregate = 0;
-            for (javaslang.collection.Array<Integer> values = state.slangPersistent; !values.isEmpty(); values = values.tail()) {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                aggregate ^= fjavaMutable.get(i);
+            }
+            assertEquals(aggregate, expectedAggregate);
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            int aggregate = 0;
+            for (javaslang.collection.Array<Integer> values = slangPersistent; !values.isEmpty(); values = values.tail()) {
                 aggregate ^= values.head();
             }
-            assertEquals(aggregate, state.expectedAggregate);
+            assertEquals(aggregate, expectedAggregate);
         }
     }
 }

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/BitSetBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/BitSetBenchmark.java
@@ -7,7 +7,7 @@ import static javaslang.benchmark.JmhRunner.*;
 
 public class BitSetBenchmark {
     public static void main(String... args) {
-        JmhRunner.runDev(BitSetBenchmark.class);
+        JmhRunner.runQuick(BitSetBenchmark.class);
     }
 
     @State(Scope.Benchmark)

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/CharSeqBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/CharSeqBenchmark.java
@@ -11,7 +11,7 @@ import static javaslang.benchmark.JmhRunner.assertEquals;
 
 public class CharSeqBenchmark {
     public static void main(java.lang.String... args) {
-        JmhRunner.runDebug(CharSeqBenchmark.class);
+        JmhRunner.runQuick(CharSeqBenchmark.class);
     }
 
     @State(Scope.Benchmark)
@@ -66,37 +66,76 @@ public class CharSeqBenchmark {
 
     public static class Tail extends Base {
         @Benchmark
-        public Object java_persistent() { return javaPersistent.substring(1); }
+        public void java_persistent() {
+            java.lang.String values = javaPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.substring(1);
+            }
+            assertEquals(values, "");
+        }
 
         @Benchmark
-        public Object fjava_persistent() { return fjavaPersistent.tail(); }
+        public void fjava_persistent() {
+            fj.data.LazyString values = fjavaPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.tail();
+            }
+            if (!values.isEmpty()) { throw new IllegalStateException(); } // .equals is not defined for LazyString
+        }
 
         @Benchmark
-        public Object slang_persistent() { return slangPersistent.tail(); }
+        public void slang_persistent() {
+            javaslang.collection.CharSeq values = slangPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.tail();
+            }
+            assertEquals(values, javaslang.collection.CharSeq.empty());
+        }
     }
 
     public static class Get extends Base {
-        final int index = CONTAINER_SIZE / 2;
+        @Benchmark
+        public void java_persistent() {
+            for (int i = 0; i < ELEMENTS.length; i++) {
+                assertEquals(javaPersistent.charAt(i), ELEMENTS[i]);
+            }
+        }
 
         @Benchmark
-        public Object java_persistent() { return javaPersistent.charAt(index); }
+        public void fjava_persistent() {
+            for (int i = 0; i < ELEMENTS.length; i++) {
+                assertEquals(fjavaPersistent.charAt(i), ELEMENTS[i]);
+            }
+        }
 
         @Benchmark
-        public Object fjava_persistent() { return fjavaPersistent.charAt(index); }
-
-        @Benchmark
-        public Object slang_persistent() { return slangPersistent.charAt(index); }
+        public void slang_persistent() {
+            for (int i = 0; i < ELEMENTS.length; i++) {
+                assertEquals(slangPersistent.charAt(i), ELEMENTS[i]);
+            }
+        }
     }
 
     public static class Update extends Base {
-        final int index = CONTAINER_SIZE / 2;
         final char replacement = '-';
 
         @Benchmark
-        public Object java_persistent() { return javaPersistent.substring(0, index) + replacement + javaPersistent.substring(index + 1); }
+        public Object java_persistent() {
+            java.lang.String values = javaPersistent;
+            for (int i = 0; i < ELEMENTS.length; i++) {
+                values = values.substring(0, i) + replacement + values.substring(i + 1);
+            }
+            return values;
+        }
 
         @Benchmark
-        public Object slang_persistent() { return slangPersistent.update(index, replacement); }
+        public Object slang_persistent() {
+            javaslang.collection.CharSeq values = slangPersistent;
+            for (int i = 0; i < ELEMENTS.length; i++) {
+                values = slangPersistent.update(i, replacement);
+            }
+            return values;
+        }
     }
 
     public static class Prepend extends Base {

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/HashSetBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/HashSetBenchmark.java
@@ -7,7 +7,7 @@ import static javaslang.benchmark.JmhRunner.*;
 
 public class HashSetBenchmark {
     public static void main(String... args) {
-        JmhRunner.runDev(HashSetBenchmark.class);
+        JmhRunner.runQuick(HashSetBenchmark.class);
     }
 
     @State(Scope.Benchmark)

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/HashSetBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/HashSetBenchmark.java
@@ -1,6 +1,7 @@
 package javaslang.benchmark.collection;
 
 import javaslang.benchmark.JmhRunner;
+import javaslang.collection.HashSet;
 import org.openjdk.jmh.annotations.*;
 
 import static javaslang.benchmark.JmhRunner.*;
@@ -15,20 +16,38 @@ public class HashSetBenchmark {
         @Param({ "10", "100", "1000" })
         public int CONTAINER_SIZE;
 
-        public Integer[] ELEMENTS;
-        public int SET_SIZE;
-        public int EXPECTED_AGGREGATE;
+        Integer[] ELEMENTS;
+        int SET_SIZE;
+        int EXPECTED_AGGREGATE;
+
+        org.pcollections.PSet<Integer> pcollectionsPersistent = org.pcollections.HashTreePSet.empty();
+        scala.collection.immutable.HashSet<Integer> scalaPersistent = new scala.collection.immutable.HashSet<>();
+        javaslang.collection.Set<Integer> slangPersistent = javaslang.collection.HashSet.empty();
 
         @Setup
         public void setup() {
             ELEMENTS = getRandomValues(CONTAINER_SIZE, 0);
-            SET_SIZE = javaslang.collection.Stream.of(ELEMENTS).distinct().size();
-            EXPECTED_AGGREGATE = javaslang.collection.Stream.of(ELEMENTS).distinct().fold(0, (i, j) -> i ^ j);
+
+            final HashSet<Integer> set = HashSet.of(ELEMENTS);
+            SET_SIZE = set.size();
+            EXPECTED_AGGREGATE = set.fold(0, (i, j) -> i ^ j);
+
+            assertEquals(pcollectionsPersistent.size(), 0);
+            assertEquals(scalaPersistent.size(), 0);
+            assertEquals(slangPersistent.size(), 0);
+            for (Integer element : ELEMENTS) {
+                pcollectionsPersistent = pcollectionsPersistent.plus(element);
+                scalaPersistent = scalaPersistent.$plus(element);
+                slangPersistent = slangPersistent.add(element);
+            }
+            assertEquals(pcollectionsPersistent.size(), SET_SIZE);
+            assertEquals(scalaPersistent.size(), SET_SIZE);
+            assertEquals(slangPersistent.size(), SET_SIZE);
+
         }
     }
 
-    public static class AddAll extends Base {
-
+    public static class Add extends Base {
         @Benchmark
         public void pcollections_persistent() {
             org.pcollections.PSet<Integer> values = org.pcollections.HashTreePSet.empty();
@@ -58,23 +77,6 @@ public class HashSetBenchmark {
     }
 
     public static class Iterate extends Base {
-
-        org.pcollections.PSet<Integer> pcollectionsPersistent = org.pcollections.HashTreePSet.empty();
-        scala.collection.immutable.HashSet<Integer> scalaPersistent = new scala.collection.immutable.HashSet<>();
-        javaslang.collection.Set<Integer> slangPersistent = javaslang.collection.HashSet.empty();
-
-        @Setup
-        public void initializeImmutable(Base state) {
-            for (Integer element : state.ELEMENTS) {
-                pcollectionsPersistent = pcollectionsPersistent.plus(element);
-                scalaPersistent = scalaPersistent.$plus(element);
-                slangPersistent = slangPersistent.add(element);
-            }
-            assertEquals(pcollectionsPersistent.size(), state.SET_SIZE);
-            assertEquals(scalaPersistent.size(), state.SET_SIZE);
-            assertEquals(slangPersistent.size(), state.SET_SIZE);
-        }
-
         @Benchmark
         public void scala_persistent() {
             int aggregate = 0;

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/ListBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/ListBenchmark.java
@@ -11,7 +11,7 @@ import static javaslang.benchmark.JmhRunner.*;
 
 public class ListBenchmark {
     public static void main(String... args) {
-        JmhRunner.runDev(ListBenchmark.class);
+        JmhRunner.runQuick(ListBenchmark.class);
     }
 
     @State(Scope.Benchmark)
@@ -19,21 +19,279 @@ public class ListBenchmark {
         @Param({ "10", "100", "1000" })
         public int CONTAINER_SIZE;
 
+        int expectedAggregate = 0;
         public Integer[] ELEMENTS;
+
+        /* Only use these for non-mutating operations */
+        final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
+        final java.util.LinkedList<Integer> javaMutableLinked = new java.util.LinkedList<>();
+        final scala.collection.mutable.MutableList<Integer> scalaMutable = new scala.collection.mutable.MutableList<>();
+
+        fj.data.List<Integer> fjavaPersistent = fj.data.List.list();
+        org.pcollections.PStack<Integer> pcollectionsPersistent = org.pcollections.ConsPStack.empty();
+        scala.collection.immutable.List<Integer> scalaPersistent = scala.collection.immutable.List$.MODULE$.empty();
+        javaslang.collection.List<Integer> slangPersistent = javaslang.collection.List.empty();
 
         @Setup
         public void setup() {
             ELEMENTS = getRandomValues(CONTAINER_SIZE, 0);
+
+            for (Integer element : ELEMENTS) {
+                expectedAggregate ^= element;
+            }
+
+            assertEquals(javaMutable.size(), 0);
+            assertEquals(javaMutableLinked.size(), 0);
+            assertEquals(scalaMutable.size(), 0);
+            assertEquals(fjavaPersistent.length(), 0);
+            assertEquals(pcollectionsPersistent.size(), 0);
+            assertEquals(scalaPersistent.size(), 0);
+            assertEquals(slangPersistent.size(), 0);
+            for (int i = CONTAINER_SIZE - 1; i >= 0; i--) {
+                final Integer element = ELEMENTS[i];
+
+                javaMutable.add(0, element);
+                javaMutableLinked.addFirst(element);
+                scalaMutable.prependElem(element);
+
+                fjavaPersistent = fjavaPersistent.cons(element);
+                pcollectionsPersistent = pcollectionsPersistent.plus(element);
+                scalaPersistent = scalaPersistent.$colon$colon(element);
+                slangPersistent = slangPersistent.prepend(element);
+            }
+            assertEquals(javaMutable.size(), CONTAINER_SIZE);
+            assertEquals(javaMutableLinked.size(), CONTAINER_SIZE);
+            assertEquals(scalaMutable.size(), CONTAINER_SIZE);
+            assertEquals(fjavaPersistent.length(), CONTAINER_SIZE);
+            assertEquals(pcollectionsPersistent.size(), CONTAINER_SIZE);
+            assertEquals(scalaPersistent.size(), CONTAINER_SIZE);
+            assertEquals(slangPersistent.size(), CONTAINER_SIZE);
         }
     }
 
-    public static class AddAll extends Base {
+    public static class Head extends Base {
+        @Benchmark
+        public Object java_mutable() { return javaMutable.get(0); }
+
+        @Benchmark
+        public Object java_mutable_linked() { return javaMutableLinked.get(0); }
+
+        @Benchmark
+        public Object scala_mutable() { return scalaMutable.head(); }
+
+        @Benchmark
+        public Object scala_persistent() { return scalaPersistent.head(); }
+
+        @Benchmark
+        public Object fjava_persistent() { return fjavaPersistent.head(); }
+
+        @Benchmark
+        public Object pcollections_persistent() { return pcollectionsPersistent.get(0); }
+
+        @Benchmark
+        public Object slang_persistent() { return slangPersistent.head(); }
+    }
+
+    public static class Tail extends Base {
+        @State(Scope.Thread)
+        public static class Initialized {
+            final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
+
+            @Setup(Level.Invocation)
+            public void initializeMutable(Base state) {
+                assertEquals(javaMutable.size(), 0);
+                Collections.addAll(javaMutable, state.ELEMENTS);
+                assertEquals(javaMutable.size(), state.CONTAINER_SIZE);
+            }
+
+            @TearDown(Level.Invocation)
+            public void tearDown() {
+                javaMutable.clear();
+            }
+        }
+
+        @Benchmark
+        public void java_mutable(Initialized state) {
+            final java.util.ArrayList<Integer> values = state.javaMutable;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values.remove(0);
+            }
+            assertEquals(values, new java.util.ArrayList<>());
+        }
+
+        @Benchmark
+        public void scala_persistent() {
+            scala.collection.immutable.List<Integer> values = scalaPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.drop(1);
+            }
+            assertEquals(values, scala.collection.immutable.List.empty());
+        }
+
+        @Benchmark
+        public void fjava_persistent() {
+            fj.data.List<Integer> values = fjavaPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.tail();
+            }
+            assertEquals(values, fj.data.List.list());
+        }
+
+        @Benchmark
+        public void pcollections_persistent() {
+            org.pcollections.PStack<Integer> values = pcollectionsPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.minus(0);
+            }
+            assertEquals(values, org.pcollections.ConsPStack.empty());
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            javaslang.collection.List<Integer> values = slangPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.tail();
+            }
+            assertEquals(values, javaslang.collection.List.empty());
+        }
+    }
+
+    public static class Get extends Base {
+        @Benchmark
+        public void java_mutable() {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                assertEquals(javaMutable.get(i), ELEMENTS[i]);
+            }
+        }
+
+        @Benchmark
+        public void java_mutable_linked() {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                assertEquals(javaMutableLinked.get(i), ELEMENTS[i]);
+            }
+        }
+
+        @Benchmark
+        public void scala_mutable() {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                assertEquals(scalaMutable.get(i).get(), ELEMENTS[i]);
+            }
+        }
+
+        @Benchmark
+        public void scala_persistent() {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                assertEquals(scalaPersistent.apply(i), ELEMENTS[i]);
+            }
+        }
+
+        @Benchmark
+        public void fjava_persistent() {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                assertEquals(fjavaPersistent.index(i), ELEMENTS[i]);
+            }
+        }
+
+        @Benchmark
+        public void pcollections_persistent() {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                assertEquals(pcollectionsPersistent.get(i), ELEMENTS[i]);
+            }
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                assertEquals(slangPersistent.get(i), ELEMENTS[i]);
+            }
+        }
+    }
+
+    public static class Update extends Base {
+        @State(Scope.Thread)
+        public static class Initialized {
+            final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
+            final java.util.LinkedList<Integer> javaMutableLinked = new java.util.LinkedList<>();
+            final scala.collection.mutable.MutableList<Integer> scalaMutable = new scala.collection.mutable.MutableList<>();
+
+            @Setup(Level.Invocation)
+            public void initializeMutable(Base state) {
+                assertEquals(javaMutable.size(), 0);
+                Collections.addAll(javaMutable, state.ELEMENTS);
+                assertEquals(javaMutable.size(), state.CONTAINER_SIZE);
+
+                assertEquals(javaMutableLinked.size(), 0);
+                Collections.addAll(javaMutableLinked, state.ELEMENTS);
+                assertEquals(javaMutableLinked.size(), state.CONTAINER_SIZE);
+
+                assertEquals(scalaMutable.size(), 0);
+                for (int i = state.CONTAINER_SIZE - 1; i >= 0; i--) {
+                    scalaMutable.prependElem(state.ELEMENTS[i]);
+                }
+                assertEquals(scalaMutable.size(), state.CONTAINER_SIZE);
+            }
+
+            @TearDown(Level.Invocation)
+            public void tearDown() {
+                javaMutable.clear();
+                javaMutableLinked.clear();
+                scalaMutable.clear();
+            }
+        }
+
+        @Benchmark
+        public Object java_mutable(Initialized state) {
+            final java.util.ArrayList<Integer> values = state.javaMutable;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values.set(i, 0);
+            }
+            return values;
+        }
+
+        @Benchmark
+        public Object java_mutable_linked(Initialized state) {
+            final java.util.LinkedList<Integer> values = state.javaMutableLinked;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values.set(i, 0);
+            }
+            return values;
+        }
+
+        @Benchmark
+        public Object scala_mutable(Initialized state) {
+            final scala.collection.mutable.MutableList<Integer> values = state.scalaMutable;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values.update(i, 0);
+            }
+            return values;
+        }
+
+        @Benchmark
+        public Object pcollections_persistent() {
+            org.pcollections.PStack<Integer> values = pcollectionsPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.with(i, 0);
+            }
+            return values;
+        }
+
+        @Benchmark
+        public Object slang_persistent() {
+            javaslang.collection.List<Integer> values = slangPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.update(i, 0);
+            }
+            return values;
+        }
+    }
+
+    public static class Prepend extends Base {
         @Benchmark
         @SuppressWarnings("ManualArrayToCollectionCopy")
         public void java_mutable() {
-            final java.util.ArrayList<Integer> values = new java.util.ArrayList<>(ELEMENTS.length);
+            final java.util.ArrayList<Integer> values = new java.util.ArrayList<>(CONTAINER_SIZE);
             for (Integer element : ELEMENTS) {
-                values.add(element);
+                values.add(0, element);
             }
             assertEquals(values.size(), CONTAINER_SIZE);
         }
@@ -43,7 +301,7 @@ public class ListBenchmark {
         public void java_mutable_linked() {
             final java.util.LinkedList<Integer> values = new java.util.LinkedList<>();
             for (Integer element : ELEMENTS) {
-                values.add(element);
+                values.addFirst(element);
             }
             assertEquals(values.size(), CONTAINER_SIZE);
         }
@@ -94,18 +352,93 @@ public class ListBenchmark {
         }
     }
 
+    public static class Append extends Base {
+        @Benchmark
+        @SuppressWarnings("ManualArrayToCollectionCopy")
+        public void java_mutable() {
+            final java.util.ArrayList<Integer> values = new java.util.ArrayList<>(CONTAINER_SIZE);
+            for (Integer element : ELEMENTS) {
+                values.add(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ManualArrayToCollectionCopy")
+        public void java_mutable_linked() {
+            final java.util.LinkedList<Integer> values = new java.util.LinkedList<>();
+            for (Integer element : ELEMENTS) {
+                values.addLast(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void scala_mutable() {
+            final scala.collection.mutable.MutableList<Integer> values = new scala.collection.mutable.MutableList<>();
+            for (Integer element : ELEMENTS) {
+                values.appendElem(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void scala_persistent() {
+            scala.collection.immutable.List<Integer> values = scala.collection.immutable.List$.MODULE$.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.$colon$colon$colon(scala.collection.immutable.List$.MODULE$.empty().$colon$colon(element)); // TODO there should be a better way to append an element to the end of the list in Scala
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void fjava_persistent() {
+            fj.data.List<Integer> values = fj.data.List.list();
+            for (Integer element : ELEMENTS) {
+                values = values.snoc(element);
+            }
+            assertEquals(values.length(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void pcollections_persistent() {
+            org.pcollections.PStack<Integer> values = org.pcollections.ConsPStack.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.plus(values.size(), element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            javaslang.collection.List<Integer> values = javaslang.collection.List.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.append(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+    }
+
+    public static class GroupBy extends Base {
+        @Benchmark
+        public Object java_mutable() { return javaMutable.stream().collect(Collectors.groupingBy(Integer::bitCount)); }
+
+        @Benchmark
+        public Object scala_persistent() { return scalaPersistent.groupBy(JFunction.func(Integer::bitCount)); }
+
+        @Benchmark
+        public Object fjava_persistent() { return fjavaPersistent.groupBy(Integer::bitCount); }
+
+        @Benchmark
+        public Object slang_persistent() { return slangPersistent.groupBy(Integer::bitCount); }
+    }
+
     public static class Iterate extends Base {
         @State(Scope.Thread)
         public static class Initialized {
             final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
             final java.util.LinkedList<Integer> javaMutableLinked = new java.util.LinkedList<>();
             final scala.collection.mutable.MutableList<Integer> scalaMutable = new scala.collection.mutable.MutableList<>();
-
-            int expectedAggregate = 0;
-            fj.data.List<Integer> fjavaPersistent = fj.data.List.list();
-            org.pcollections.PStack<Integer> pcollectionsPersistent = org.pcollections.ConsPStack.empty();
-            scala.collection.immutable.List<Integer> scalaPersistent = scala.collection.immutable.List$.MODULE$.empty();
-            javaslang.collection.List<Integer> slangPersistent = javaslang.collection.List.empty();
 
             @Setup(Level.Invocation)
             public void initializeMutable(Base state) {
@@ -118,31 +451,10 @@ public class ListBenchmark {
                 assertEquals(javaMutableLinked.size(), state.CONTAINER_SIZE);
 
                 assertEquals(scalaMutable.size(), 0);
-                for (Integer element : state.ELEMENTS) {
-                    scalaMutable.prependElem(element);
+                for (int i = state.CONTAINER_SIZE - 1; i >= 0; i--) {
+                    scalaMutable.prependElem(state.ELEMENTS[i]);
                 }
                 assertEquals(scalaMutable.size(), state.CONTAINER_SIZE);
-
-                if (expectedAggregate == 0) {
-                    for (Integer element : state.ELEMENTS) {
-                        expectedAggregate ^= element;
-                    }
-
-                    assertEquals(fjavaPersistent.length(), 0);
-                    assertEquals(pcollectionsPersistent.size(), 0);
-                    assertEquals(scalaPersistent.size(), 0);
-                    assertEquals(slangPersistent.size(), 0);
-                    for (Integer element : state.ELEMENTS) {
-                        fjavaPersistent = fjavaPersistent.cons(element);
-                        pcollectionsPersistent = pcollectionsPersistent.plus(element);
-                        scalaPersistent = scalaPersistent.$colon$colon(element);
-                        slangPersistent = slangPersistent.prepend(element);
-                    }
-                    assertEquals(fjavaPersistent.length(), state.CONTAINER_SIZE);
-                    assertEquals(pcollectionsPersistent.size(), state.CONTAINER_SIZE);
-                    assertEquals(scalaPersistent.size(), state.CONTAINER_SIZE);
-                    assertEquals(slangPersistent.size(), state.CONTAINER_SIZE);
-                }
             }
 
             @TearDown(Level.Invocation)
@@ -160,7 +472,7 @@ public class ListBenchmark {
             for (final Iterator<Integer> iterator = state.javaMutable.iterator(); iterator.hasNext(); ) {
                 aggregate ^= iterator.next();
             }
-            assertEquals(aggregate, state.expectedAggregate);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
@@ -170,7 +482,7 @@ public class ListBenchmark {
             for (final Iterator<Integer> iterator = state.javaMutableLinked.iterator(); iterator.hasNext(); ) {
                 aggregate ^= iterator.next();
             }
-            assertEquals(aggregate, state.expectedAggregate);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
@@ -179,95 +491,46 @@ public class ListBenchmark {
             for (final scala.collection.Iterator<Integer> iterator = state.scalaMutable.iterator(); iterator.hasNext(); ) {
                 aggregate ^= iterator.next();
             }
-            assertEquals(aggregate, state.expectedAggregate);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
-        public void scala_persistent(Initialized state) {
+        public void scala_persistent() {
             int aggregate = 0;
-            for (final scala.collection.Iterator<Integer> iterator = state.scalaPersistent.iterator(); iterator.hasNext(); ) {
+            for (final scala.collection.Iterator<Integer> iterator = scalaPersistent.iterator(); iterator.hasNext(); ) {
                 aggregate ^= iterator.next();
             }
-            assertEquals(aggregate, state.expectedAggregate);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
         @SuppressWarnings("ForLoopReplaceableByForEach")
-        public void fjava_persistent(Initialized state) {
+        public void fjava_persistent() {
             int aggregate = 0;
-            for (final Iterator<Integer> iterator = state.fjavaPersistent.iterator(); iterator.hasNext(); ) {
+            for (final Iterator<Integer> iterator = fjavaPersistent.iterator(); iterator.hasNext(); ) {
                 aggregate ^= iterator.next();
             }
-            assertEquals(aggregate, state.expectedAggregate);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
         @SuppressWarnings("ForLoopReplaceableByForEach")
-        public void pcollections_persistent(Initialized state) {
+        public void pcollections_persistent() {
             int aggregate = 0;
-            for (final Iterator<Integer> iterator = state.pcollectionsPersistent.iterator(); iterator.hasNext(); ) {
+            for (final Iterator<Integer> iterator = pcollectionsPersistent.iterator(); iterator.hasNext(); ) {
                 aggregate ^= iterator.next();
             }
-            assertEquals(aggregate, state.expectedAggregate);
+            assertEquals(aggregate, expectedAggregate);
         }
 
         @Benchmark
         @SuppressWarnings("ForLoopReplaceableByForEach")
-        public void slang_persistent(Initialized state) {
+        public void slang_persistent() {
             int aggregate = 0;
-            for (final Iterator<Integer> iterator = state.slangPersistent.iterator(); iterator.hasNext(); ) {
+            for (final Iterator<Integer> iterator = slangPersistent.iterator(); iterator.hasNext(); ) {
                 aggregate ^= iterator.next();
             }
-            assertEquals(aggregate, state.expectedAggregate);
-        }
-    }
-
-    public static class GroupBy extends Base {
-        @State(Scope.Thread)
-        public static class Initialized {
-            final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
-            scala.collection.immutable.List<Integer> scalaPersistent = scala.collection.immutable.List$.MODULE$.empty();
-            fj.data.List<Integer> fjavaPersistent = fj.data.List.list();
-            javaslang.collection.List<Integer> slangPersistent = javaslang.collection.List.empty();
-
-            @Setup
-            public void initializeMutable(Base state) {
-                assertEquals(javaMutable.size(), 0);
-                Collections.addAll(javaMutable, state.ELEMENTS);
-                assertEquals(javaMutable.size(), state.CONTAINER_SIZE);
-
-                assertEquals(fjavaPersistent.length(), 0);
-                assertEquals(scalaPersistent.size(), 0);
-                assertEquals(slangPersistent.size(), 0);
-                for (Integer element : state.ELEMENTS) {
-                    fjavaPersistent = fjavaPersistent.cons(element);
-                    scalaPersistent = scalaPersistent.$colon$colon(element);
-                    slangPersistent = slangPersistent.prepend(element);
-                }
-                assertEquals(fjavaPersistent.length(), state.CONTAINER_SIZE);
-                assertEquals(scalaPersistent.size(), state.CONTAINER_SIZE);
-                assertEquals(slangPersistent.size(), state.CONTAINER_SIZE);
-            }
-        }
-
-        @Benchmark
-        public Object java_mutable(Initialized state) {
-            return state.javaMutable.stream().collect(Collectors.groupingBy(Integer::bitCount));
-        }
-
-        @Benchmark
-        public Object scala_persistent(Initialized state) {
-            return state.scalaPersistent.groupBy(JFunction.func(Integer::bitCount));
-        }
-
-        @Benchmark
-        public Object fjava_persistent(Initialized state) {
-            return state.fjavaPersistent.groupBy(Integer::bitCount);
-        }
-
-        @Benchmark
-        public Object slang_persistent(Initialized state) {
-            return state.slangPersistent.groupBy(Integer::bitCount);
+            assertEquals(aggregate, expectedAggregate);
         }
     }
 }

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/PriorityQueueBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/PriorityQueueBenchmark.java
@@ -15,7 +15,7 @@ import static javaslang.benchmark.JmhRunner.*;
 
 public class PriorityQueueBenchmark {
     public static void main(String... args) {
-        JmhRunner.runDev(PriorityQueueBenchmark.class);
+        JmhRunner.runQuick(PriorityQueueBenchmark.class);
     }
 
     @State(Scope.Benchmark)

--- a/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/VectorBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/benchmark/collection/VectorBenchmark.java
@@ -1,0 +1,446 @@
+package javaslang.benchmark.collection;
+
+import javaslang.benchmark.JmhRunner;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import scala.compat.java8.JFunction;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static javaslang.benchmark.JmhRunner.*;
+
+public class VectorBenchmark {
+    public static void main(String... args) {
+        JmhRunner.runQuick(VectorBenchmark.class);
+    }
+
+    @State(Scope.Benchmark)
+    public static class Base {
+        @Param({ "10", "100", "1000" })
+        public int CONTAINER_SIZE;
+
+        int expectedAggregate = 0;
+        public Integer[] ELEMENTS;
+
+        /* Only use these for non-mutating operations */
+        final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
+
+        fj.data.Seq<Integer> fjavaPersistent = fj.data.Seq.empty();
+        org.pcollections.PVector<Integer> pcollectionsPersistent = org.pcollections.TreePVector.empty();
+        scala.collection.immutable.Vector<Integer> scalaPersistent = scala.collection.immutable.Vector$.MODULE$.empty();
+        javaslang.collection.Vector<Integer> slangPersistent = javaslang.collection.Vector.empty();
+
+        @Setup
+        public void setup() {
+            ELEMENTS = getRandomValues(CONTAINER_SIZE, 0);
+
+            assertEquals(javaMutable.size(), 0);
+            assertEquals(fjavaPersistent.length(), 0);
+            assertEquals(pcollectionsPersistent.size(), 0);
+            assertEquals(scalaPersistent.size(), 0);
+            assertEquals(slangPersistent.size(), 0);
+            for (Integer element : ELEMENTS) {
+                expectedAggregate ^= element;
+
+                javaMutable.add(element);
+
+                fjavaPersistent = fjavaPersistent.snoc(element);
+                pcollectionsPersistent = pcollectionsPersistent.plus(element);
+                scalaPersistent = scalaPersistent.appendBack(element);
+                slangPersistent = slangPersistent.append(element);
+            }
+            assertEquals(javaMutable.size(), CONTAINER_SIZE);
+            assertEquals(fjavaPersistent.length(), CONTAINER_SIZE);
+            assertEquals(pcollectionsPersistent.size(), CONTAINER_SIZE);
+            assertEquals(scalaPersistent.size(), CONTAINER_SIZE);
+            assertEquals(slangPersistent.size(), CONTAINER_SIZE);
+        }
+    }
+
+    public static class Head extends Base {
+        @Benchmark
+        public Object java_mutable() { return javaMutable.get(0); }
+
+        @Benchmark
+        public Object scala_persistent() { return scalaPersistent.head(); }
+
+        @Benchmark
+        public Object fjava_persistent() { return fjavaPersistent.head(); }
+
+        @Benchmark
+        public Object pcollections_persistent() { return pcollectionsPersistent.get(0); }
+
+        @Benchmark
+        public Object slang_persistent() { return slangPersistent.head(); }
+    }
+
+    public static class Tail extends Base {
+        @State(Scope.Thread)
+        public static class Initialized {
+            final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
+
+            @Setup(Level.Invocation)
+            public void initializeMutable(Base state) {
+                assertEquals(javaMutable.size(), 0);
+                Collections.addAll(javaMutable, state.ELEMENTS);
+                assertEquals(javaMutable.size(), state.CONTAINER_SIZE);
+            }
+
+            @TearDown(Level.Invocation)
+            public void tearDown() {
+                javaMutable.clear();
+            }
+        }
+
+        @Benchmark
+        public void java_mutable(Initialized state) {
+            final java.util.ArrayList<Integer> values = state.javaMutable;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values.remove(0);
+            }
+            assertEquals(values, new java.util.ArrayList<>());
+        }
+
+        @Benchmark
+        public void scala_persistent() {
+            scala.collection.immutable.Vector<Integer> values = scalaPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.tail();
+            }
+            assertEquals(values, scala.collection.immutable.Vector.empty());
+        }
+
+        @Benchmark
+        public void fjava_persistent() {
+            fj.data.Seq<Integer> values = fjavaPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.tail();
+            }
+            assertEquals(values, fj.data.Seq.empty());
+        }
+
+        @Benchmark
+        public void pcollections_persistent() {
+            org.pcollections.PVector<Integer> values = pcollectionsPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.minus(0);
+            }
+            assertEquals(values, org.pcollections.TreePVector.empty());
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            javaslang.collection.Vector<Integer> values = slangPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.tail();
+            }
+            assertEquals(values, javaslang.collection.Vector.empty());
+        }
+    }
+
+    public static class Get extends Base {
+        @Benchmark
+        public void java_mutable() {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                assertEquals(javaMutable.get(i), ELEMENTS[i]);
+            }
+        }
+
+        @Benchmark
+        public void scala_persistent() {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                assertEquals(scalaPersistent.apply(i), ELEMENTS[i]);
+            }
+        }
+
+        @Benchmark
+        public void fjava_persistent() {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                assertEquals(fjavaPersistent.index(i), ELEMENTS[i]);
+            }
+        }
+
+        @Benchmark
+        public void pcollections_persistent() {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                assertEquals(pcollectionsPersistent.get(i), ELEMENTS[i]);
+            }
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                assertEquals(slangPersistent.get(i), ELEMENTS[i]);
+            }
+        }
+    }
+
+    public static class Update extends Base {
+        @State(Scope.Thread)
+        public static class Initialized {
+            final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
+
+            @Setup(Level.Invocation)
+            public void initializeMutable(Base state) {
+                assertEquals(javaMutable.size(), 0);
+                Collections.addAll(javaMutable, state.ELEMENTS);
+                assertEquals(javaMutable.size(), state.CONTAINER_SIZE);
+            }
+
+            @TearDown(Level.Invocation)
+            public void tearDown() {
+                javaMutable.clear();
+            }
+        }
+
+        @Benchmark
+        public Object java_mutable(Initialized state) {
+            final java.util.ArrayList<Integer> values = state.javaMutable;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values.set(i, 0);
+            }
+            return values;
+        }
+
+        @Benchmark
+        public Object scala_persistent() {
+            scala.collection.immutable.Vector<Integer> values = scalaPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.updateAt(i, 0);
+            }
+            return values;
+        }
+
+        @Benchmark
+        public Object fjava_persistent() {
+            fj.data.Seq<Integer> values = fjavaPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.update(i, 0);
+            }
+            return values;
+        }
+
+        @Benchmark
+        public Object pcollections_persistent() {
+            org.pcollections.PVector<Integer> values = pcollectionsPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.with(i, 0);
+            }
+            return values;
+        }
+
+        @Benchmark
+        public Object slang_persistent() {
+            javaslang.collection.Vector<Integer> values = slangPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.update(i, 0);
+            }
+            return values;
+        }
+    }
+
+    public static class Prepend extends Base {
+        @Benchmark
+        @SuppressWarnings("ManualArrayToCollectionCopy")
+        public void java_mutable() {
+            final java.util.ArrayList<Integer> values = new java.util.ArrayList<>(CONTAINER_SIZE);
+            for (Integer element : ELEMENTS) {
+                values.add(0, element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void scala_persistent() {
+            scala.collection.immutable.Vector<Integer> values = scala.collection.immutable.Vector$.MODULE$.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.appendFront(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void fjava_persistent() {
+            fj.data.Seq<Integer> values = fj.data.Seq.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.cons(element);
+            }
+            assertEquals(values.length(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void pcollections_persistent() {
+            org.pcollections.PVector<Integer> values = org.pcollections.TreePVector.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.plus(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            javaslang.collection.Vector<Integer> values = javaslang.collection.Vector.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.prepend(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+    }
+
+    public static class Append extends Base {
+        @Benchmark
+        @SuppressWarnings("ManualArrayToCollectionCopy")
+        public void java_mutable() {
+            final java.util.ArrayList<Integer> values = new java.util.ArrayList<>(CONTAINER_SIZE);
+            for (Integer element : ELEMENTS) {
+                values.add(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void scala_persistent() {
+            scala.collection.immutable.Vector<Integer> values = scala.collection.immutable.Vector$.MODULE$.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.appendBack(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void fjava_persistent() {
+            fj.data.Seq<Integer> values = fj.data.Seq.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.snoc(element);
+            }
+            assertEquals(values.length(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void pcollections_persistent() {
+            org.pcollections.PVector<Integer> values = org.pcollections.TreePVector.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.plus(values.size(), element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+
+        @Benchmark
+        public void slang_persistent() {
+            javaslang.collection.Vector<Integer> values = javaslang.collection.Vector.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.append(element);
+            }
+            assertEquals(values.size(), CONTAINER_SIZE);
+        }
+    }
+
+    public static class GroupBy extends Base {
+        @Benchmark
+        public Object java_mutable() { return javaMutable.stream().collect(Collectors.groupingBy(Integer::bitCount)); }
+
+        @Benchmark
+        public Object scala_persistent() { return scalaPersistent.groupBy(JFunction.func(Integer::bitCount)); }
+
+        @Benchmark
+        public Object slang_persistent() { return slangPersistent.groupBy(Integer::bitCount); }
+    }
+
+    public static class Slice extends Base {
+        @Benchmark
+        public void java_mutable(Blackhole bh) {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                for (int j = i; j < CONTAINER_SIZE; j++) {
+                    bh.consume(javaMutable.subList(i, j));
+                }
+            }
+        }
+
+        @Benchmark
+        public void scala_persistent(Blackhole bh) {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                for (int j = i; j < CONTAINER_SIZE; j++) {
+                    bh.consume(scalaPersistent.slice(i, j));
+                }
+            }
+        }
+
+        @Benchmark
+        public void slang_persistent(Blackhole bh) {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                for (int j = i; j < CONTAINER_SIZE; j++) {
+                    bh.consume(slangPersistent.slice(i, j));
+                }
+            }
+        }
+    }
+
+    public static class Iterate extends Base {
+        @State(Scope.Thread)
+        public static class Initialized {
+            final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
+
+            @Setup(Level.Invocation)
+            public void initializeMutable(Base state) {
+                assertEquals(javaMutable.size(), 0);
+                Collections.addAll(javaMutable, state.ELEMENTS);
+                assertEquals(javaMutable.size(), state.CONTAINER_SIZE);
+            }
+
+            @TearDown(Level.Invocation)
+            public void tearDown() {
+                javaMutable.clear();
+            }
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void java_mutable(Initialized state) {
+            int aggregate = 0;
+            for (final Iterator<Integer> iterator = state.javaMutable.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, expectedAggregate);
+        }
+
+        @Benchmark
+        public void scala_persistent() {
+            int aggregate = 0;
+            for (final scala.collection.Iterator<Integer> iterator = scalaPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void fjava_persistent() {
+            int aggregate = 0;
+            for (final Iterator<Integer> iterator = fjavaPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void pcollections_persistent() {
+            int aggregate = 0;
+            for (final Iterator<Integer> iterator = pcollectionsPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, expectedAggregate);
+        }
+
+        @Benchmark
+        @SuppressWarnings("ForLoopReplaceableByForEach")
+        public void slang_persistent() {
+            int aggregate = 0;
+            for (final Iterator<Integer> iterator = slangPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assertEquals(aggregate, expectedAggregate);
+        }
+    }
+}


### PR DESCRIPTION
Compared it against `ArrayList`, `LinkedList`, `PCollections`, `Functional Java`, `Scala Mutable` and `Scala Persistent`

> List

```java
Ratios slang / <alternative_impl>
Target         Operation   Ratio                                                    10        100       1000 
ListBenchmark  Head        slang_persistent/fjava_persistent                     1.08x      1.03x      1.02x 
ListBenchmark  Head        slang_persistent/java_mutable                         1.03x      1.04x      1.03x 
ListBenchmark  Head        slang_persistent/java_mutable_linked                  1.01x      0.99x      1.00x 
ListBenchmark  Head        slang_persistent/pcollections_persistent              1.12x      1.11x      1.12x 
ListBenchmark  Head        slang_persistent/scala_mutable                        1.04x      1.02x      1.02x 
ListBenchmark  Head        slang_persistent/scala_persistent                     1.00x      1.01x      1.00x 

ListBenchmark  Tail        slang_persistent/fjava_persistent                     0.98x      1.00x      0.97x 
ListBenchmark  Tail        slang_persistent/java_mutable                        24.40x     30.00x    148.05x 
ListBenchmark  Tail        slang_persistent/java_mutable_linked                  8.34x      9.68x     53.63x 
ListBenchmark  Tail        slang_persistent/pcollections_persistent              1.26x      1.30x      1.28x 
ListBenchmark  Tail        slang_persistent/scala_mutable                        5.44x      7.76x     50.02x 
ListBenchmark  Tail        slang_persistent/scala_persistent                     0.97x      1.01x      0.99x 

ListBenchmark  Append      slang_persistent/fjava_persistent                     0.39x      0.62x      0.67x 
ListBenchmark  Append      slang_persistent/java_mutable                         0.06x      0.01x      0.00x 
ListBenchmark  Append      slang_persistent/java_mutable_linked                  0.06x      0.01x      0.00x 
ListBenchmark  Append      slang_persistent/pcollections_persistent              0.33x      0.57x      0.98x 
ListBenchmark  Append      slang_persistent/scala_mutable                        0.11x      0.02x      0.00x 
ListBenchmark  Append      slang_persistent/scala_persistent                     0.25x      0.05x      0.00x 

ListBenchmark  Prepend     slang_persistent/fjava_persistent                     1.52x      1.65x      1.40x 
ListBenchmark  Prepend     slang_persistent/java_mutable                         4.62x      6.16x     16.36x 
ListBenchmark  Prepend     slang_persistent/java_mutable_linked                  1.04x      1.12x      1.11x 
ListBenchmark  Prepend     slang_persistent/pcollections_persistent              0.80x      0.86x      1.12x 
ListBenchmark  Prepend     slang_persistent/scala_mutable                        1.07x      1.07x      1.21x 
ListBenchmark  Prepend     slang_persistent/scala_persistent                     0.89x      1.04x      1.14x 

ListBenchmark  Get         slang_persistent/fjava_persistent                    18.65x      6.72x      4.79x 
ListBenchmark  Get         slang_persistent/java_mutable                         0.11x      0.00x      0.00x 
ListBenchmark  Get         slang_persistent/java_mutable_linked                  0.45x      0.22x      0.34x 
ListBenchmark  Get         slang_persistent/pcollections_persistent              1.36x      1.32x      1.61x 
ListBenchmark  Get         slang_persistent/scala_mutable                        1.12x      1.12x      1.03x 
ListBenchmark  Get         slang_persistent/scala_persistent                     0.77x      0.97x      0.99x 

ListBenchmark  Update      slang_persistent/java_mutable                         0.05x      0.00x      0.00x 
ListBenchmark  Update      slang_persistent/java_mutable_linked                  0.07x      0.03x      0.06x 
ListBenchmark  Update      slang_persistent/pcollections_persistent              0.50x      0.60x      0.90x 
ListBenchmark  Update      slang_persistent/scala_mutable                        0.13x      0.16x      0.17x

ListBenchmark  Iterate     slang_persistent/fjava_persistent                     1.09x      1.08x      0.98x 
ListBenchmark  Iterate     slang_persistent/java_mutable                         0.95x      0.46x      0.26x 
ListBenchmark  Iterate     slang_persistent/java_mutable_linked                  0.97x      0.83x      0.88x 
ListBenchmark  Iterate     slang_persistent/pcollections_persistent              0.84x      0.99x      0.98x 
ListBenchmark  Iterate     slang_persistent/scala_mutable                        1.41x      1.19x      0.61x 
ListBenchmark  Iterate     slang_persistent/scala_persistent                     0.94x      1.04x      1.00x 

ListBenchmark  GroupBy     slang_persistent/fjava_persistent                    10.63x     71.37x    226.17x 
ListBenchmark  GroupBy     slang_persistent/java_mutable                         0.41x      0.49x      0.73x 
ListBenchmark  GroupBy     slang_persistent/scala_persistent                     1.53x      1.25x      1.09x 
```

In conclusion: `List` is pretty fast, though it could use some minor optimizations here and there (e.g. `append` and `update` are still quite slow).

> Vector 

```java
Ratios slang / <alternative_impl>
Target           Operation  Ratio                                           10      100     1000 
VectorBenchmark  Head       slang_persistent/fjava_persistent            0.28x    0.27x    0.25x
VectorBenchmark  Head       slang_persistent/java_mutable                0.24x    0.22x    0.21x
VectorBenchmark  Head       slang_persistent/pcollections_persistent     0.65x    1.02x    1.50x
VectorBenchmark  Head       slang_persistent/scala_persistent            0.28x    0.34x    0.32x

VectorBenchmark  Tail       slang_persistent/fjava_persistent            7.77x   14.43x   10.47x
VectorBenchmark  Tail       slang_persistent/java_mutable                0.82x    0.84x    1.23x
VectorBenchmark  Tail       slang_persistent/pcollections_persistent     1.02x    1.65x    1.77x
VectorBenchmark  Tail       slang_persistent/scala_persistent            0.62x    1.01x    0.99x

VectorBenchmark  Get        slang_persistent/fjava_persistent            9.60x    7.73x   17.68x
VectorBenchmark  Get        slang_persistent/java_mutable                0.14x    0.03x    0.03x
VectorBenchmark  Get        slang_persistent/pcollections_persistent     1.39x    1.00x    2.54x
VectorBenchmark  Get        slang_persistent/scala_persistent            0.27x    0.14x    0.15x

VectorBenchmark  Update     slang_persistent/fjava_persistent           50.71x  163.88x  195.51x
VectorBenchmark  Update     slang_persistent/java_mutable                0.11x    0.05x    0.03x
VectorBenchmark  Update     slang_persistent/pcollections_persistent     1.22x    1.66x    2.08x
VectorBenchmark  Update     slang_persistent/scala_persistent            0.89x    0.62x    0.40x

VectorBenchmark  Prepend    slang_persistent/fjava_persistent            2.25x    2.77x    2.72x
VectorBenchmark  Prepend    slang_persistent/java_mutable                0.53x    0.55x    1.02x
VectorBenchmark  Prepend    slang_persistent/pcollections_persistent     0.97x    2.11x    2.88x
VectorBenchmark  Prepend    slang_persistent/scala_persistent            0.52x    0.48x    0.37x

VectorBenchmark  Append     slang_persistent/fjava_persistent            3.15x    3.44x    3.14x
VectorBenchmark  Append     slang_persistent/java_mutable                0.15x    0.10x    0.09x
VectorBenchmark  Append     slang_persistent/pcollections_persistent     1.33x    2.61x    4.20x
VectorBenchmark  Append     slang_persistent/scala_persistent            0.64x    0.51x    0.42x

VectorBenchmark  GroupBy    slang_persistent/java_mutable                0.21x    0.19x    0.25x
VectorBenchmark  GroupBy    slang_persistent/scala_persistent            0.89x    0.44x    0.30x

VectorBenchmark  Slice      slang_persistent/java_mutable                0.07x    0.00x    0.00x
VectorBenchmark  Slice      slang_persistent/scala_persistent            0.51x    0.07x    0.01x

VectorBenchmark  Iterate    slang_persistent/fjava_persistent           31.00x   55.51x   50.76x
VectorBenchmark  Iterate    slang_persistent/java_mutable                0.17x    0.07x    0.07x
VectorBenchmark  Iterate    slang_persistent/pcollections_persistent     1.95x    1.72x    1.51x
VectorBenchmark  Iterate    slang_persistent/scala_persistent            0.30x    0.19x    0.16x
```