### PR TITLE
new static function Function*.constant

### DIFF
--- a/javaslang/generator/Generator.scala
+++ b/javaslang/generator/Generator.scala
@@ -751,6 +751,17 @@ def generateMainClasses(): Unit = {
                   return $i;
               }
 
+              /**
+               * Returns a function that always returns the constant
+               * value that you give in parameter.
+               *
+               * @param value the value to be returned
+               * @return a function always returning the given value
+               */
+              static $fullGenerics $className$fullGenerics constant(R value) {
+                  return ($params) -> value;
+              }
+
               @Override
               default ${curriedType(i, name)} curried() {
                   return ${if (i < 2) "this" else s"$curried -> apply($params)"};
@@ -1344,7 +1355,7 @@ def generateTestClasses(): Unit = {
             returnType(1, max)
           }
         }
-        
+
         xs"""
           public class $className {
 
@@ -1397,6 +1408,12 @@ def generateTestClasses(): Unit = {
               public void shouldGetArity() {
                   final $name$i<$generics> f = ($functionArgs) -> null;
                   $assertThat(f.arity()).isEqualTo($i);
+              }
+
+              @$test
+              public void shouldConstant()${checked.gen(" throws Throwable")} {
+                  final $name$i<$generics> f = $name$i.constant(6);
+                  $assertThat(f.apply(${(1 to i).gen(j => s"$j")(", ")})).isEqualTo(6);
               }
 
               @$test

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction0.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction0.java
@@ -90,6 +90,17 @@ public interface CheckedFunction0<R> extends λ<R> {
         return 0;
     }
 
+    /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <R> CheckedFunction0<R> constant(R value) {
+        return () -> value;
+    }
+
     @Override
     default CheckedFunction0<R> curried() {
         return this;

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction1.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction1.java
@@ -106,6 +106,17 @@ public interface CheckedFunction1<T1, R> extends λ<R> {
         return 1;
     }
 
+    /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, R> CheckedFunction1<T1, R> constant(R value) {
+        return (t1) -> value;
+    }
+
     @Override
     default CheckedFunction1<T1, R> curried() {
         return this;

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction2.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction2.java
@@ -110,6 +110,17 @@ public interface CheckedFunction2<T1, T2, R> extends λ<R> {
         return 2;
     }
 
+    /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, R> CheckedFunction2<T1, T2, R> constant(R value) {
+        return (t1, t2) -> value;
+    }
+
     @Override
     default CheckedFunction1<T1, CheckedFunction1<T2, R>> curried() {
         return t1 -> t2 -> apply(t1, t2);

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction3.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction3.java
@@ -125,6 +125,17 @@ public interface CheckedFunction3<T1, T2, T3, R> extends λ<R> {
         return 3;
     }
 
+    /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, R> CheckedFunction3<T1, T2, T3, R> constant(R value) {
+        return (t1, t2, t3) -> value;
+    }
+
     @Override
     default CheckedFunction1<T1, CheckedFunction1<T2, CheckedFunction1<T3, R>>> curried() {
         return t1 -> t2 -> t3 -> apply(t1, t2, t3);

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction4.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction4.java
@@ -141,6 +141,17 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends λ<R> {
         return 4;
     }
 
+    /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, R> CheckedFunction4<T1, T2, T3, T4, R> constant(R value) {
+        return (t1, t2, t3, t4) -> value;
+    }
+
     @Override
     default CheckedFunction1<T1, CheckedFunction1<T2, CheckedFunction1<T3, CheckedFunction1<T4, R>>>> curried() {
         return t1 -> t2 -> t3 -> t4 -> apply(t1, t2, t3, t4);

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction5.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction5.java
@@ -158,6 +158,17 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends λ<R> {
         return 5;
     }
 
+    /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, T5, R> CheckedFunction5<T1, T2, T3, T4, T5, R> constant(R value) {
+        return (t1, t2, t3, t4, t5) -> value;
+    }
+
     @Override
     default CheckedFunction1<T1, CheckedFunction1<T2, CheckedFunction1<T3, CheckedFunction1<T4, CheckedFunction1<T5, R>>>>> curried() {
         return t1 -> t2 -> t3 -> t4 -> t5 -> apply(t1, t2, t3, t4, t5);

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction6.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction6.java
@@ -176,6 +176,17 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
         return 6;
     }
 
+    /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, T5, T6, R> CheckedFunction6<T1, T2, T3, T4, T5, T6, R> constant(R value) {
+        return (t1, t2, t3, t4, t5, t6) -> value;
+    }
+
     @Override
     default CheckedFunction1<T1, CheckedFunction1<T2, CheckedFunction1<T3, CheckedFunction1<T4, CheckedFunction1<T5, CheckedFunction1<T6, R>>>>>> curried() {
         return t1 -> t2 -> t3 -> t4 -> t5 -> t6 -> apply(t1, t2, t3, t4, t5, t6);

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction7.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction7.java
@@ -195,6 +195,17 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
         return 7;
     }
 
+    /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, T5, T6, T7, R> CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> constant(R value) {
+        return (t1, t2, t3, t4, t5, t6, t7) -> value;
+    }
+
     @Override
     default CheckedFunction1<T1, CheckedFunction1<T2, CheckedFunction1<T3, CheckedFunction1<T4, CheckedFunction1<T5, CheckedFunction1<T6, CheckedFunction1<T7, R>>>>>>> curried() {
         return t1 -> t2 -> t3 -> t4 -> t5 -> t6 -> t7 -> apply(t1, t2, t3, t4, t5, t6, t7);

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction8.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction8.java
@@ -215,6 +215,17 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<
         return 8;
     }
 
+    /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, T5, T6, T7, T8, R> CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> constant(R value) {
+        return (t1, t2, t3, t4, t5, t6, t7, t8) -> value;
+    }
+
     @Override
     default CheckedFunction1<T1, CheckedFunction1<T2, CheckedFunction1<T3, CheckedFunction1<T4, CheckedFunction1<T5, CheckedFunction1<T6, CheckedFunction1<T7, CheckedFunction1<T8, R>>>>>>>> curried() {
         return t1 -> t2 -> t3 -> t4 -> t5 -> t6 -> t7 -> t8 -> apply(t1, t2, t3, t4, t5, t6, t7, t8);

--- a/javaslang/src-gen/main/java/javaslang/Function0.java
+++ b/javaslang/src-gen/main/java/javaslang/Function0.java
@@ -102,6 +102,17 @@ public interface Function0<R> extends λ<R>, Supplier<R> {
         return 0;
     }
 
+    /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <R> Function0<R> constant(R value) {
+        return () -> value;
+    }
+
     @Override
     default Function0<R> curried() {
         return this;

--- a/javaslang/src-gen/main/java/javaslang/Function1.java
+++ b/javaslang/src-gen/main/java/javaslang/Function1.java
@@ -107,6 +107,17 @@ public interface Function1<T1, R> extends λ<R>, Function<T1, R> {
         return 1;
     }
 
+    /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, R> Function1<T1, R> constant(R value) {
+        return (t1) -> value;
+    }
+
     @Override
     default Function1<T1, R> curried() {
         return this;

--- a/javaslang/src-gen/main/java/javaslang/Function2.java
+++ b/javaslang/src-gen/main/java/javaslang/Function2.java
@@ -112,6 +112,17 @@ public interface Function2<T1, T2, R> extends λ<R>, BiFunction<T1, T2, R> {
         return 2;
     }
 
+    /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, R> Function2<T1, T2, R> constant(R value) {
+        return (t1, t2) -> value;
+    }
+
     @Override
     default Function1<T1, Function1<T2, R>> curried() {
         return t1 -> t2 -> apply(t1, t2);

--- a/javaslang/src-gen/main/java/javaslang/Function3.java
+++ b/javaslang/src-gen/main/java/javaslang/Function3.java
@@ -126,6 +126,17 @@ public interface Function3<T1, T2, T3, R> extends λ<R> {
         return 3;
     }
 
+    /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, R> Function3<T1, T2, T3, R> constant(R value) {
+        return (t1, t2, t3) -> value;
+    }
+
     @Override
     default Function1<T1, Function1<T2, Function1<T3, R>>> curried() {
         return t1 -> t2 -> t3 -> apply(t1, t2, t3);

--- a/javaslang/src-gen/main/java/javaslang/Function4.java
+++ b/javaslang/src-gen/main/java/javaslang/Function4.java
@@ -142,6 +142,17 @@ public interface Function4<T1, T2, T3, T4, R> extends λ<R> {
         return 4;
     }
 
+    /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, R> Function4<T1, T2, T3, T4, R> constant(R value) {
+        return (t1, t2, t3, t4) -> value;
+    }
+
     @Override
     default Function1<T1, Function1<T2, Function1<T3, Function1<T4, R>>>> curried() {
         return t1 -> t2 -> t3 -> t4 -> apply(t1, t2, t3, t4);

--- a/javaslang/src-gen/main/java/javaslang/Function5.java
+++ b/javaslang/src-gen/main/java/javaslang/Function5.java
@@ -159,6 +159,17 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends λ<R> {
         return 5;
     }
 
+    /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, T5, R> Function5<T1, T2, T3, T4, T5, R> constant(R value) {
+        return (t1, t2, t3, t4, t5) -> value;
+    }
+
     @Override
     default Function1<T1, Function1<T2, Function1<T3, Function1<T4, Function1<T5, R>>>>> curried() {
         return t1 -> t2 -> t3 -> t4 -> t5 -> apply(t1, t2, t3, t4, t5);

--- a/javaslang/src-gen/main/java/javaslang/Function6.java
+++ b/javaslang/src-gen/main/java/javaslang/Function6.java
@@ -177,6 +177,17 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
         return 6;
     }
 
+    /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, T5, T6, R> Function6<T1, T2, T3, T4, T5, T6, R> constant(R value) {
+        return (t1, t2, t3, t4, t5, t6) -> value;
+    }
+
     @Override
     default Function1<T1, Function1<T2, Function1<T3, Function1<T4, Function1<T5, Function1<T6, R>>>>>> curried() {
         return t1 -> t2 -> t3 -> t4 -> t5 -> t6 -> apply(t1, t2, t3, t4, t5, t6);

--- a/javaslang/src-gen/main/java/javaslang/Function7.java
+++ b/javaslang/src-gen/main/java/javaslang/Function7.java
@@ -196,6 +196,17 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
         return 7;
     }
 
+    /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, T5, T6, T7, R> Function7<T1, T2, T3, T4, T5, T6, T7, R> constant(R value) {
+        return (t1, t2, t3, t4, t5, t6, t7) -> value;
+    }
+
     @Override
     default Function1<T1, Function1<T2, Function1<T3, Function1<T4, Function1<T5, Function1<T6, Function1<T7, R>>>>>>> curried() {
         return t1 -> t2 -> t3 -> t4 -> t5 -> t6 -> t7 -> apply(t1, t2, t3, t4, t5, t6, t7);

--- a/javaslang/src-gen/main/java/javaslang/Function8.java
+++ b/javaslang/src-gen/main/java/javaslang/Function8.java
@@ -216,6 +216,17 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<R> {
         return 8;
     }
 
+    /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, T5, T6, T7, T8, R> Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> constant(R value) {
+        return (t1, t2, t3, t4, t5, t6, t7, t8) -> value;
+    }
+
     @Override
     default Function1<T1, Function1<T2, Function1<T3, Function1<T4, Function1<T5, Function1<T6, Function1<T7, Function1<T8, R>>>>>>>> curried() {
         return t1 -> t2 -> t3 -> t4 -> t5 -> t6 -> t7 -> t8 -> apply(t1, t2, t3, t4, t5, t6, t7, t8);

--- a/javaslang/src-gen/test/java/javaslang/CheckedFunction0Test.java
+++ b/javaslang/src-gen/test/java/javaslang/CheckedFunction0Test.java
@@ -39,6 +39,12 @@ public class CheckedFunction0Test {
     }
 
     @Test
+    public void shouldConstant() throws Throwable {
+        final CheckedFunction0<Object> f = CheckedFunction0.constant(6);
+        assertThat(f.apply()).isEqualTo(6);
+    }
+
+    @Test
     public void shouldCurry() {
         final CheckedFunction0<Object> f = () -> null;
         final CheckedFunction0<Object> curried = f.curried();

--- a/javaslang/src-gen/test/java/javaslang/CheckedFunction1Test.java
+++ b/javaslang/src-gen/test/java/javaslang/CheckedFunction1Test.java
@@ -46,6 +46,12 @@ public class CheckedFunction1Test {
     }
 
     @Test
+    public void shouldConstant() throws Throwable {
+        final CheckedFunction1<Object, Object> f = CheckedFunction1.constant(6);
+        assertThat(f.apply(1)).isEqualTo(6);
+    }
+
+    @Test
     public void shouldCurry() {
         final CheckedFunction1<Object, Object> f = (o1) -> null;
         final CheckedFunction1<Object, Object> curried = f.curried();

--- a/javaslang/src-gen/test/java/javaslang/CheckedFunction2Test.java
+++ b/javaslang/src-gen/test/java/javaslang/CheckedFunction2Test.java
@@ -45,6 +45,12 @@ public class CheckedFunction2Test {
     }
 
     @Test
+    public void shouldConstant() throws Throwable {
+        final CheckedFunction2<Object, Object, Object> f = CheckedFunction2.constant(6);
+        assertThat(f.apply(1, 2)).isEqualTo(6);
+    }
+
+    @Test
     public void shouldCurry() {
         final CheckedFunction2<Object, Object, Object> f = (o1, o2) -> null;
         final CheckedFunction1<Object, CheckedFunction1<Object, Object>> curried = f.curried();

--- a/javaslang/src-gen/test/java/javaslang/CheckedFunction3Test.java
+++ b/javaslang/src-gen/test/java/javaslang/CheckedFunction3Test.java
@@ -46,6 +46,12 @@ public class CheckedFunction3Test {
     }
 
     @Test
+    public void shouldConstant() throws Throwable {
+        final CheckedFunction3<Object, Object, Object, Object> f = CheckedFunction3.constant(6);
+        assertThat(f.apply(1, 2, 3)).isEqualTo(6);
+    }
+
+    @Test
     public void shouldCurry() {
         final CheckedFunction3<Object, Object, Object, Object> f = (o1, o2, o3) -> null;
         final CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, Object>>> curried = f.curried();

--- a/javaslang/src-gen/test/java/javaslang/CheckedFunction4Test.java
+++ b/javaslang/src-gen/test/java/javaslang/CheckedFunction4Test.java
@@ -47,6 +47,12 @@ public class CheckedFunction4Test {
     }
 
     @Test
+    public void shouldConstant() throws Throwable {
+        final CheckedFunction4<Object, Object, Object, Object, Object> f = CheckedFunction4.constant(6);
+        assertThat(f.apply(1, 2, 3, 4)).isEqualTo(6);
+    }
+
+    @Test
     public void shouldCurry() {
         final CheckedFunction4<Object, Object, Object, Object, Object> f = (o1, o2, o3, o4) -> null;
         final CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, Object>>>> curried = f.curried();

--- a/javaslang/src-gen/test/java/javaslang/CheckedFunction5Test.java
+++ b/javaslang/src-gen/test/java/javaslang/CheckedFunction5Test.java
@@ -48,6 +48,12 @@ public class CheckedFunction5Test {
     }
 
     @Test
+    public void shouldConstant() throws Throwable {
+        final CheckedFunction5<Object, Object, Object, Object, Object, Object> f = CheckedFunction5.constant(6);
+        assertThat(f.apply(1, 2, 3, 4, 5)).isEqualTo(6);
+    }
+
+    @Test
     public void shouldCurry() {
         final CheckedFunction5<Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5) -> null;
         final CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, Object>>>>> curried = f.curried();

--- a/javaslang/src-gen/test/java/javaslang/CheckedFunction6Test.java
+++ b/javaslang/src-gen/test/java/javaslang/CheckedFunction6Test.java
@@ -49,6 +49,12 @@ public class CheckedFunction6Test {
     }
 
     @Test
+    public void shouldConstant() throws Throwable {
+        final CheckedFunction6<Object, Object, Object, Object, Object, Object, Object> f = CheckedFunction6.constant(6);
+        assertThat(f.apply(1, 2, 3, 4, 5, 6)).isEqualTo(6);
+    }
+
+    @Test
     public void shouldCurry() {
         final CheckedFunction6<Object, Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5, o6) -> null;
         final CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, Object>>>>>> curried = f.curried();

--- a/javaslang/src-gen/test/java/javaslang/CheckedFunction7Test.java
+++ b/javaslang/src-gen/test/java/javaslang/CheckedFunction7Test.java
@@ -50,6 +50,12 @@ public class CheckedFunction7Test {
     }
 
     @Test
+    public void shouldConstant() throws Throwable {
+        final CheckedFunction7<Object, Object, Object, Object, Object, Object, Object, Object> f = CheckedFunction7.constant(6);
+        assertThat(f.apply(1, 2, 3, 4, 5, 6, 7)).isEqualTo(6);
+    }
+
+    @Test
     public void shouldCurry() {
         final CheckedFunction7<Object, Object, Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5, o6, o7) -> null;
         final CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, Object>>>>>>> curried = f.curried();

--- a/javaslang/src-gen/test/java/javaslang/CheckedFunction8Test.java
+++ b/javaslang/src-gen/test/java/javaslang/CheckedFunction8Test.java
@@ -51,6 +51,12 @@ public class CheckedFunction8Test {
     }
 
     @Test
+    public void shouldConstant() throws Throwable {
+        final CheckedFunction8<Object, Object, Object, Object, Object, Object, Object, Object, Object> f = CheckedFunction8.constant(6);
+        assertThat(f.apply(1, 2, 3, 4, 5, 6, 7, 8)).isEqualTo(6);
+    }
+
+    @Test
     public void shouldCurry() {
         final CheckedFunction8<Object, Object, Object, Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5, o6, o7, o8) -> null;
         final CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, Object>>>>>>>> curried = f.curried();

--- a/javaslang/src-gen/test/java/javaslang/Function0Test.java
+++ b/javaslang/src-gen/test/java/javaslang/Function0Test.java
@@ -46,6 +46,12 @@ public class Function0Test {
     }
 
     @Test
+    public void shouldConstant() {
+        final Function0<Object> f = Function0.constant(6);
+        assertThat(f.apply()).isEqualTo(6);
+    }
+
+    @Test
     public void shouldCurry() {
         final Function0<Object> f = () -> null;
         final Function0<Object> curried = f.curried();

--- a/javaslang/src-gen/test/java/javaslang/Function1Test.java
+++ b/javaslang/src-gen/test/java/javaslang/Function1Test.java
@@ -46,6 +46,12 @@ public class Function1Test {
     }
 
     @Test
+    public void shouldConstant() {
+        final Function1<Object, Object> f = Function1.constant(6);
+        assertThat(f.apply(1)).isEqualTo(6);
+    }
+
+    @Test
     public void shouldCurry() {
         final Function1<Object, Object> f = (o1) -> null;
         final Function1<Object, Object> curried = f.curried();

--- a/javaslang/src-gen/test/java/javaslang/Function2Test.java
+++ b/javaslang/src-gen/test/java/javaslang/Function2Test.java
@@ -45,6 +45,12 @@ public class Function2Test {
     }
 
     @Test
+    public void shouldConstant() {
+        final Function2<Object, Object, Object> f = Function2.constant(6);
+        assertThat(f.apply(1, 2)).isEqualTo(6);
+    }
+
+    @Test
     public void shouldCurry() {
         final Function2<Object, Object, Object> f = (o1, o2) -> null;
         final Function1<Object, Function1<Object, Object>> curried = f.curried();

--- a/javaslang/src-gen/test/java/javaslang/Function3Test.java
+++ b/javaslang/src-gen/test/java/javaslang/Function3Test.java
@@ -46,6 +46,12 @@ public class Function3Test {
     }
 
     @Test
+    public void shouldConstant() {
+        final Function3<Object, Object, Object, Object> f = Function3.constant(6);
+        assertThat(f.apply(1, 2, 3)).isEqualTo(6);
+    }
+
+    @Test
     public void shouldCurry() {
         final Function3<Object, Object, Object, Object> f = (o1, o2, o3) -> null;
         final Function1<Object, Function1<Object, Function1<Object, Object>>> curried = f.curried();

--- a/javaslang/src-gen/test/java/javaslang/Function4Test.java
+++ b/javaslang/src-gen/test/java/javaslang/Function4Test.java
@@ -47,6 +47,12 @@ public class Function4Test {
     }
 
     @Test
+    public void shouldConstant() {
+        final Function4<Object, Object, Object, Object, Object> f = Function4.constant(6);
+        assertThat(f.apply(1, 2, 3, 4)).isEqualTo(6);
+    }
+
+    @Test
     public void shouldCurry() {
         final Function4<Object, Object, Object, Object, Object> f = (o1, o2, o3, o4) -> null;
         final Function1<Object, Function1<Object, Function1<Object, Function1<Object, Object>>>> curried = f.curried();

--- a/javaslang/src-gen/test/java/javaslang/Function5Test.java
+++ b/javaslang/src-gen/test/java/javaslang/Function5Test.java
@@ -48,6 +48,12 @@ public class Function5Test {
     }
 
     @Test
+    public void shouldConstant() {
+        final Function5<Object, Object, Object, Object, Object, Object> f = Function5.constant(6);
+        assertThat(f.apply(1, 2, 3, 4, 5)).isEqualTo(6);
+    }
+
+    @Test
     public void shouldCurry() {
         final Function5<Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5) -> null;
         final Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Object>>>>> curried = f.curried();

--- a/javaslang/src-gen/test/java/javaslang/Function6Test.java
+++ b/javaslang/src-gen/test/java/javaslang/Function6Test.java
@@ -49,6 +49,12 @@ public class Function6Test {
     }
 
     @Test
+    public void shouldConstant() {
+        final Function6<Object, Object, Object, Object, Object, Object, Object> f = Function6.constant(6);
+        assertThat(f.apply(1, 2, 3, 4, 5, 6)).isEqualTo(6);
+    }
+
+    @Test
     public void shouldCurry() {
         final Function6<Object, Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5, o6) -> null;
         final Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Object>>>>>> curried = f.curried();

--- a/javaslang/src-gen/test/java/javaslang/Function7Test.java
+++ b/javaslang/src-gen/test/java/javaslang/Function7Test.java
@@ -50,6 +50,12 @@ public class Function7Test {
     }
 
     @Test
+    public void shouldConstant() {
+        final Function7<Object, Object, Object, Object, Object, Object, Object, Object> f = Function7.constant(6);
+        assertThat(f.apply(1, 2, 3, 4, 5, 6, 7)).isEqualTo(6);
+    }
+
+    @Test
     public void shouldCurry() {
         final Function7<Object, Object, Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5, o6, o7) -> null;
         final Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Object>>>>>>> curried = f.curried();

--- a/javaslang/src-gen/test/java/javaslang/Function8Test.java
+++ b/javaslang/src-gen/test/java/javaslang/Function8Test.java
@@ -51,6 +51,12 @@ public class Function8Test {
     }
 
     @Test
+    public void shouldConstant() {
+        final Function8<Object, Object, Object, Object, Object, Object, Object, Object, Object> f = Function8.constant(6);
+        assertThat(f.apply(1, 2, 3, 4, 5, 6, 7, 8)).isEqualTo(6);
+    }
+
+    @Test
     public void shouldCurry() {
         final Function8<Object, Object, Object, Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5, o6, o7, o8) -> null;
         final Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Object>>>>>>>> curried = f.curried();


### PR DESCRIPTION
taking as a model [the haskell const function](http://hackage.haskell.org/package/base-4.9.0.0/docs/Prelude.html#v:const), this adds `Function*.constant`. I regret the longer name, but `const` is a keyword in java, and right now I can't think of a shorter, clear name. Maybe `Function*.value()` but probably not (?).
I think if java allowed `_` as a variable name we wouldn't really need this, you could just write `_ -> 7` for instance. But since we can't have that, it does feel clunky to write `x -> 7` where x stands for nothing and is useless.

But then `x -> 7` is considerably shorter than `Function1.constant(7)` (and comparable to `constant(7)` if you static import)... So I think there's really valid ground to reject this PR. I'll let you judge...