### PR TITLE
Implement new method: Map#mapKeys()

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/Collections.java
+++ b/javaslang/src/main/java/javaslang/collection/Collections.java
@@ -8,13 +8,8 @@ package javaslang.collection;
 import javaslang.Function2;
 import javaslang.control.Option;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Objects;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
+import java.util.*;
+import java.util.function.*;
 
 /**
  * Internal class, containing helpers.

--- a/javaslang/src/main/java/javaslang/collection/Collections.java
+++ b/javaslang/src/main/java/javaslang/collection/Collections.java
@@ -5,10 +5,16 @@
  */
 package javaslang.collection;
 
+import javaslang.Function2;
 import javaslang.control.Option;
 
-import java.util.*;
-import java.util.function.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * Internal class, containing helpers.
@@ -59,6 +65,20 @@ final class Collections {
             results = results.put(entry.getKey(), mapper.apply(entry.getValue()));
         }
         return results;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <K, V, K2, U extends Map<K2, V>> U mapKeys(Map<K, V> source, U zero, Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge) {
+        Objects.requireNonNull(source, "source is null");
+        Objects.requireNonNull(zero, "zero is null");
+        Objects.requireNonNull(keyMapper, "keyMapper is null");
+        Objects.requireNonNull(valueMerge, "valueMerge is null");
+        return source.foldLeft(zero, (acc, entry) -> {
+            K2 k2 = keyMapper.apply(entry._1());
+            V v2 = entry._2();
+            V v = acc.get(k2).map(v1 -> valueMerge.apply(v1, v2)).getOrElse(v2);
+            return (U) acc.put(k2, v);
+        });
     }
 
     static Option<Integer> indexOption(int index) {

--- a/javaslang/src/main/java/javaslang/collection/Collections.java
+++ b/javaslang/src/main/java/javaslang/collection/Collections.java
@@ -5,11 +5,15 @@
  */
 package javaslang.collection;
 
-import javaslang.Function2;
 import javaslang.control.Option;
 
-import java.util.*;
-import java.util.function.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * Internal class, containing helpers.
@@ -63,15 +67,16 @@ final class Collections {
     }
 
     @SuppressWarnings("unchecked")
-    public static <K, V, K2, U extends Map<K2, V>> U mapKeys(Map<K, V> source, U zero, Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge) {
+    public static <K, V, K2, U extends Map<K2, V>> U mapKeys(Map<K, V> source, U zero, Function<? super K, ? extends K2> keyMapper, BiFunction<? super V, ? super V, ? extends V> valueMerge) {
         Objects.requireNonNull(source, "source is null");
         Objects.requireNonNull(zero, "zero is null");
         Objects.requireNonNull(keyMapper, "keyMapper is null");
         Objects.requireNonNull(valueMerge, "valueMerge is null");
         return source.foldLeft(zero, (acc, entry) -> {
-            K2 k2 = keyMapper.apply(entry._1());
-            V v2 = entry._2();
-            V v = acc.get(k2).map(v1 -> valueMerge.apply(v1, v2)).getOrElse(v2);
+            final K2 k2 = keyMapper.apply(entry._1());
+            final V v2 = entry._2();
+            final Option<V> v1 = acc.get(k2);
+            final V v = v1.isDefined() ? valueMerge.apply(v1.get(), v2) : v2;
             return (U) acc.put(k2, v);
         });
     }

--- a/javaslang/src/main/java/javaslang/collection/HashMap.java
+++ b/javaslang/src/main/java/javaslang/collection/HashMap.java
@@ -310,7 +310,7 @@ public final class HashMap<K, V> extends AbstractMap<K, V, HashMap<K, V>> implem
     }
 
     @Override
-    public <K2> HashMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge) {
+    public <K2> HashMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, BiFunction<? super V, ? super V, ? extends V> valueMerge) {
         return Collections.mapKeys(this, HashMap.empty(), keyMapper, valueMerge);
     }
 

