### PR TITLE
add the Map.putOrUpdate function.

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/AbstractMap.java
+++ b/javaslang/src/main/java/javaslang/collection/AbstractMap.java
@@ -48,6 +48,7 @@ abstract class AbstractMap<K, V, M extends AbstractMap<K, V, M>> implements Map<
     @SuppressWarnings("unchecked")
     @Override
     public M putWith(K key, V value, BiFunction<? super V, ? super V, ? extends V> merge) {
+        Objects.requireNonNull(merge, "the merge function is null");
         Option<V> currentValue = get(key);
         if (currentValue.isEmpty()) {
             return (M) put(key, value);
@@ -59,6 +60,7 @@ abstract class AbstractMap<K, V, M extends AbstractMap<K, V, M>> implements Map<
     @Override
     public M putWith(Tuple2<? extends K, ? extends V> entry,
                      BiFunction<? super V, ? super V, ? extends V> merge) {
+        Objects.requireNonNull(merge, "the merge function is null");
         Option<V> currentValue = get(entry._1);
         if (currentValue.isEmpty()) {
             return put(entry);

--- a/javaslang/src/main/java/javaslang/collection/AbstractMap.java
+++ b/javaslang/src/main/java/javaslang/collection/AbstractMap.java
@@ -5,7 +5,6 @@
  */
 package javaslang.collection;
 
-import javaslang.Function2;
 import javaslang.Tuple;
 import javaslang.Tuple2;
 import javaslang.control.Option;
@@ -48,7 +47,7 @@ abstract class AbstractMap<K, V, M extends AbstractMap<K, V, M>> implements Map<
 
     @SuppressWarnings("unchecked")
     @Override
-    public M putWith(K key, V value, Function2<? super V, ? super V, ? extends V> merge) {
+    public M putWith(K key, V value, BiFunction<? super V, ? super V, ? extends V> merge) {
         Option<V> currentValue = get(key);
         if (currentValue.isEmpty()) {
             return (M) put(key, value);
@@ -59,7 +58,7 @@ abstract class AbstractMap<K, V, M extends AbstractMap<K, V, M>> implements Map<
 
     @Override
     public M putWith(Tuple2<? extends K, ? extends V> entry,
-                         Function2<? super V, ? super V, ? extends V> merge) {
+                     BiFunction<? super V, ? super V, ? extends V> merge) {
         Option<V> currentValue = get(entry._1);
         if (currentValue.isEmpty()) {
             return put(entry);

--- a/javaslang/src/main/java/javaslang/collection/AbstractMap.java
+++ b/javaslang/src/main/java/javaslang/collection/AbstractMap.java
@@ -5,6 +5,7 @@
  */
 package javaslang.collection;
 
+import javaslang.Function2;
 import javaslang.Tuple;
 import javaslang.Tuple2;
 import javaslang.control.Option;
@@ -43,6 +44,29 @@ abstract class AbstractMap<K, V, M extends AbstractMap<K, V, M>> implements Map<
     public M put(Tuple2<? extends K, ? extends V> entry) {
         Objects.requireNonNull(entry, "entry is null");
         return (M) put(entry._1, entry._2);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public M putWith(K key, V value, Function2<? super V, ? super V, ? extends V> merge) {
+        Option<V> currentValue = get(key);
+        if (currentValue.isEmpty()) {
+            return (M) put(key, value);
+        } else {
+            return (M) put(key, merge.apply(currentValue.get(), value));
+        }
+    }
+
+    @Override
+    public M putWith(Tuple2<? extends K, ? extends V> entry,
+                         Function2<? super V, ? super V, ? extends V> merge) {
+        Option<V> currentValue = get(entry._1);
+        if (currentValue.isEmpty()) {
+            return put(entry);
+        } else {
+            return put(entry.map2(
+                           value -> merge.apply(currentValue.get(), value)));
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/javaslang/src/main/java/javaslang/collection/AbstractMap.java
+++ b/javaslang/src/main/java/javaslang/collection/AbstractMap.java
@@ -47,9 +47,10 @@ abstract class AbstractMap<K, V, M extends AbstractMap<K, V, M>> implements Map<
 
     @SuppressWarnings("unchecked")
     @Override
-    public M putWith(K key, V value, BiFunction<? super V, ? super V, ? extends V> merge) {
+    public <U extends V> M putWith(K key, U value,
+                                   BiFunction<? super V, ? super U, ? extends V> merge) {
         Objects.requireNonNull(merge, "the merge function is null");
-        Option<V> currentValue = get(key);
+        final Option<V> currentValue = get(key);
         if (currentValue.isEmpty()) {
             return (M) put(key, value);
         } else {
@@ -58,10 +59,10 @@ abstract class AbstractMap<K, V, M extends AbstractMap<K, V, M>> implements Map<
     }
 
     @Override
-    public M putWith(Tuple2<? extends K, ? extends V> entry,
-                     BiFunction<? super V, ? super V, ? extends V> merge) {
+    public <U extends V> M putWith(Tuple2<? extends K, U> entry,
+                                   BiFunction<? super V, ? super U, ? extends V> merge) {
         Objects.requireNonNull(merge, "the merge function is null");
-        Option<V> currentValue = get(entry._1);
+        final Option<V> currentValue = get(entry._1);
         if (currentValue.isEmpty()) {
             return put(entry);
         } else {

--- a/javaslang/src/main/java/javaslang/collection/AbstractMap.java
+++ b/javaslang/src/main/java/javaslang/collection/AbstractMap.java
@@ -47,7 +47,7 @@ abstract class AbstractMap<K, V, M extends AbstractMap<K, V, M>> implements Map<
 
     @SuppressWarnings("unchecked")
     @Override
-    public <U extends V> M putWith(K key, U value,
+    public <U extends V> M put(K key, U value,
                                    BiFunction<? super V, ? super U, ? extends V> merge) {
         Objects.requireNonNull(merge, "the merge function is null");
         final Option<V> currentValue = get(key);
@@ -59,7 +59,7 @@ abstract class AbstractMap<K, V, M extends AbstractMap<K, V, M>> implements Map<
     }
 
     @Override
-    public <U extends V> M putWith(Tuple2<? extends K, U> entry,
+    public <U extends V> M put(Tuple2<? extends K, U> entry,
                                    BiFunction<? super V, ? super U, ? extends V> merge) {
         Objects.requireNonNull(merge, "the merge function is null");
         final Option<V> currentValue = get(entry._1);

--- a/javaslang/src/main/java/javaslang/collection/Map.java
+++ b/javaslang/src/main/java/javaslang/collection/Map.java
@@ -185,7 +185,7 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
      * @param merge function taking the old and new values and merging them.
      * @return A new Map containing these elements and that entry.
      */
-    Map<K, V> putWith(K key, V value, BiFunction<? super V, ? super V, ? extends V> merge);
+    <U extends V> Map<K, V> putWith(K key, U value, BiFunction<? super V, ? super U, ? extends V> merge);
 
     /**
      * Convenience method for {@code putOrUpdate(entry._1, entry._2)}.
@@ -194,8 +194,7 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
      * @param merge function taking the old and new values and merging them.
      * @return A new Map containing these elements and that entry.
      */
-    Map<K, V> putWith(Tuple2<? extends K, ? extends V> entry,
-                      BiFunction<? super V, ? super V, ? extends V> merge);
+    <U extends V> Map<K, V> putWith(Tuple2<? extends K, U> entry, BiFunction<? super V, ? super U, ? extends V> merge);
 
     /**
      * Removes the mapping for a key from this map if it is present.

--- a/javaslang/src/main/java/javaslang/collection/Map.java
+++ b/javaslang/src/main/java/javaslang/collection/Map.java
@@ -185,16 +185,16 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
      * @param merge function taking the old and new values and merging them.
      * @return A new Map containing these elements and that entry.
      */
-    <U extends V> Map<K, V> putWith(K key, U value, BiFunction<? super V, ? super U, ? extends V> merge);
+    <U extends V> Map<K, V> put(K key, U value, BiFunction<? super V, ? super U, ? extends V> merge);
 
     /**
-     * Convenience method for {@code putOrUpdate(entry._1, entry._2)}.
+     * Convenience method for {@code put(entry._1, entry._2, merge)}.
      *
      * @param entry A Tuple2 containing the key and value
      * @param merge function taking the old and new values and merging them.
      * @return A new Map containing these elements and that entry.
      */
-    <U extends V> Map<K, V> putWith(Tuple2<? extends K, U> entry, BiFunction<? super V, ? super U, ? extends V> merge);
+    <U extends V> Map<K, V> put(Tuple2<? extends K, U> entry, BiFunction<? super V, ? super U, ? extends V> merge);
 
     /**
      * Removes the mapping for a key from this map if it is present.

--- a/javaslang/src/main/java/javaslang/collection/Map.java
+++ b/javaslang/src/main/java/javaslang/collection/Map.java
@@ -6,7 +6,6 @@
 package javaslang.collection;
 
 import javaslang.Function1;
-import javaslang.Function2;
 import javaslang.Tuple;
 import javaslang.Tuple2;
 import javaslang.Tuple3;
@@ -186,7 +185,7 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
      * @param merge function taking the old and new values and merging them.
      * @return A new Map containing these elements and that entry.
      */
-    Map<K, V> putWith(K key, V value, Function2<? super V, ? super V, ? extends V> merge);
+    Map<K, V> putWith(K key, V value, BiFunction<? super V, ? super V, ? extends V> merge);
 
     /**
      * Convenience method for {@code putOrUpdate(entry._1, entry._2)}.
@@ -196,7 +195,7 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
      * @return A new Map containing these elements and that entry.
      */
     Map<K, V> putWith(Tuple2<? extends K, ? extends V> entry,
-                      Function2<? super V, ? super V, ? extends V> merge);
+                      BiFunction<? super V, ? super V, ? extends V> merge);
 
     /**
      * Removes the mapping for a key from this map if it is present.

--- a/javaslang/src/main/java/javaslang/collection/Map.java
+++ b/javaslang/src/main/java/javaslang/collection/Map.java
@@ -197,6 +197,24 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
     }
 
     /**
+     * Convenience method for {@code putOrUpdate(entry._1, entry._2)}.
+     *
+     * @param entry A Tuple2 containing the key and value
+     * @param merge function taking the old and new values and merging them.
+     * @return A new Map containing these elements and that entry.
+     */
+    default Map<K, V> putOrUpdate(Tuple2<? extends K, ? extends V> entry,
+                                  Function2<V, V, V> merge) {
+        Option<V> currentValue = get(entry._1);
+        if (currentValue.isEmpty()) {
+            return put(entry);
+        } else {
+            return put(entry.map2(
+                           value -> merge.apply(currentValue.get(), value)));
+        }
+    }
+
+    /**
      * Removes the mapping for a key from this map if it is present.
      *
      * @param key key whose mapping is to be removed from the map

--- a/javaslang/src/main/java/javaslang/collection/Map.java
+++ b/javaslang/src/main/java/javaslang/collection/Map.java
@@ -6,6 +6,7 @@
 package javaslang.collection;
 
 import javaslang.Function1;
+import javaslang.Function2;
 import javaslang.Tuple;
 import javaslang.Tuple2;
 import javaslang.Tuple3;
@@ -173,6 +174,27 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
      * @return A new Map containing these elements and that entry.
      */
     Map<K, V> put(Tuple2<? extends K, ? extends V> entry);
+
+
+    /**
+     * Associates the specified value with the specified key in this map.
+     * If the map previously contained a mapping for the key, the merge
+     * function is used to combine the previous value to the value to
+     * be inserted, and the result of that call is inserted in the map.
+     *
+     * @param key   key with which the specified value is to be associated
+     * @param value value to be associated with the specified key
+     * @param merge function taking the old and new values and merging them.
+     * @return A new Map containing these elements and that entry.
+     */
+    default Map<K, V> putOrUpdate(K key, V value, Function2<V, V, V> merge) {
+        Option<V> currentValue = get(key);
+        if (currentValue.isEmpty()) {
+            return put(key, value);
+        } else {
+            return put(key, merge.apply(currentValue.get(), value));
+        }
+    }
 
     /**
      * Removes the mapping for a key from this map if it is present.

--- a/javaslang/src/main/java/javaslang/collection/Map.java
+++ b/javaslang/src/main/java/javaslang/collection/Map.java
@@ -175,7 +175,6 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
      */
     Map<K, V> put(Tuple2<? extends K, ? extends V> entry);
 
-
     /**
      * Associates the specified value with the specified key in this map.
      * If the map previously contained a mapping for the key, the merge
@@ -187,14 +186,7 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
      * @param merge function taking the old and new values and merging them.
      * @return A new Map containing these elements and that entry.
      */
-    default Map<K, V> putOrUpdate(K key, V value, Function2<V, V, V> merge) {
-        Option<V> currentValue = get(key);
-        if (currentValue.isEmpty()) {
-            return put(key, value);
-        } else {
-            return put(key, merge.apply(currentValue.get(), value));
-        }
-    }
+    Map<K, V> putWith(K key, V value, Function2<? super V, ? super V, ? extends V> merge);
 
     /**
      * Convenience method for {@code putOrUpdate(entry._1, entry._2)}.
@@ -203,16 +195,8 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
      * @param merge function taking the old and new values and merging them.
      * @return A new Map containing these elements and that entry.
      */
-    default Map<K, V> putOrUpdate(Tuple2<? extends K, ? extends V> entry,
-                                  Function2<V, V, V> merge) {
-        Option<V> currentValue = get(entry._1);
-        if (currentValue.isEmpty()) {
-            return put(entry);
-        } else {
-            return put(entry.map2(
-                           value -> merge.apply(currentValue.get(), value)));
-        }
-    }
+    Map<K, V> putWith(Tuple2<? extends K, ? extends V> entry,
+                      Function2<? super V, ? super V, ? extends V> merge);
 
     /**
      * Removes the mapping for a key from this map if it is present.

--- a/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
@@ -719,33 +719,33 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
         assertThat(result[0]).isEqualTo(10);
     }
 
-    // -- putOrUpdate
+    // -- putWith
 
     @Test
-    public void putOrUpdateWasntPresent() {
+    public void putWithWasntPresent() {
         Map<Integer, Integer> map = mapOf(1, 2)
-            .putOrUpdate(2, 3, (x, y) -> x+y);
+            .putWith(2, 3, (x, y) -> x+y);
         assertThat(map).isEqualTo(emptyIntInt().put(1, 2).put(2, 3));
     }
 
     @Test
-    public void putOrUpdateWasPresent() {
+    public void putWithWasPresent() {
         Map<Integer, Integer> map = mapOf(1, 2)
-            .putOrUpdate(1, 3, (x, y) -> x+y);
+            .putWith(1, 3, (x, y) -> x+y);
         assertThat(map).isEqualTo(emptyIntInt().put(1, 5));
     }
 
     @Test
-    public void putOrUpdateTupleWasntPresent() {
+    public void putWithTupleWasntPresent() {
         Map<Integer, Integer> map = mapOf(1, 2)
-            .putOrUpdate(Tuple.of(2, 3), (x, y) -> x+y);
+            .putWith(Tuple.of(2, 3), (x, y) -> x+y);
         assertThat(map).isEqualTo(emptyIntInt().put(1, 2).put(2, 3));
     }
 
     @Test
-    public void putOrUpdateTupleWasPresent() {
+    public void putWithTupleWasPresent() {
         Map<Integer, Integer> map = mapOf(1, 2)
-            .putOrUpdate(Tuple.of(1, 3), (x, y) -> x+y);
+            .putWith(Tuple.of(1, 3), (x, y) -> x+y);
         assertThat(map).isEqualTo(emptyIntInt().put(1, 5));
     }
 

--- a/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
@@ -719,6 +719,22 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
         assertThat(result[0]).isEqualTo(10);
     }
 
+    // -- putOrUpdate
+
+    @Test
+    public void putOrUpdateWasntPresent() {
+        Map<Integer, Integer> map = mapOf(1, 2)
+            .putOrUpdate(2, 3, (x, y) -> x+y);
+        assertThat(map).isEqualTo(emptyIntInt().put(1, 2).put(2, 3));
+    }
+
+    @Test
+    public void putOrUpdateWasPresent() {
+        Map<Integer, Integer> map = mapOf(1, 2)
+            .putOrUpdate(1, 3, (x, y) -> x+y);
+        assertThat(map).isEqualTo(emptyIntInt().put(1, 5));
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void shouldTabulateTheSeq() {

--- a/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
@@ -719,33 +719,33 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
         assertThat(result[0]).isEqualTo(10);
     }
 
-    // -- putWith
+    // -- put with merge function
 
     @Test
     public void putWithWasntPresent() {
         Map<Integer, Integer> map = mapOf(1, 2)
-            .putWith(2, 3, (x, y) -> x+y);
+            .put(2, 3, (x, y) -> x+y);
         assertThat(map).isEqualTo(emptyIntInt().put(1, 2).put(2, 3));
     }
 
     @Test
     public void putWithWasPresent() {
         Map<Integer, Integer> map = mapOf(1, 2)
-            .putWith(1, 3, (x, y) -> x+y);
+            .put(1, 3, (x, y) -> x+y);
         assertThat(map).isEqualTo(emptyIntInt().put(1, 5));
     }
 
     @Test
     public void putWithTupleWasntPresent() {
         Map<Integer, Integer> map = mapOf(1, 2)
-            .putWith(Tuple.of(2, 3), (x, y) -> x+y);
+            .put(Tuple.of(2, 3), (x, y) -> x+y);
         assertThat(map).isEqualTo(emptyIntInt().put(1, 2).put(2, 3));
     }
 
     @Test
     public void putWithTupleWasPresent() {
         Map<Integer, Integer> map = mapOf(1, 2)
-            .putWith(Tuple.of(1, 3), (x, y) -> x+y);
+            .put(Tuple.of(1, 3), (x, y) -> x+y);
         assertThat(map).isEqualTo(emptyIntInt().put(1, 5));
     }
 

--- a/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
@@ -735,6 +735,20 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
         assertThat(map).isEqualTo(emptyIntInt().put(1, 5));
     }
 
+    @Test
+    public void putOrUpdateTupleWasntPresent() {
+        Map<Integer, Integer> map = mapOf(1, 2)
+            .putOrUpdate(Tuple.of(2, 3), (x, y) -> x+y);
+        assertThat(map).isEqualTo(emptyIntInt().put(1, 2).put(2, 3));
+    }
+
+    @Test
+    public void putOrUpdateTupleWasPresent() {
+        Map<Integer, Integer> map = mapOf(1, 2)
+            .putOrUpdate(Tuple.of(1, 3), (x, y) -> x+y);
+        assertThat(map).isEqualTo(emptyIntInt().put(1, 5));
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void shouldTabulateTheSeq() {


### PR DESCRIPTION
Adding the "putOrUpdate" function.
java8 has an equivalent function [Map.merge()](https://docs.oracle.com/javase/8/docs/api/java/util/Map.html#merge-K-V-java.util.function.BiFunction-). Haskell calls it [insertWith](https://hackage.haskell.org/package/containers-0.5.7.1/docs/Data-Map-Strict.html#v:insertWith).
`Map.merge()` is already taken in javaslang, so we need another name.

I think it makes sense that the name starts with `put` so that you spot it immediately next to the normal `put`. Then it could be `purOrMerge`, `putWith` or something else I guess.