--- a/javaslang/src/main/java/javaslang/collection/HashMap.java
+++ b/javaslang/src/main/java/javaslang/collection/HashMap.java
@@ -304,6 +304,12 @@ public final class HashMap<K, V> extends AbstractMap<K, V, HashMap<K, V>> implem
     }
 
     @Override
+    public <K2> HashMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper) {
+        Objects.requireNonNull(keyMapper, "keyMapper is null");
+        return map((k, v) -> Tuple.of(keyMapper.apply(k), v));
+    }
+
+    @Override
     public <V2> HashMap<K, V2> mapValues(Function<? super V, ? extends V2> valueMapper) {
         Objects.requireNonNull(valueMapper, "valueMapper is null");
         return map((k, v) -> Tuple.of(k, valueMapper.apply(v)));

--- a/javaslang/src/main/java/javaslang/collection/HashMap.java
+++ b/javaslang/src/main/java/javaslang/collection/HashMap.java
@@ -5,16 +5,11 @@
  */
 package javaslang.collection;
 
-import javaslang.Function2;
-import javaslang.Kind2;
-import javaslang.Tuple;
-import javaslang.Tuple2;
+import javaslang.*;
 import javaslang.control.Option;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.NoSuchElementException;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;
 

--- a/javaslang/src/main/java/javaslang/collection/HashMap.java
+++ b/javaslang/src/main/java/javaslang/collection/HashMap.java
@@ -5,11 +5,16 @@
  */
 package javaslang.collection;
 
-import javaslang.*;
+import javaslang.Function2;
+import javaslang.Kind2;
+import javaslang.Tuple;
+import javaslang.Tuple2;
 import javaslang.control.Option;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.function.*;
 import java.util.stream.Collector;
 
@@ -310,15 +315,8 @@ public final class HashMap<K, V> extends AbstractMap<K, V, HashMap<K, V>> implem
     }
 
     @Override
-    public <K2> Map<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge) {
-        Objects.requireNonNull(keyMapper, "keyMapper is null");
-        Objects.requireNonNull(valueMerge, "valueMerge is null");
-        return foldLeft(HashMap.empty(), (acc, entry) -> {
-            K2 k2 = keyMapper.apply(entry._1());
-            V v2 = entry._2();
-            V v = acc.get(k2).map(v1 -> valueMerge.apply(v1, v2)).getOrElse(v2);
-            return acc.put(k2, v);
-        });
+    public <K2> HashMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge) {
+        return Collections.mapKeys(this, HashMap.empty(), keyMapper, valueMerge);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/HashMap.java
+++ b/javaslang/src/main/java/javaslang/collection/HashMap.java
@@ -310,6 +310,18 @@ public final class HashMap<K, V> extends AbstractMap<K, V, HashMap<K, V>> implem
     }
 
     @Override
+    public <K2> Map<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge) {
+        Objects.requireNonNull(keyMapper, "keyMapper is null");
+        Objects.requireNonNull(valueMerge, "valueMerge is null");
+        return foldLeft(HashMap.empty(), (acc, entry) -> {
+            K2 k2 = keyMapper.apply(entry._1());
+            V v2 = entry._2();
+            V v = acc.get(k2).map(v1 -> valueMerge.apply(v1, v2)).getOrElse(v2);
+            return acc.put(k2, v);
+        });
+    }
+
+    @Override
     public <V2> HashMap<K, V2> mapValues(Function<? super V, ? extends V2> valueMapper) {
         Objects.requireNonNull(valueMapper, "valueMapper is null");
         return map((k, v) -> Tuple.of(k, valueMapper.apply(v)));

--- a/javaslang/src/main/java/javaslang/collection/LinkedHashMap.java
+++ b/javaslang/src/main/java/javaslang/collection/LinkedHashMap.java
@@ -5,6 +5,7 @@
  */
 package javaslang.collection;
 
+import javaslang.Function2;
 import javaslang.Kind2;
 import javaslang.Tuple;
 import javaslang.Tuple2;
@@ -317,6 +318,18 @@ public final class LinkedHashMap<K, V> extends AbstractMap<K, V, LinkedHashMap<K
     public <K2> LinkedHashMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper) {
         Objects.requireNonNull(keyMapper, "keyMapper is null");
         return map((k, v) -> Tuple.of(keyMapper.apply(k), v));
+    }
+
+    @Override
+    public <K2> Map<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge) {
+        Objects.requireNonNull(keyMapper, "keyMapper is null");
+        Objects.requireNonNull(valueMerge, "valueMerge is null");
+        return foldLeft(LinkedHashMap.empty(), (acc, entry) -> {
+            K2 k2 = keyMapper.apply(entry._1());
+            V v2 = entry._2();
+            V v = acc.get(k2).map(v1 -> valueMerge.apply(v1, v2)).getOrElse(v2);
+            return acc.put(k2, v);
+        });
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/LinkedHashMap.java
+++ b/javaslang/src/main/java/javaslang/collection/LinkedHashMap.java
@@ -321,15 +321,8 @@ public final class LinkedHashMap<K, V> extends AbstractMap<K, V, LinkedHashMap<K
     }
 
     @Override
-    public <K2> Map<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge) {
-        Objects.requireNonNull(keyMapper, "keyMapper is null");
-        Objects.requireNonNull(valueMerge, "valueMerge is null");
-        return foldLeft(LinkedHashMap.empty(), (acc, entry) -> {
-            K2 k2 = keyMapper.apply(entry._1());
-            V v2 = entry._2();
-            V v = acc.get(k2).map(v1 -> valueMerge.apply(v1, v2)).getOrElse(v2);
-            return acc.put(k2, v);
-        });
+    public <K2> LinkedHashMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge) {
+        return Collections.mapKeys(this, LinkedHashMap.empty(), keyMapper, valueMerge);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/LinkedHashMap.java
+++ b/javaslang/src/main/java/javaslang/collection/LinkedHashMap.java
@@ -314,6 +314,12 @@ public final class LinkedHashMap<K, V> extends AbstractMap<K, V, LinkedHashMap<K
     }
 
     @Override
+    public <K2> LinkedHashMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper) {
+        Objects.requireNonNull(keyMapper, "keyMapper is null");
+        return map((k, v) -> Tuple.of(keyMapper.apply(k), v));
+    }
+
+    @Override
     public <W> LinkedHashMap<K, W> mapValues(Function<? super V, ? extends W> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return map((k, v) -> Tuple.of(k, mapper.apply(v)));

--- a/javaslang/src/main/java/javaslang/collection/LinkedHashMap.java
+++ b/javaslang/src/main/java/javaslang/collection/LinkedHashMap.java
@@ -321,7 +321,7 @@ public final class LinkedHashMap<K, V> extends AbstractMap<K, V, LinkedHashMap<K
     }
 
     @Override
-    public <K2> LinkedHashMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge) {
+    public <K2> LinkedHashMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, BiFunction<? super V, ? super V, ? extends V> valueMerge) {
         return Collections.mapKeys(this, LinkedHashMap.empty(), keyMapper, valueMerge);
     }
 

--- a/javaslang/src/main/java/javaslang/collection/Map.java
+++ b/javaslang/src/main/java/javaslang/collection/Map.java
@@ -167,7 +167,7 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
      * @return a new {@code Map}
      * @throws NullPointerException if {@code keyMapper} is null
      */
-    <K2> Map<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge);
+    <K2> Map<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, BiFunction<? super V, ? super V, ? extends V> valueMerge);
 
     /**
      * Maps the values of this {@code Map} while preserving the corresponding keys.

--- a/javaslang/src/main/java/javaslang/collection/Map.java
+++ b/javaslang/src/main/java/javaslang/collection/Map.java
@@ -144,9 +144,12 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
 
     /**
      * Maps the keys of this {@code Map} while preserving the corresponding values.
-     * If {@code keyMapper} will return not unique values for keys, result map will lost some values which will be mapped to same key.
+     * <p>
+     * The size of the result map may be smaller if {@code keyMapper} maps two or more distinct keys to the same new key.
+     * In this case the value at the {@code latest} of the original keys is retained.
+     * Order of keys is predictable in {@code TreeMap} (by comparator) and {@code LinkedHashMap} (insertion-order) and not predictable in {@code HashMap}.
      *
-     * @param <K2>        the new key type
+     * @param <K2>      the new key type
      * @param keyMapper a {@code Function} that maps keys of type {@code V} to keys of type {@code V2}
      * @return a new {@code Map}
      * @throws NullPointerException if {@code keyMapper} is null

--- a/javaslang/src/main/java/javaslang/collection/Map.java
+++ b/javaslang/src/main/java/javaslang/collection/Map.java
@@ -146,6 +146,17 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
     <K2, V2> Map<K2, V2> map(BiFunction<? super K, ? super V, Tuple2<K2, V2>> mapper);
 
     /**
+     * Maps the keys of this {@code Map} while preserving the corresponding values.
+     * If {@code keyMapper} will return not unique values for keys, result map will lost some values which will be mapped to same key.
+     *
+     * @param <K2>        the new key type
+     * @param keyMapper a {@code Function} that maps keys of type {@code V} to keys of type {@code V2}
+     * @return a new {@code Map}
+     * @throws NullPointerException if {@code keyMapper} is null
+     */
+    <K2> Map<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper);
+
+    /**
      * Maps the values of this {@code Map} while preserving the corresponding keys.
      *
      * @param <V2>        the new value type

--- a/javaslang/src/main/java/javaslang/collection/Map.java
+++ b/javaslang/src/main/java/javaslang/collection/Map.java
@@ -5,10 +5,7 @@
  */
 package javaslang.collection;
 
-import javaslang.Function1;
-import javaslang.Tuple;
-import javaslang.Tuple2;
-import javaslang.Tuple3;
+import javaslang.*;
 import javaslang.control.Option;
 
 import java.util.*;
@@ -155,6 +152,8 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
      * @throws NullPointerException if {@code keyMapper} is null
      */
     <K2> Map<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper);
+
+    <K2> Map<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge);
 
     /**
      * Maps the values of this {@code Map} while preserving the corresponding keys.

--- a/javaslang/src/main/java/javaslang/collection/Map.java
+++ b/javaslang/src/main/java/javaslang/collection/Map.java
@@ -153,6 +153,17 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
      */
     <K2> Map<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper);
 
+    /**
+     * Maps the keys of this {@code Map} while preserving the corresponding values.
+     * <p>
+     * The size of the result map may be smaller if {@code keyMapper} maps two or more distinct keys to the same new key.
+     * In this case the associated values will be combined using {@code valueMerge}.
+     *
+     * @param <K2>      the new key type
+     * @param keyMapper a {@code Function} that maps keys of type {@code V} to keys of type {@code V2}
+     * @return a new {@code Map}
+     * @throws NullPointerException if {@code keyMapper} is null
+     */
     <K2> Map<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge);
 
     /**

--- a/javaslang/src/main/java/javaslang/collection/SortedMap.java
+++ b/javaslang/src/main/java/javaslang/collection/SortedMap.java
@@ -151,7 +151,7 @@ public interface SortedMap<K, V> extends Map<K, V> {
     <K2> SortedMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper);
 
     @Override
-    <K2> SortedMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge);
+    <K2> SortedMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, BiFunction<? super V, ? super V, ? extends V> valueMerge);
 
     @Override
     <V2> SortedMap<K, V2> mapValues(Function<? super V, ? extends V2> valueMapper);

--- a/javaslang/src/main/java/javaslang/collection/SortedMap.java
+++ b/javaslang/src/main/java/javaslang/collection/SortedMap.java
@@ -147,6 +147,9 @@ public interface SortedMap<K, V> extends Map<K, V> {
     <K2, V2> SortedMap<K2, V2> map(BiFunction<? super K, ? super V, Tuple2<K2, V2>> mapper);
 
     @Override
+    <K2> SortedMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper);
+
+    @Override
     <V2> SortedMap<K, V2> mapValues(Function<? super V, ? extends V2> valueMapper);
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/SortedMap.java
+++ b/javaslang/src/main/java/javaslang/collection/SortedMap.java
@@ -5,6 +5,7 @@
  */
 package javaslang.collection;
 
+import javaslang.Function2;
 import javaslang.Tuple2;
 import javaslang.control.Option;
 
@@ -148,6 +149,9 @@ public interface SortedMap<K, V> extends Map<K, V> {
 
     @Override
     <K2> SortedMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper);
+
+    @Override
+    <K2> SortedMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge);
 
     @Override
     <V2> SortedMap<K, V2> mapValues(Function<? super V, ? extends V2> valueMapper);

--- a/javaslang/src/main/java/javaslang/collection/TreeMap.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeMap.java
@@ -505,16 +505,9 @@ public final class TreeMap<K, V> extends AbstractMap<K, V, TreeMap<K, V>> implem
 
     @Override
     public <K2> TreeMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge) {
-        Objects.requireNonNull(keyMapper, "keyMapper is null");
-        Objects.requireNonNull(valueMerge, "valueMerge is null");
         //todo Hack
         Comparator<K2> comparator = Comparators.naturalComparator();
-        return foldLeft(TreeMap.empty(comparator), (acc, entry) -> {
-            K2 k2 = keyMapper.apply(entry._1());
-            V v2 = entry._2();
-            V v = acc.get(k2).map(v1 -> valueMerge.apply(v1, v2)).getOrElse(v2);
-            return acc.put(k2, v);
-        });
+        return Collections.mapKeys(this, TreeMap.<K2, V>empty(comparator), keyMapper, valueMerge);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/TreeMap.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeMap.java
@@ -5,11 +5,17 @@
  */
 package javaslang.collection;
 
-import javaslang.*;
+import javaslang.Function2;
+import javaslang.Kind2;
+import javaslang.Tuple;
+import javaslang.Tuple2;
 import javaslang.control.Option;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.function.*;
 import java.util.stream.Collector;
 
@@ -495,6 +501,20 @@ public final class TreeMap<K, V> extends AbstractMap<K, V, TreeMap<K, V>> implem
     public <K2> TreeMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper) {
         Objects.requireNonNull(keyMapper, "keyMapper is null");
         return map((k, v) -> Tuple.of(keyMapper.apply(k), v));
+    }
+
+    @Override
+    public <K2> TreeMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge) {
+        Objects.requireNonNull(keyMapper, "keyMapper is null");
+        Objects.requireNonNull(valueMerge, "valueMerge is null");
+        //todo Hack
+        Comparator<K2> comparator = Comparators.naturalComparator();
+        return foldLeft(TreeMap.empty(comparator), (acc, entry) -> {
+            K2 k2 = keyMapper.apply(entry._1());
+            V v2 = entry._2();
+            V v = acc.get(k2).map(v1 -> valueMerge.apply(v1, v2)).getOrElse(v2);
+            return acc.put(k2, v);
+        });
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/TreeMap.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeMap.java
@@ -5,17 +5,11 @@
  */
 package javaslang.collection;
 
-import javaslang.Function2;
-import javaslang.Kind2;
-import javaslang.Tuple;
-import javaslang.Tuple2;
+import javaslang.*;
 import javaslang.control.Option;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.NoSuchElementException;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;
 

--- a/javaslang/src/main/java/javaslang/collection/TreeMap.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeMap.java
@@ -499,7 +499,6 @@ public final class TreeMap<K, V> extends AbstractMap<K, V, TreeMap<K, V>> implem
 
     @Override
     public <K2> TreeMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge) {
-        //todo Hack
         Comparator<K2> comparator = Comparators.naturalComparator();
         return Collections.mapKeys(this, TreeMap.<K2, V>empty(comparator), keyMapper, valueMerge);
     }

--- a/javaslang/src/main/java/javaslang/collection/TreeMap.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeMap.java
@@ -492,6 +492,12 @@ public final class TreeMap<K, V> extends AbstractMap<K, V, TreeMap<K, V>> implem
     }
 
     @Override
+    public <K2> TreeMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper) {
+        Objects.requireNonNull(keyMapper, "keyMapper is null");
+        return map((k, v) -> Tuple.of(keyMapper.apply(k), v));
+    }
+
+    @Override
     public <W> TreeMap<K, W> mapValues(Function<? super V, ? extends W> valueMapper) {
         Objects.requireNonNull(valueMapper, "valueMapper is null");
         return map(keyComparator(), (k, v) -> Tuple.of(k, valueMapper.apply(v)));

--- a/javaslang/src/main/java/javaslang/collection/TreeMap.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeMap.java
@@ -498,8 +498,8 @@ public final class TreeMap<K, V> extends AbstractMap<K, V, TreeMap<K, V>> implem
     }
 
     @Override
-    public <K2> TreeMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, Function2<V, V, V> valueMerge) {
-        Comparator<K2> comparator = Comparators.naturalComparator();
+    public <K2> TreeMap<K2, V> mapKeys(Function<? super K, ? extends K2> keyMapper, BiFunction<? super V, ? super V, ? extends V> valueMerge) {
+        final Comparator<K2> comparator = Comparators.naturalComparator();
         return Collections.mapKeys(this, TreeMap.<K2, V>empty(comparator), keyMapper, valueMerge);
     }
 

--- a/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
@@ -13,6 +13,8 @@ import org.assertj.core.api.IterableAssert;
 import org.junit.Test;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.*;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -402,6 +404,54 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
     @Test
     public void shouldReturnTuple2SetOfANonEmptyMap() {
         assertThat(emptyInt().put(1, "1").put(2, "2").toSet()).isEqualTo(HashSet.of(Tuple.of(1, "1"), Tuple.of(2, "2")));
+    }
+
+    @Test
+    public void shouldReturnModifiedKeysMap() {
+        Map<String, String> actual = emptyIntString().put(1, "1").put(2, "2").mapKeys(k -> k * 12).mapKeys(Integer::toHexString).mapKeys(String::toUpperCase);
+        Map<String, String> expected = this.<String, String>emptyMap().put("C", "1").put("18", "2");
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldReturnModifiedKeysMapWithNonUniqueMapper() {
+        Map<Integer, String> actual = emptyIntString()
+                .put(1, "1").put(2, "2").put(3, "3")
+                .mapKeys(k -> k * 118).mapKeys(Integer::toHexString).mapKeys(AbstractMapTest::md5).mapKeys(String::length);
+        assertThat(actual).hasSize(1);
+        assertThat(actual.values()).hasSize(1);
+        //In different cases (based on items order) transformed map may contain different values
+        assertThat(actual.values().head()).isIn("1", "2", "3");
+    }
+
+    private static String md5(String src) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            md.update(src.getBytes(StandardCharsets.UTF_8));
+            return toHexString(md.digest());
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * Returns a string in the hexadecimal format.
+     *
+     * @param bytes the converted bytes
+     * @return the hexadecimal string representing the bytes data
+     * @throws IllegalArgumentException if the byte array is null
+     */
+    public static String toHexString(byte[] bytes) {
+        if (bytes == null) {
+            throw new IllegalArgumentException("byte array must not be null");
+        }
+
+        StringBuilder hex = new StringBuilder(bytes.length * 2);
+        for (byte aByte : bytes) {
+            hex.append(Character.forDigit((aByte & 0XF0) >> 4, 16));
+            hex.append(Character.forDigit((aByte & 0X0F), 16));
+        }
+        return hex.toString();
     }
 
     @Test

--- a/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
@@ -455,6 +455,16 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
     }
 
     @Test
+    public void shouldReturnModifiedKeysMapWithNonUniqueMapperAndMergedValus() {
+        Map<Integer, String> actual = emptyIntString()
+                .put(1, "1").put(2, "2").put(3, "3")
+                .mapKeys(k -> k * 118).mapKeys(Integer::toHexString).mapKeys(AbstractMapTest::md5)//Unique key mappers
+                .mapKeys(String::length, (v1, v2) -> List.of(v1.split("#")).append(v2).sorted().mkString("#"));
+        Map<Integer, String> expected = emptyIntString().put(32, "1#2#3");
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldReturnModifiedValuesMap() {
         assertThat(emptyIntString().put(1, "1").put(2, "2").mapValues(Integer::parseInt)).isEqualTo(emptyInt().put(1, 1).put(2, 2));
     }

--- a/javaslang/src/test/java/javaslang/collection/LinkedHashMapTest.java
+++ b/javaslang/src/test/java/javaslang/collection/LinkedHashMapTest.java
@@ -139,4 +139,15 @@ public class LinkedHashMapTest extends AbstractMapTest {
         source.put(3, 4);
         assertThat(LinkedHashMap.ofAll(source)).isEqualTo(emptyIntInt().put(1, 2).put(3, 4));
     }
+
+    // -- map
+
+    @Test
+    public void shouldReturnModifiedKeysMapWithNonUniqueMapperAndPredictableOrder() {
+        Map<Integer, String> actual = LinkedHashMap
+                .of(3, "3").put(1, "1").put(2, "2")
+                .mapKeys(Integer::toHexString).mapKeys(String::length);
+        Map<Integer, String> expected = LinkedHashMap.of(1, "2");
+        assertThat(actual).isEqualTo(expected);
+    }
 }

--- a/javaslang/src/test/java/javaslang/collection/TreeMapTest.java
+++ b/javaslang/src/test/java/javaslang/collection/TreeMapTest.java
@@ -19,6 +19,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 
+import static javaslang.collection.Comparators.naturalComparator;
+
 public class TreeMapTest extends AbstractSortedMapTest {
 
     @Override

--- a/javaslang/src/test/java/javaslang/collection/TreeMapTest.java
+++ b/javaslang/src/test/java/javaslang/collection/TreeMapTest.java
@@ -19,8 +19,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 
-import static javaslang.collection.Comparators.naturalComparator;
-
 public class TreeMapTest extends AbstractSortedMapTest {
 
     @Override
@@ -135,5 +133,16 @@ public class TreeMapTest extends AbstractSortedMapTest {
 
     private static Comparator<Object> toStringComparator() { // moveup
         return (Comparator<Object> & Serializable) (o1, o2) -> String.valueOf(o1).compareTo(String.valueOf(o2));
+    }
+
+    // -- map
+
+    @Test
+    public void shouldReturnModifiedKeysMapWithNonUniqueMapperAndPredictableOrder() {
+        Map<Integer, String> actual = TreeMap
+                .of(3, "3").put(1, "1").put(2, "2")
+                .mapKeys(Integer::toHexString).mapKeys(String::length);
+        Map<Integer, String> expected = TreeMap.of(1, "3");
+        assertThat(actual).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
fix #1379.

@danieldietrich, I don't known how to remove hack from `TreeMap#mapKeys(Function<? super K,? extends K2>, Function2<V,V,V>)`.
If I describe `K2` in `TreeMap` as `K2 extends Comparable<? super K2>` then I must describe it with same limit in `SortedMap` (it's ok) and `Map` (this is not ok).
