### PR TITLE
Changed and unified all `groupBy` methods to keep insertion order

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/AbstractMap.java
+++ b/javaslang/src/main/java/javaslang/collection/AbstractMap.java
@@ -5,16 +5,11 @@
  */
 package javaslang.collection;
 
-import javaslang.Tuple;
-import javaslang.Tuple2;
+import javaslang.*;
 import javaslang.control.Option;
 
-import java.util.Comparator;
-import java.util.Objects;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Predicate;
+import java.util.*;
+import java.util.function.*;
 
 /**
  * An abstract {@link Map} implementation (not intended to be public).
@@ -48,7 +43,7 @@ abstract class AbstractMap<K, V, M extends AbstractMap<K, V, M>> implements Map<
     @SuppressWarnings("unchecked")
     @Override
     public <U extends V> M put(K key, U value,
-                                   BiFunction<? super V, ? super U, ? extends V> merge) {
+                               BiFunction<? super V, ? super U, ? extends V> merge) {
         Objects.requireNonNull(merge, "the merge function is null");
         final Option<V> currentValue = get(key);
         if (currentValue.isEmpty()) {
@@ -60,14 +55,14 @@ abstract class AbstractMap<K, V, M extends AbstractMap<K, V, M>> implements Map<
 
     @Override
     public <U extends V> M put(Tuple2<? extends K, U> entry,
-                                   BiFunction<? super V, ? super U, ? extends V> merge) {
+                               BiFunction<? super V, ? super U, ? extends V> merge) {
         Objects.requireNonNull(merge, "the merge function is null");
         final Option<V> currentValue = get(entry._1);
         if (currentValue.isEmpty()) {
             return put(entry);
         } else {
             return put(entry.map2(
-                           value -> merge.apply(currentValue.get(), value)));
+                    value -> merge.apply(currentValue.get(), value)));
         }
     }
 
@@ -134,14 +129,7 @@ abstract class AbstractMap<K, V, M extends AbstractMap<K, V, M>> implements Map<
     @SuppressWarnings("unchecked")
     @Override
     public <C> Map<C, M> groupBy(Function<? super Tuple2<K, V>, ? extends C> classifier) {
-        Objects.requireNonNull(classifier, "classifier is null");
-        return foldLeft(HashMap.empty(), (map, entry) -> {
-            final C key = classifier.apply(entry);
-            final Map<K, V> values = map.get(key)
-                    .map(entries -> entries.put(entry._1, entry._2))
-                    .getOrElse(createFromEntries(Iterator.of(entry)));
-            return map.put(key, (M) values);
-        });
+        return Collections.groupBy(this, classifier, this::createFromEntries);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/AbstractMultimap.java
+++ b/javaslang/src/main/java/javaslang/collection/AbstractMultimap.java
@@ -5,14 +5,11 @@
  */
 package javaslang.collection;
 
-import javaslang.Tuple;
-import javaslang.Tuple2;
+import javaslang.*;
 import javaslang.control.Option;
 
 import java.io.Serializable;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.*;
 
 /**
@@ -148,7 +145,7 @@ abstract class AbstractMultimap<K, V, M extends Multimap<K, V>> implements Multi
     @SuppressWarnings("unchecked")
     @Override
     public M removeAll(Iterable<? extends K> keys) {
-        Map<K, Traversable<V>> result = back.removeAll(keys);
+        final Map<K, Traversable<V>> result = back.removeAll(keys);
         return (M) (result == back ? this : createFromMap(result));
     }
 
@@ -227,14 +224,7 @@ abstract class AbstractMultimap<K, V, M extends Multimap<K, V>> implements Multi
 
     @Override
     public <C> Map<C, Multimap<K, V>> groupBy(Function<? super Tuple2<K, V>, ? extends C> classifier) {
-        Objects.requireNonNull(classifier, "classifier is null");
-        return foldLeft(HashMap.empty(), (map, entry) -> {
-            final C key = classifier.apply(entry);
-            final Multimap<K, V> values = map.get(key)
-                    .map(entries -> entries.put(entry._1, entry._2))
-                    .getOrElse(createFromEntries(Iterator.of(entry)));
-            return map.put(key, values);
-        });
+        return Collections.groupBy(this, classifier, this::createFromEntries);
     }
 
     @Override
@@ -302,7 +292,7 @@ abstract class AbstractMultimap<K, V, M extends Multimap<K, V>> implements Multi
         } else if (that.isEmpty()) {
             return this;
         } else {
-            Map<K, Traversable<V>> result = that.keySet().foldLeft(this.back, (map, key) -> {
+            final Map<K, Traversable<V>> result = that.keySet().foldLeft(this.back, (map, key) -> {
                 final Traversable<V> thisValues = map.get(key).getOrElse((Traversable<V>) emptyContainer.get());
                 final Traversable<V2> thatValues = that.get(key).get();
                 final Traversable<V> newValues = collisionResolution.apply(thisValues, thatValues);

--- a/javaslang/src/main/java/javaslang/collection/Array.java
+++ b/javaslang/src/main/java/javaslang/collection/Array.java
@@ -34,8 +34,8 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
 
     static <T> Array<T> wrap(Object[] array) {
         return array.length == 0
-                ? empty()
-                : new Array<T>(array);
+               ? empty()
+               : new Array<T>(array);
     }
 
     /**
@@ -116,8 +116,8 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
     public static <T> Array<T> ofAll(Iterable<? extends T> elements) {
         Objects.requireNonNull(elements, "elements is null");
         return elements instanceof Array
-                ? (Array<T>) elements
-                : wrap(toArray(elements));
+               ? (Array<T>) elements
+               : wrap(toArray(elements));
     }
 
     /**
@@ -482,7 +482,7 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
      * @return an Array with the values built up by the iteration
      * @throws IllegalArgumentException if {@code f} is null
      */
-    static <T,U> Array<U> unfoldRight(T seed, Function<? super T,Option<Tuple2<? extends U, ? extends T>>> f) {
+    static <T, U> Array<U> unfoldRight(T seed, Function<? super T, Option<Tuple2<? extends U, ? extends T>>> f) {
         return Iterator.unfoldRight(seed, f).toArray();
     }
 
@@ -509,7 +509,7 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
      * @return an Array with the values built up by the iteration
      * @throws IllegalArgumentException if {@code f} is null
      */
-    static <T,U> Array<U> unfoldLeft(T seed, Function<? super T,Option<Tuple2<? extends T, ? extends U>>> f) {
+    static <T, U> Array<U> unfoldLeft(T seed, Function<? super T, Option<Tuple2<? extends T, ? extends U>>> f) {
         return Iterator.unfoldLeft(seed, f).toArray();
     }
 
@@ -536,7 +536,7 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
      * @return an Array with the values built up by the iteration
      * @throws IllegalArgumentException if {@code f} is null
      */
-    static <T> Array<T> unfold(T seed, Function<? super T,Option<Tuple2<? extends T, ? extends T>>> f) {
+    static <T> Array<T> unfold(T seed, Function<? super T, Option<Tuple2<? extends T, ? extends T>>> f) {
         return Iterator.unfold(seed, f).toArray();
     }
 
@@ -708,11 +708,7 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
 
     @Override
     public <C> Map<C, Array<T>> groupBy(Function<? super T, ? extends C> classifier) {
-        return foldLeft(HashMap.empty(), (map, t) -> {
-            final C key = classifier.apply(t);
-            final Array<T> values = map.get(key).map(ts -> ts.append(t)).getOrElse(of(t));
-            return map.put(key, values);
-        });
+        return Collections.groupBy(this, classifier, Array::ofAll);
     }
 
     @Override
@@ -1056,13 +1052,13 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
                 new java.util.ArrayList<>(), (c, u) -> {
                     c.add(u);
                     return c;
-                }, list -> Array.<U>wrap(list.toArray()));
+                }, list -> Array.<U> wrap(list.toArray()));
     }
 
     @Override
     public <U> Array<U> scanRight(U zero, BiFunction<? super T, ? super U, ? extends U> operation) {
         Objects.requireNonNull(operation, "operation is null");
-        return Collections.scanRight(this, zero, operation, List.empty(), List::prepend, list -> Array.<U>wrap(list.toJavaArray()));
+        return Collections.scanRight(this, zero, operation, List.empty(), List::prepend, list -> Array.<U> wrap(list.toJavaArray()));
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/BitSet.java
+++ b/javaslang/src/main/java/javaslang/collection/BitSet.java
@@ -5,16 +5,11 @@
  */
 package javaslang.collection;
 
-import javaslang.Tuple;
-import javaslang.Tuple2;
-import javaslang.Tuple3;
+import javaslang.*;
 import javaslang.control.Option;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.NoSuchElementException;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;
 
@@ -59,9 +54,9 @@ public interface BitSet<T> extends SortedSet<T> {
 
         public BitSet<T> of(T t) {
             final int value = toInt.apply(t);
-            if(value < BitSetModule.BITS_PER_WORD) {
+            if (value < BitSetModule.BITS_PER_WORD) {
                 return new BitSetModule.BitSet1<>(fromInt, toInt, 1L << value);
-            } else if(value < 2 * BitSetModule.BITS_PER_WORD) {
+            } else if (value < 2 * BitSetModule.BITS_PER_WORD) {
                 return new BitSetModule.BitSet2<>(fromInt, toInt, 0L, 1L << value);
             } else {
                 return empty().add(t);
@@ -657,7 +652,7 @@ interface BitSetModule {
             while (newlen > 0 && elements[newlen - 1] == 0) {
                 newlen--;
             }
-            long[] newelems = new long[newlen];
+            final long[] newelems = new long[newlen];
             System.arraycopy(elements, 0, newelems, 0, newlen);
             return newelems;
         }
@@ -715,11 +710,11 @@ interface BitSetModule {
             if (isEmpty() || elements.isEmpty()) {
                 return createEmpty();
             } else {
-                int size = size();
+                final int size = size();
                 if (size <= elements.size()) {
                     return retainAll(elements);
                 } else {
-                    BitSet<T> results = createFromAll(elements).retainAll(this);
+                    final BitSet<T> results = createFromAll(elements).retainAll(this);
                     return (size == results.size()) ? this : results;
                 }
             }
@@ -759,9 +754,8 @@ interface BitSetModule {
         }
 
         @Override
-        public  <C> Map<C, BitSet<T>> groupBy(Function<? super T, ? extends C> classifier) {
-            Objects.requireNonNull(classifier, "classifier is null");
-            return iterator().groupBy(classifier).map((key, iterator) -> Tuple.of(key, createFromAll(iterator)));
+        public <C> Map<C, BitSet<T>> groupBy(Function<? super T, ? extends C> classifier) {
+            return Collections.groupBy(this, classifier, this::createFromAll);
         }
 
         @Override
@@ -899,7 +893,7 @@ interface BitSetModule {
 
         @Override
         protected T getNext() {
-            int pos = Long.numberOfTrailingZeros(element);
+            final int pos = Long.numberOfTrailingZeros(element);
             element &= ~(1L << pos);
             return bitSet.fromInt.apply(pos + (index << ADDRESS_BITS_PER_WORD));
         }
@@ -937,10 +931,10 @@ interface BitSetModule {
 
         @Override
         long[] copyExpand(int wordsNum) {
-            if(wordsNum < 1) {
+            if (wordsNum < 1) {
                 wordsNum = 1;
             }
-            long[] arr = new long[wordsNum];
+            final long[] arr = new long[wordsNum];
             arr[0] = elements;
             return arr;
         }
@@ -1004,10 +998,10 @@ interface BitSetModule {
 
         @Override
         long[] copyExpand(int wordsNum) {
-            if(wordsNum < 2) {
+            if (wordsNum < 2) {
                 wordsNum = 2;
             }
-            long[] arr = new long[wordsNum];
+            final long[] arr = new long[wordsNum];
             arr[0] = elements1;
             arr[1] = elements2;
             return arr;
@@ -1089,10 +1083,10 @@ interface BitSetModule {
 
         @Override
         long[] copyExpand(int wordsNum) {
-            if(wordsNum < elements.length) {
+            if (wordsNum < elements.length) {
                 wordsNum = elements.length;
             }
-            long[] arr = new long[wordsNum];
+            final long[] arr = new long[wordsNum];
             System.arraycopy(elements, 0, arr, 0, elements.length);
             return arr;
         }
@@ -1107,7 +1101,7 @@ interface BitSetModule {
             int offset = 0;
             int element = 0;
             for (int i = 0; i < getWordsNum(); i++) {
-                if(elements[i] == 0) {
+                if (elements[i] == 0) {
                     offset += BITS_PER_WORD;
                 } else {
                     element = offset + Long.numberOfTrailingZeros(elements[i]);

--- a/javaslang/src/main/java/javaslang/collection/CharSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/CharSeq.java
@@ -13,8 +13,7 @@ import java.io.*;
 import java.nio.charset.Charset;
 import java.util.*;
 import java.util.function.*;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
+import java.util.regex.*;
 import java.util.stream.Collector;
 
 /**
@@ -103,7 +102,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
 
     /**
      * Creates a String of the given elements.
-     *
+     * <p>
      * The resulting string has the same iteration order as the given iterable of elements
      * if the iteration order of the elements is stable.
      *
@@ -239,7 +238,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * @return a CharSeq with the values built up by the iteration
      * @throws IllegalArgumentException if {@code f} is null
      */
-    static <T> CharSeq unfoldRight(T seed, Function<? super T,Option<Tuple2<? extends Character, ? extends T>>> f) {
+    static <T> CharSeq unfoldRight(T seed, Function<? super T, Option<Tuple2<? extends Character, ? extends T>>> f) {
         return CharSeq.ofAll(Iterator.unfoldRight(seed, f));
     }
 
@@ -266,7 +265,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * @return a CharSeq with the values built up by the iteration
      * @throws IllegalArgumentException if {@code f} is null
      */
-    static <T> CharSeq unfoldLeft(T seed, Function<? super T,Option<Tuple2<? extends T,? extends Character>>> f) {
+    static <T> CharSeq unfoldLeft(T seed, Function<? super T, Option<Tuple2<? extends T, ? extends Character>>> f) {
         return CharSeq.ofAll(Iterator.unfoldLeft(seed, f));
     }
 
@@ -293,7 +292,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * @return a CharSeq with the values built up by the iteration
      * @throws IllegalArgumentException if {@code f} is null
      */
-    static CharSeq unfold(Character seed, Function<? super Character,Option<Tuple2<? extends Character,? extends Character>>> f) {
+    static CharSeq unfold(Character seed, Function<? super Character, Option<Tuple2<? extends Character, ? extends Character>>> f) {
         return CharSeq.ofAll(Iterator.unfold(seed, f));
     }
 
@@ -480,8 +479,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
 
     @Override
     public <C> Map<C, CharSeq> groupBy(Function<? super Character, ? extends C> classifier) {
-        Objects.requireNonNull(classifier, "classifier is null");
-        return iterator().groupBy(classifier).map((c, it) -> Tuple.of(c, CharSeq.ofAll(it)));
+        return Collections.groupBy(this, classifier, CharSeq::ofAll);
     }
 
     @Override
@@ -1159,7 +1157,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * {@code length() - 1}. The first {@code char} value of the sequence
      * is at index {@code 0}, the next at index {@code 1},
      * and so on, as for array indexing.
-     *
+     * <p>
      * <p>If the {@code char} value specified by the index is a
      * <a href="Character.html#unicode">surrogate</a>, the surrogate
      * value is returned.
@@ -1200,7 +1198,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * index. The index refers to {@code char} values
      * (Unicode code units) and ranges from {@code 0} to
      * {@link #length()}{@code  - 1}.
-     *
+     * <p>
      * <p> If the {@code char} value specified at the given index
      * is in the high-surrogate range, the following index is less
      * than the length of this {@code CharSeq}, and the
@@ -1225,7 +1223,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * index. The index refers to {@code char} values
      * (Unicode code units) and ranges from {@code 1} to {@link
      * CharSequence#length() length}.
-     *
+     * <p>
      * <p> If the {@code char} value at {@code (index - 1)}
      * is in the low-surrogate range, {@code (index - 2)} is not
      * negative, and the {@code char} value at {@code (index -
@@ -1329,7 +1327,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
     /**
      * Encodes this {@code CharSeq} into a sequence of bytes using the named
      * charset, storing the result into a new byte array.
-     *
+     * <p>
      * <p> The behavior of this method when this string cannot be encoded in
      * the given charset is unspecified.  The {@link
      * java.nio.charset.CharsetEncoder} class should be used when more control
@@ -1348,7 +1346,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * Encodes this {@code CharSeq} into a sequence of bytes using the given
      * {@linkplain java.nio.charset.Charset charset}, storing the result into a
      * new byte array.
-     *
+     * <p>
      * <p> This method always replaces malformed-input and unmappable-character
      * sequences with this charset's default replacement byte array.  The
      * {@link java.nio.charset.CharsetEncoder} class should be used when more
@@ -1365,7 +1363,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
     /**
      * Encodes this {@code CharSeq} into a sequence of bytes using the
      * platform's default charset, storing the result into a new byte array.
-     *
+     * <p>
      * <p> The behavior of this method when this string cannot be encoded in
      * the default charset is unspecified.  The {@link
      * java.nio.charset.CharsetEncoder} class should be used when more control
@@ -1413,7 +1411,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * considerations.  Two strings are considered equal ignoring case if they
      * are of the same length and corresponding characters in the two strings
      * are equal ignoring case.
-     *
+     * <p>
      * <p> Two characters {@code c1} and {@code c2} are considered the same
      * ignoring case if at least one of the following is true:
      * <ul>
@@ -1724,14 +1722,14 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * is true. In either case, if no such character occurs in this
      * string at or after position {@code fromIndex}, then
      * {@code -1} is returned.
-     *
+     * <p>
      * <p>
      * There is no restriction on the value of {@code fromIndex}. If it
      * is negative, it has the same effect as if it were zero: this entire
      * string may be searched. If it is greater than the length of this
      * string, it has the same effect as if it were equal to the length of
      * this string: {@code -1} is returned.
-     *
+     * <p>
      * <p>All indices are specified in {@code char} values
      * (Unicode code units).
      *
@@ -1812,7 +1810,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * is true. In either case, if no such character occurs in this
      * string at or before position {@code fromIndex}, then
      * {@code -1} is returned.
-     *
+     * <p>
      * <p>All indices are specified in {@code char} values
      * (Unicode code units).
      *
@@ -1848,7 +1846,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
     /**
      * Returns the index within this string of the first occurrence of the
      * specified substring.
-     *
+     * <p>
      * <p>The returned index is the smallest value <i>k</i> for which:
      * <blockquote><pre>
      * this.startsWith(str, <i>k</i>)
@@ -1876,7 +1874,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
     /**
      * Returns the index within this string of the first occurrence of the
      * specified substring, starting at the specified index.
-     *
+     * <p>
      * <p>The returned index is the smallest value <i>k</i> for which:
      * <blockquote><pre>
      * <i>k</i> &gt;= fromIndex {@code &&} this.startsWith(str, <i>k</i>)
@@ -1909,7 +1907,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * Returns the index within this string of the last occurrence of the
      * specified substring.  The last occurrence of the empty string ""
      * is considered to occur at the index value {@code this.length()}.
-     *
+     * <p>
      * <p>The returned index is the largest value <i>k</i> for which:
      * <blockquote><pre>
      * this.startsWith(str, <i>k</i>)
@@ -1937,7 +1935,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
     /**
      * Returns the index within this string of the last occurrence of the
      * specified substring, searching backward starting at the specified index.
-     *
+     * <p>
      * <p>The returned index is the largest value <i>k</i> for which:
      * <blockquote><pre>
      * <i>k</i> {@code <=} fromIndex {@code &&} this.startsWith(str, <i>k</i>)
@@ -2057,11 +2055,11 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
     /**
      * Tells whether or not this string matches the given <a
      * href="../util/regex/Pattern.html#sum">regular expression</a>.
-     *
+     * <p>
      * <p> An invocation of this method of the form
      * <i>str</i>{@code .matches(}<i>regex</i>{@code )} yields exactly the
      * same result as the expression
-     *
+     * <p>
      * <blockquote>
      * {@link Pattern}.{@link Pattern#matches(String, CharSequence)
      * matches(<i>regex</i>, <i>str</i>)}
@@ -2092,11 +2090,11 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * Replaces the first substring of this string that matches the given <a
      * href="../util/regex/Pattern.html#sum">regular expression</a> with the
      * given replacement.
-     *
+     * <p>
      * <p> An invocation of this method of the form
      * <i>str</i>{@code .replaceFirst(}<i>regex</i>{@code ,} <i>repl</i>{@code )}
      * yields exactly the same result as the expression
-     *
+     * <p>
      * <blockquote>
      * <code>
      * {@link Pattern}.{@link
@@ -2105,7 +2103,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * java.util.regex.Matcher#replaceFirst replaceFirst}(<i>repl</i>)
      * </code>
      * </blockquote>
-     *
+     * <p>
      * <p>
      * Note that backslashes ({@code \}) and dollar signs ({@code $}) in the
      * replacement string may cause the results to be different than if it were
@@ -2128,11 +2126,11 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * Replaces each substring of this string that matches the given <a
      * href="../util/regex/Pattern.html#sum">regular expression</a> with the
      * given replacement.
-     *
+     * <p>
      * <p> An invocation of this method of the form
      * <i>str</i>{@code .replaceAll(}<i>regex</i>{@code ,} <i>repl</i>{@code )}
      * yields exactly the same result as the expression
-     *
+     * <p>
      * <blockquote>
      * <code>
      * {@link Pattern}.{@link
@@ -2141,7 +2139,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * java.util.regex.Matcher#replaceAll replaceAll}(<i>repl</i>)
      * </code>
      * </blockquote>
-     *
+     * <p>
      * <p>
      * Note that backslashes ({@code \}) and dollar signs ({@code $}) in the
      * replacement string may cause the results to be different than if it were
@@ -2178,19 +2176,19 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
     /**
      * Splits this string around matches of the given
      * <a href="../util/regex/Pattern.html#sum">regular expression</a>.
-     *
+     * <p>
      * <p> The array returned by this method contains each substring of this
      * string that is terminated by another substring that matches the given
      * expression or is terminated by the end of the string.  The substrings in
      * the array are in the order in which they occur in this string.  If the
      * expression does not match any part of the input then the resulting array
      * has just one element, namely this string.
-     *
+     * <p>
      * <p> When there is a positive-width match at the beginning of this
      * string then an empty leading substring is included at the beginning
      * of the resulting array. A zero-width match at the beginning however
      * never produces such empty leading substring.
-     *
+     * <p>
      * <p> The {@code limit} parameter controls the number of times the
      * pattern is applied and therefore affects the length of the resulting
      * array.  If the limit <i>n</i> is greater than zero then the pattern
@@ -2201,10 +2199,10 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * possible and the array can have any length.  If <i>n</i> is zero then
      * the pattern will be applied as many times as possible, the array can
      * have any length, and trailing empty strings will be discarded.
-     *
+     * <p>
      * <p> The string {@code "boo:and:foo"}, for example, yields the
      * following results with these parameters:
-     *
+     * <p>
      * <blockquote><table cellpadding=1 cellspacing=0 summary="Split example showing regex, limit, and result">
      * <tr>
      * <th>Regex</th>
@@ -2230,11 +2228,11 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * <td align=center>0</td>
      * <td>{@code { "b", "", ":and:f" }}</td></tr>
      * </table></blockquote>
-     *
+     * <p>
      * <p> An invocation of this method of the form
      * <i>str.</i>{@code split(}<i>regex</i>{@code ,}&nbsp;<i>n</i>{@code )}
      * yields the same result as the expression
-     *
+     * <p>
      * <blockquote>
      * <code>
      * {@link Pattern}.{@link
@@ -2255,6 +2253,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
     public CharSeq[] split(String regex, int limit) {
         return splitSeq(regex, limit).toJavaArray(CharSeq.class);
     }
+
     public Seq<CharSeq> splitSeq(String regex, int limit) {
         final Seq<String> split = Array.wrap(back.split(regex, limit));
         return split.map(CharSeq::of);
@@ -2263,15 +2262,15 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
     /**
      * Splits this string around matches of the given <a
      * href="../util/regex/Pattern.html#sum">regular expression</a>.
-     *
+     * <p>
      * <p> This method works as if by invoking the two-argument {@link
      * #splitSeq(String, int) splitSeq} method with the given expression and a limit
      * argument of zero.  Trailing empty strings are therefore not included in
      * the resulting {@link javaslang.collection.Seq}.
-     *
+     * <p>
      * <p> The string {@code "boo:and:foo"}, for example, yields the following
      * results with these expressions:
-     *
+     * <p>
      * <blockquote><table cellpadding=1 cellspacing=0 summary="Split examples showing regex and result">
      * <tr>
      * <th>Regex</th>
@@ -2294,6 +2293,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
     public CharSeq[] split(String regex) {
         return splitSeq(regex, 0).toJavaArray(CharSeq.class);
     }
+
     public Seq<CharSeq> splitSeq(String regex) {
         return splitSeq(regex, 0);
     }
@@ -2385,7 +2385,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * {@code CharSeq} may be a different length than the original {@code CharSeq}.
      * <p>
      * Examples of locale-sensitive and 1:M case mappings are in the following table.
-     *
+     * <p>
      * <table border="1" summary="Examples of locale-sensitive and 1:M case mappings. Shows Language code of locale, lower case, upper case, and description.">
      * <tr>
      * <th>Language Code of Locale</th>

--- a/javaslang/src/main/java/javaslang/collection/Collections.java
+++ b/javaslang/src/main/java/javaslang/collection/Collections.java
@@ -7,13 +7,8 @@ package javaslang.collection;
 
 import javaslang.control.Option;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Objects;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
+import java.util.*;
+import java.util.function.*;
 
 /**
  * Internal class, containing helpers.
@@ -53,13 +48,13 @@ final class Collections {
         Objects.requireNonNull(classifier, "classifier is null");
         Objects.requireNonNull(mapper, "mapper is null");
 
-        final java.util.Map<C, Collection<T>> mutableResults = new java.util.HashMap<>();
+        final java.util.Map<C, Collection<T>> mutableResults = new java.util.LinkedHashMap<>();
         for (T value : collection) {
             final C key = classifier.apply(value);
             mutableResults.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
         }
 
-        HashMap<C, R> results = HashMap.empty();
+        Map<C, R> results = LinkedHashMap.empty();
         for (java.util.Map.Entry<C, Collection<T>> entry : mutableResults.entrySet()) {
             results = results.put(entry.getKey(), mapper.apply(entry.getValue()));
         }

--- a/javaslang/src/main/java/javaslang/collection/HashSet.java
+++ b/javaslang/src/main/java/javaslang/collection/HashSet.java
@@ -82,7 +82,7 @@ public final class HashSet<T> implements Kind1<HashSet<?>, T>, Set<T>, Serializa
 
     /**
      * Creates a HashSet of the given elements.
-     *
+     * <p>
      * <pre><code>HashSet.of(1, 2, 3, 4)</code></pre>
      *
      * @param <T>      Component type of the HashSet.
@@ -565,11 +565,7 @@ public final class HashSet<T> implements Kind1<HashSet<?>, T>, Set<T>, Serializa
 
     @Override
     public <C> Map<C, HashSet<T>> groupBy(Function<? super T, ? extends C> classifier) {
-        return foldLeft(HashMap.empty(), (map, t) -> {
-            final C key = classifier.apply(t);
-            final HashSet<T> values = map.get(key).map(ts -> ts.add(t)).getOrElse(HashSet.of(t));
-            return map.put(key, values);
-        });
+        return Collections.groupBy(this, classifier, HashSet::ofAll);
     }
 
     @Override
@@ -611,11 +607,11 @@ public final class HashSet<T> implements Kind1<HashSet<?>, T>, Set<T>, Serializa
         if (isEmpty() || elements.isEmpty()) {
             return empty();
         } else {
-            int size = size();
+            final int size = size();
             if (size <= elements.size()) {
                 return retainAll(elements);
             } else {
-                HashSet<T> results = HashSet.<T> ofAll(elements).retainAll(this);
+                final HashSet<T> results = HashSet.<T> ofAll(elements).retainAll(this);
                 return (size == results.size()) ? this : results;
             }
         }
@@ -782,7 +778,7 @@ public final class HashSet<T> implements Kind1<HashSet<?>, T>, Set<T>, Serializa
     @Override
     public HashSet<T> takeWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        HashSet<T> taken = HashSet.ofAll(iterator().takeWhile(predicate));
+        final HashSet<T> taken = HashSet.ofAll(iterator().takeWhile(predicate));
         return taken.length() == length() ? this : taken;
     }
 
@@ -830,7 +826,7 @@ public final class HashSet<T> implements Kind1<HashSet<?>, T>, Set<T>, Serializa
     public <T1, T2> Tuple2<HashSet<T1>, HashSet<T2>> unzip(
             Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
-        Tuple2<Iterator<T1>, Iterator<T2>> t = iterator().unzip(unzipper);
+        final Tuple2<Iterator<T1>, Iterator<T2>> t = iterator().unzip(unzipper);
         return Tuple.of(HashSet.ofAll(t._1), HashSet.ofAll(t._2));
     }
 
@@ -838,7 +834,7 @@ public final class HashSet<T> implements Kind1<HashSet<?>, T>, Set<T>, Serializa
     public <T1, T2, T3> Tuple3<HashSet<T1>, HashSet<T2>, HashSet<T3>> unzip3(
             Function<? super T, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
-        Tuple3<Iterator<T1>, Iterator<T2>, Iterator<T3>> t = iterator().unzip3(unzipper);
+        final Tuple3<Iterator<T1>, Iterator<T2>, Iterator<T3>> t = iterator().unzip3(unzipper);
         return Tuple.of(HashSet.ofAll(t._1), HashSet.ofAll(t._2), HashSet.ofAll(t._3));
     }
 

--- a/javaslang/src/main/java/javaslang/collection/LinkedHashSet.java
+++ b/javaslang/src/main/java/javaslang/collection/LinkedHashSet.java
@@ -82,7 +82,7 @@ public final class LinkedHashSet<T> implements Kind1<LinkedHashSet<?>, T>, Set<T
 
     /**
      * Creates a LinkedHashSet of the given elements.
-     *
+     * <p>
      * <pre><code>LinkedHashSet.of(1, 2, 3, 4)</code></pre>
      *
      * @param <T>      Component type of the LinkedHashSet.
@@ -561,11 +561,7 @@ public final class LinkedHashSet<T> implements Kind1<LinkedHashSet<?>, T>, Set<T
 
     @Override
     public <C> Map<C, LinkedHashSet<T>> groupBy(Function<? super T, ? extends C> classifier) {
-        return foldLeft(HashMap.empty(), (map, t) -> {
-            final C key = classifier.apply(t);
-            final LinkedHashSet<T> values = map.get(key).map(ts -> ts.add(t)).getOrElse(LinkedHashSet.of(t));
-            return map.put(key, values);
-        });
+        return Collections.groupBy(this, classifier, LinkedHashSet::ofAll);
     }
 
     @Override
@@ -776,7 +772,7 @@ public final class LinkedHashSet<T> implements Kind1<LinkedHashSet<?>, T>, Set<T
     @Override
     public LinkedHashSet<T> takeWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        LinkedHashSet<T> taken = LinkedHashSet.ofAll(iterator().takeWhile(predicate));
+        final LinkedHashSet<T> taken = LinkedHashSet.ofAll(iterator().takeWhile(predicate));
         return taken.length() == length() ? this : taken;
     }
 
@@ -824,7 +820,7 @@ public final class LinkedHashSet<T> implements Kind1<LinkedHashSet<?>, T>, Set<T
     public <T1, T2> Tuple2<LinkedHashSet<T1>, LinkedHashSet<T2>> unzip(
             Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
-        Tuple2<Iterator<T1>, Iterator<T2>> t = iterator().unzip(unzipper);
+        final Tuple2<Iterator<T1>, Iterator<T2>> t = iterator().unzip(unzipper);
         return Tuple.of(LinkedHashSet.ofAll(t._1), LinkedHashSet.ofAll(t._2));
     }
 
@@ -832,7 +828,7 @@ public final class LinkedHashSet<T> implements Kind1<LinkedHashSet<?>, T>, Set<T
     public <T1, T2, T3> Tuple3<LinkedHashSet<T1>, LinkedHashSet<T2>, LinkedHashSet<T3>> unzip3(
             Function<? super T, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
-        Tuple3<Iterator<T1>, Iterator<T2>, Iterator<T3>> t = iterator().unzip3(unzipper);
+        final Tuple3<Iterator<T1>, Iterator<T2>, Iterator<T3>> t = iterator().unzip3(unzipper);
         return Tuple.of(LinkedHashSet.ofAll(t._1), LinkedHashSet.ofAll(t._2), LinkedHashSet.ofAll(t._3));
     }
 

--- a/javaslang/src/main/java/javaslang/collection/PriorityQueue.java
+++ b/javaslang/src/main/java/javaslang/collection/PriorityQueue.java
@@ -337,8 +337,7 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
 
     @Override
     public <C> Map<C, ? extends PriorityQueue<T>> groupBy(Function<? super T, ? extends C> classifier) {
-        Objects.requireNonNull(classifier, "classifier is null");
-        return iterator().groupBy(classifier).map((c, q) -> Tuple.of(c, ofAll(comparator, q)));
+        return Collections.groupBy(this, classifier, (elements) -> ofAll(comparator, elements));
     }
 
     @Override
@@ -559,8 +558,8 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
                 assert rank == tree.rank;
 
                 return comparator.isLessOrEqual(this.root, tree.root)
-                        ? of(this.root, this.rank + 1, tree.appendTo(this.children))
-                        : of(tree.root, tree.rank + 1, this.appendTo(tree.children));
+                       ? of(this.root, this.rank + 1, tree.appendTo(this.children))
+                       : of(tree.root, tree.rank + 1, this.appendTo(tree.children));
             }
 
             /**
@@ -663,8 +662,8 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
          **/
         static <T> Seq<Node<T>> uniqify(SerializableComparator<? super T> comparator, Seq<Node<T>> forest) {
             return forest.isEmpty()
-                    ? forest
-                    : ins(comparator, forest.head(), forest.tail());
+                   ? forest
+                   : ins(comparator, forest.head(), forest.tail());
         }
 
         /**

--- a/javaslang/src/main/java/javaslang/collection/Tree.java
+++ b/javaslang/src/main/java/javaslang/collection/Tree.java
@@ -16,8 +16,8 @@ import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;
 
-import static javaslang.collection.Tree.*;
 import static javaslang.collection.Tree.Order.PRE_ORDER;
+import static javaslang.collection.Tree.*;
 
 /**
  * A general Tree interface.
@@ -431,12 +431,7 @@ public interface Tree<T> extends Traversable<T> {
     @SuppressWarnings("unchecked")
     @Override
     default <C> Map<C, Seq<T>> groupBy(Function<? super T, ? extends C> classifier) {
-        Objects.requireNonNull(classifier, "classifier is null");
-        if (isEmpty()) {
-            return HashMap.empty();
-        } else {
-            return (Map<C, Seq<T>>) values().groupBy(classifier);
-        }
+        return Collections.groupBy(values(), classifier, Stream::ofAll);
     }
 
     @Override
@@ -659,7 +654,7 @@ public interface Tree<T> extends Traversable<T> {
     default <U> Tree<Tuple2<T, U>> zipAll(Iterable<? extends U> that, T thisElem, U thatElem) {
         Objects.requireNonNull(that, "that is null");
         if (isEmpty()) {
-            return Iterator.<U>ofAll(that).map(elem -> Tuple.of(thisElem, elem)).toTree();
+            return Iterator.<U> ofAll(that).map(elem -> Tuple.of(thisElem, elem)).toTree();
         } else {
             final java.util.Iterator<? extends U> thatIter = that.iterator();
             final Tree<Tuple2<T, U>> tree = ZipAll.apply((Node<T>) this, thatIter, thatElem);
@@ -756,7 +751,7 @@ public interface Tree<T> extends Traversable<T> {
             } else if (o instanceof Node) {
                 final Node<?> that = (Node<?>) o;
                 return Objects.equals(this.getValue(), that.getValue())
-                        && Objects.equals(this.getChildren(), that.getChildren());
+                       && Objects.equals(this.getChildren(), that.getChildren());
             } else {
                 return false;
             }
@@ -784,8 +779,8 @@ public interface Tree<T> extends Traversable<T> {
             for (List<Node<T>> it = children; !it.isEmpty(); it = it.tail()) {
                 final boolean isLast = it.tail().isEmpty();
                 builder.append('\n')
-                        .append(indent)
-                        .append(isLast ? "└──" : "├──");
+                       .append(indent)
+                       .append(isLast ? "└──" : "├──");
                 it.head().drawAux(indent + (isLast ? "   " : "│  "), builder);
             }
         }
@@ -1135,7 +1130,7 @@ interface TreeModule {
                                                                            Function<? super T, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
             final Tuple3<? extends T1, ? extends T2, ? extends T3> value = unzipper.apply(node.getValue());
             final List<Tuple3<Node<T1>, Node<T2>, Node<T3>>> children = node.getChildren()
-                    .map(child -> Unzip.apply3(child, unzipper));
+                                                                            .map(child -> Unzip.apply3(child, unzipper));
             final Node<T1> node1 = new Node<>(value._1, children.map(t -> t._1));
             final Node<T2> node2 = new Node<>(value._2, children.map(t -> t._2));
             final Node<T3> node3 = new Node<>(value._3, children.map(t -> t._3));

--- a/javaslang/src/main/java/javaslang/collection/TreeSet.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeSet.java
@@ -50,7 +50,7 @@ public final class TreeSet<T> implements Kind1<TreeSet<?>, T>, SortedSet<T>, Ser
      * Returns a {@link java.util.stream.Collector} which may be used in conjunction with
      * {@link java.util.stream.Stream#collect(java.util.stream.Collector)} to obtain a {@link javaslang.collection.TreeSet}.
      *
-     * @param <T> Component type of the List.
+     * @param <T>        Component type of the List.
      * @param comparator An element comparator
      * @return A javaslang.collection.List Collector.
      */
@@ -189,8 +189,8 @@ public final class TreeSet<T> implements Kind1<TreeSet<?>, T>, SortedSet<T>, Ser
         Objects.requireNonNull(comparator, "comparator is null");
         Objects.requireNonNull(values, "values is null");
         return values.iterator().hasNext()
-                ? new TreeSet<>(RedBlackTree.ofAll(comparator, values))
-                : (TreeSet<T>) empty();
+               ? new TreeSet<>(RedBlackTree.ofAll(comparator, values))
+               : (TreeSet<T>) empty();
     }
 
     public static <T extends Comparable<? super T>> TreeSet<T> ofAll(java.util.stream.Stream<? extends T> javaStream) {
@@ -621,9 +621,7 @@ public final class TreeSet<T> implements Kind1<TreeSet<?>, T>, SortedSet<T>, Ser
 
     @Override
     public <C> Map<C, TreeSet<T>> groupBy(Function<? super T, ? extends C> classifier) {
-        Objects.requireNonNull(classifier, "classifier is null");
-        return iterator().groupBy(classifier).map(
-                (key, iterator) -> Tuple.of(key, TreeSet.ofAll(tree.comparator(), iterator)));
+        return Collections.groupBy(this, classifier, elements -> ofAll(comparator(), elements));
     }
 
     @Override
@@ -872,7 +870,7 @@ public final class TreeSet<T> implements Kind1<TreeSet<?>, T>, SortedSet<T>, Ser
      * @return An instance of type {@code U}
      * @throws NullPointerException if {@code f} is null
      */
-    public  <U> U transform(Function<? super TreeSet<T>, ? extends U> f) {
+    public <U> U transform(Function<? super TreeSet<T>, ? extends U> f) {
         Objects.requireNonNull(f, "f is null");
         return f.apply(this);
     }

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -143,7 +143,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     /**
      * Creates a Vector of the given elements.
-     *
+     * <p>
      * The resulting vector has the same iteration order as the given iterable of elements
      * if the iteration order of the elements is stable.
      *
@@ -499,7 +499,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @return a Vector with the values built up by the iteration
      * @throws IllegalArgumentException if {@code f} is null
      */
-    static <T,U> Vector<U> unfoldRight(T seed, Function<? super T,Option<Tuple2<? extends U, ? extends T>>> f) {
+    static <T, U> Vector<U> unfoldRight(T seed, Function<? super T, Option<Tuple2<? extends U, ? extends T>>> f) {
         return Iterator.unfoldRight(seed, f).toVector();
     }
 
@@ -526,7 +526,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @return a Vector with the values built up by the iteration
      * @throws IllegalArgumentException if {@code f} is null
      */
-    static <T,U> Vector<U> unfoldLeft(T seed, Function<? super T,Option<Tuple2<? extends T, ? extends U>>> f) {
+    static <T, U> Vector<U> unfoldLeft(T seed, Function<? super T, Option<Tuple2<? extends T, ? extends U>>> f) {
         return Iterator.unfoldLeft(seed, f).toVector();
     }
 
@@ -553,7 +553,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @return a Vector with the values built up by the iteration
      * @throws IllegalArgumentException if {@code f} is null
      */
-    static <T> Vector<T> unfold(T seed, Function<? super T,Option<Tuple2<? extends T, ? extends T>>> f) {
+    static <T> Vector<T> unfold(T seed, Function<? super T, Option<Tuple2<? extends T, ? extends T>>> f) {
         return Iterator.unfold(seed, f).toVector();
     }
 
@@ -706,8 +706,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public <C> Map<C, Vector<T>> groupBy(Function<? super T, ? extends C> classifier) {
-        Objects.requireNonNull(classifier, "classifier is null");
-        return iterator().groupBy(classifier).map((c, it) -> Tuple.of(c, Vector.ofAll(it)));
+        return Collections.groupBy(this, classifier, Vector::ofAll);
     }
 
     @Override
@@ -885,7 +884,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
         Objects.requireNonNull(predicate, "predicate is null");
         final java.util.List<T> left = new ArrayList<>(), right = new ArrayList<>();
         for (int i = 0; i < length(); i++) {
-            T t = get(i);
+            final T t = get(i);
             (predicate.test(t) ? left : right).add(t);
         }
         return Tuple.of(Vector.ofAll(left), Vector.ofAll(right));
@@ -1261,7 +1260,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
         Objects.requireNonNull(predicate, "predicate is null");
         HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
         for (int i = 0; i < length(); i++) {
-            T value = get(i);
+            final T value = get(i);
             if (!predicate.test(value)) {
                 break;
             }

--- a/javaslang/src/test/java/javaslang/collection/AbstractTraversableTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractTraversableTest.java
@@ -416,7 +416,6 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         }
     }
 
-
     // -- dropUntil
 
     @Test
@@ -433,7 +432,7 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         if (useIsEqualToInsteadOfIsSameAs()) {
             assertThat(of(1, 2, 3).dropUntil(ignored -> true)).isEqualTo(of(1, 2, 3));
         } else {
-            Traversable<Integer> t = of(1, 2, 3);
+            final Traversable<Integer> t = of(1, 2, 3);
             assertThat(t.dropUntil(ignored -> true)).isSameAs(t);
         }
     }
@@ -468,7 +467,7 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         if (useIsEqualToInsteadOfIsSameAs()) {
             assertThat(of(1, 2, 3).dropWhile(ignored -> false)).isEqualTo(of(1, 2, 3));
         } else {
-            Traversable<Integer> t = of(1, 2, 3);
+            final Traversable<Integer> t = of(1, 2, 3);
             assertThat(t.dropWhile(ignored -> false)).isSameAs(t);
         }
     }
@@ -514,7 +513,7 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         if (useIsEqualToInsteadOfIsSameAs()) {
             assertThat(of(1, 2, 3).filter(ignore -> true)).isEqualTo(of(1, 2, 3));
         } else {
-            Traversable<Integer> t = of(1, 2, 3);
+            final Traversable<Integer> t = of(1, 2, 3);
             assertThat(t.filter(ignore -> true)).isSameAs(t);
         }
     }
@@ -673,23 +672,22 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
 
     @Test
     public void shouldNilGroupBy() {
-        assertThat(empty().groupBy(Function.identity())).isEqualTo(HashMap.empty());
+        assertThat(empty().groupBy(Function.identity())).isEqualTo(LinkedHashMap.empty());
     }
 
     @Test
     public void shouldNonNilGroupByIdentity() {
-        Map<?, ?> actual = of('a', 'b', 'c').groupBy(Function.identity());
-        Map<?, ?> expected = HashMap.empty().put('a', of('a')).put('b', of('b')).put('c', of('c'));
+        final Map<?, ?> actual = of('a', 'b', 'c').groupBy(Function.identity());
+        final Map<?, ?> expected = LinkedHashMap.empty().put('a', of('a')).put('b', of('b')).put('c', of('c'));
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldNonNilGroupByEqual() {
-        Map<?, ?> actual = of('a', 'b', 'c').groupBy(c -> 1);
-        Map<?, ?> expected = HashMap.empty().put(1, of('a', 'b', 'c'));
+        final Map<?, ?> actual = of('a', 'b', 'c').groupBy(c -> 1);
+        final Map<?, ?> expected = LinkedHashMap.empty().put(1, of('a', 'b', 'c'));
         assertThat(actual).isEqualTo(expected);
     }
-
 
     // -- grouped
 
@@ -1345,9 +1343,9 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
 
     @Test
     public void shouldRetainAllElementsFromNil() {
-        Traversable<Object> src = empty();
-        Traversable<Object> expected = src;
-        Traversable<Object> actual = src.retainAll(of(1, 2, 3));
+        final Traversable<Object> src = empty();
+        final Traversable<Object> expected = src;
+        final Traversable<Object> actual = src.retainAll(of(1, 2, 3));
         if (useIsEqualToInsteadOfIsSameAs()) {
             assertThat(actual).isEqualTo(expected);
         } else {
@@ -1357,17 +1355,17 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
 
     @Test
     public void shouldRetainAllExistingElementsFromNonNil() {
-        Traversable<Integer> src = of(1, 2, 3, 2, 1, 3);
-        Traversable<Integer> expected = of(1, 2, 2, 1);
-        Traversable<Integer> actual = src.retainAll(of(1, 2));
+        final Traversable<Integer> src = of(1, 2, 3, 2, 1, 3);
+        final Traversable<Integer> expected = of(1, 2, 2, 1);
+        final Traversable<Integer> actual = src.retainAll(of(1, 2));
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldRetainAllElementsFromNonNil() {
-        Traversable<Integer> src = of(1, 2, 1, 2, 2);
-        Traversable<Integer> expected = of(1, 2, 1, 2, 2);
-        Traversable<Integer> actual = src.retainAll(of(1, 2));
+        final Traversable<Integer> src = of(1, 2, 1, 2, 2);
+        final Traversable<Integer> expected = of(1, 2, 1, 2, 2);
+        final Traversable<Integer> actual = src.retainAll(of(1, 2));
         if (useIsEqualToInsteadOfIsSameAs()) {
             assertThat(actual).isEqualTo(expected);
         } else {
@@ -1377,9 +1375,9 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
 
     @Test
     public void shouldNotRetainAllNonExistingElementsFromNonNil() {
-        Traversable<Integer> src = of(1, 2, 3);
-        Traversable<Object> expected = empty();
-        Traversable<Integer> actual = src.retainAll(of(4, 5));
+        final Traversable<Integer> src = of(1, 2, 3);
+        final Traversable<Object> expected = empty();
+        final Traversable<Integer> actual = src.retainAll(of(4, 5));
         if (useIsEqualToInsteadOfIsSameAs()) {
             assertThat(actual).isEqualTo(expected);
         } else {
@@ -1886,7 +1884,6 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         assertThat(of(1, 2, 3).tailOption()).isEqualTo(Option.some(of(2, 3)));
     }
 
-
     // -- unzip
 
     @Test
@@ -2248,16 +2245,16 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
 
     @Test
     public void shouldTabulateTheSeq() {
-        Function<Number, Integer> f = i -> i.intValue() * i.intValue();
-        Traversable<Number> actual = tabulate(3, f);
+        final Function<Number, Integer> f = i -> i.intValue() * i.intValue();
+        final Traversable<Number> actual = tabulate(3, f);
         assertThat(actual).isEqualTo(of(0, 1, 4));
     }
 
     @Test
     public void shouldTabulateTheSeqCallingTheFunctionInTheRightOrder() {
-        java.util.LinkedList<Integer> ints = new java.util.LinkedList<>(Arrays.asList(0, 1, 2));
-        Function<Integer, Integer> f = i -> ints.remove();
-        Traversable<Integer> actual = tabulate(3, f);
+        final java.util.LinkedList<Integer> ints = new java.util.LinkedList<>(Arrays.asList(0, 1, 2));
+        final Function<Integer, Integer> f = i -> ints.remove();
+        final Traversable<Integer> actual = tabulate(3, f);
         assertThat(actual).isEqualTo(of(0, 1, 2));
     }
 
@@ -2273,9 +2270,9 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
 
     @Test
     public void shouldFillTheSeqCallingTheSupplierInTheRightOrder() {
-        java.util.LinkedList<Integer> ints = new java.util.LinkedList<>(Arrays.asList(0, 1));
-        Supplier<Integer> s = () -> ints.remove();
-        Traversable<Number> actual = fill(2, s);
+        final java.util.LinkedList<Integer> ints = new java.util.LinkedList<>(Arrays.asList(0, 1));
+        final Supplier<Integer> s = () -> ints.remove();
+        final Traversable<Number> actual = fill(2, s);
         assertThat(actual).isEqualTo(of(0, 1));
     }
 

--- a/javaslang/src/test/java/javaslang/collection/CharSeqTest.java
+++ b/javaslang/src/test/java/javaslang/collection/CharSeqTest.java
@@ -86,7 +86,7 @@ public class CharSeqTest {
 
     @Test
     public void shouldPadNonEmptyZeroLen() {
-        CharSeq seq = of('a');
+        final CharSeq seq = of('a');
         assertThat(seq.padTo(0, 'b')).isSameAs(seq);
     }
 
@@ -111,7 +111,7 @@ public class CharSeqTest {
 
     @Test
     public void shouldLeftPadNonEmptyZeroLen() {
-        CharSeq seq = of('a');
+        final CharSeq seq = of('a');
         assertThat(seq.leftPadTo(0, 'b')).isSameAs(seq);
     }
 
@@ -135,7 +135,7 @@ public class CharSeqTest {
 
     @Test
     public void shouldPatchEmptyByNonEmpty() {
-        Seq<Character> s = of('1', '2', '3');
+        final Seq<Character> s = of('1', '2', '3');
         assertThat(empty().patch(0, s, 0)).isEqualTo(s);
         assertThat(empty().patch(-1, s, -1)).isEqualTo(s);
         assertThat(empty().patch(-1, s, 1)).isEqualTo(s);
@@ -145,7 +145,7 @@ public class CharSeqTest {
 
     @Test
     public void shouldPatchNonEmptyByEmpty() {
-        Seq<Character> s = of('1', '2', '3');
+        final Seq<Character> s = of('1', '2', '3');
         assertThat(s.patch(-1, empty(), -1)).isEqualTo(of('1', '2', '3'));
         assertThat(s.patch(-1, empty(), 0)).isEqualTo(of('1', '2', '3'));
         assertThat(s.patch(-1, empty(), 1)).isEqualTo(of('2', '3'));
@@ -166,8 +166,8 @@ public class CharSeqTest {
 
     @Test
     public void shouldPatchNonEmptyByNonEmpty() {
-        Seq<Character> s = of('1', '2', '3');
-        Seq<Character> d = of('4', '5', '6');
+        final Seq<Character> s = of('1', '2', '3');
+        final Seq<Character> d = of('4', '5', '6');
         assertThat(s.patch(-1, d, -1)).isEqualTo(of('4', '5', '6', '1', '2', '3'));
         assertThat(s.patch(-1, d, 0)).isEqualTo(of('4', '5', '6', '1', '2', '3'));
         assertThat(s.patch(-1, d, 1)).isEqualTo(of('4', '5', '6', '2', '3'));
@@ -547,7 +547,7 @@ public class CharSeqTest {
 
     @Test
     public void shouldDropWhileNoneIfPredicateIsFalse() {
-        CharSeq t = of('1', '2', '3');
+        final CharSeq t = of('1', '2', '3');
         assertThat(t.dropWhile(ignored -> false)).isSameAs(t);
     }
 
@@ -748,20 +748,20 @@ public class CharSeqTest {
 
     @Test
     public void shouldNilGroupBy() {
-        assertThat(empty().groupBy(Function.identity())).isEqualTo(HashMap.empty());
+        assertThat(empty().groupBy(Function.identity())).isEqualTo(LinkedHashMap.empty());
     }
 
     @Test
     public void shouldNonNilGroupByIdentity() {
-        Map<?, ?> actual = of('a', 'b', 'c').groupBy(Function.identity());
-        Map<?, ?> expected = HashMap.empty().put('a', of('a')).put('b', of('b')).put('c', of('c'));
+        final Map<?, ?> actual = of('a', 'b', 'c').groupBy(Function.identity());
+        final Map<?, ?> expected = LinkedHashMap.empty().put('a', of('a')).put('b', of('b')).put('c', of('c'));
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldNonNilGroupByEqual() {
-        Map<?, ?> actual = of('a', 'b', 'c').groupBy(c -> 1);
-        Map<?, ?> expected = HashMap.empty().put(1, of('a', 'b', 'c'));
+        final Map<?, ?> actual = of('a', 'b', 'c').groupBy(c -> 1);
+        final Map<?, ?> expected = LinkedHashMap.empty().put(1, of('a', 'b', 'c'));
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -1278,7 +1278,7 @@ public class CharSeqTest {
 
     @Test
     public void shouldSpanNonNil() {
-        CharSeq cs = of('0', '1', '2', '3');
+        final CharSeq cs = of('0', '1', '2', '3');
         assertThat(cs.span(i -> i == '0' || i == '1'))
                 .isEqualTo(Tuple.of(of('0', '1'), of('2', '3')));
         assertThat(cs.span(i -> false))
@@ -1840,8 +1840,8 @@ public class CharSeqTest {
     public void shouldCalculateCrossProductOfNonNil() {
         final List<Tuple2<Character, Character>> actual = of('1', '2', '3').crossProduct().toList();
         final List<Tuple2<Character, Character>> expected = Iterator.of(Tuple.of('1', '1'), Tuple.of('1', '2'),
-                                                                        Tuple.of('1', '3'), Tuple.of('2', '1'), Tuple.of('2', '2'), Tuple.of('2', '3'), Tuple.of('3', '1'),
-                                                                        Tuple.of('3', '2'), Tuple.of('3', '3')).toList();
+                Tuple.of('1', '3'), Tuple.of('2', '1'), Tuple.of('2', '2'), Tuple.of('2', '3'), Tuple.of('3', '1'),
+                Tuple.of('3', '2'), Tuple.of('3', '3')).toList();
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -1883,7 +1883,7 @@ public class CharSeqTest {
                         .crossProduct(of('a', 'b'))
                         .toList();
         final List<Tuple2<Character, Character>> expected = Vector.of(Tuple.of('1', 'a'), Tuple.of('1', 'b'),
-                                                                      Tuple.of('2', 'a'), Tuple.of('2', 'b'), Tuple.of('3', 'a'), Tuple.of('3', 'b')).toList();
+                Tuple.of('2', 'a'), Tuple.of('2', 'b'), Tuple.of('3', 'a'), Tuple.of('3', 'b')).toList();
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -2243,7 +2243,7 @@ public class CharSeqTest {
     @Test
     public void shouldFullyIterateNonNilStartingAtIndex() {
         int actual = -1;
-        for (java.util.Iterator<Character> iter = of('1', '2', '3').iterator(1); iter.hasNext(); ) {
+        for (final java.util.Iterator<Character> iter = of('1', '2', '3').iterator(1); iter.hasNext(); ) {
             actual = iter.next();
         }
         assertThat(actual).isEqualTo('3');
@@ -2723,7 +2723,7 @@ public class CharSeqTest {
 
     @Test
     public void shouldTransform() {
-        String transformed = of('0').transform(v -> String.valueOf(v.get()));
+        final String transformed = of('0').transform(v -> String.valueOf(v.get()));
         assertThat(transformed).isEqualTo("0");
     }
 
@@ -3037,8 +3037,8 @@ public class CharSeqTest {
 
     @Test
     public void shouldWrapOtherCharSeq() {
-        CharSeq cs1 = of("123");
-        CharSeq cs2 = of(cs1);
+        final CharSeq cs1 = of("123");
+        final CharSeq cs2 = of(cs1);
         assertThat(cs1 == cs2).isTrue();
     }
 
@@ -3063,15 +3063,15 @@ public class CharSeqTest {
 
     @Test
     public void shouldTabulateTheCharSeq() {
-        Function<Number, Character> f = i -> i.toString().charAt(0);
-        CharSeq actual = tabulate(3, f);
+        final Function<Number, Character> f = i -> i.toString().charAt(0);
+        final CharSeq actual = tabulate(3, f);
         assertThat(actual).isEqualTo(of('0', '1', '2'));
     }
 
     @Test
     public void shouldTabulateTheCharSeqCallingTheFunctionInTheRightOrder() {
-        java.util.LinkedList<Character> chars = new java.util.LinkedList<>(Arrays.asList('0', '1', '2'));
-        CharSeq actual = tabulate(3, i -> chars.remove());
+        final java.util.LinkedList<Character> chars = new java.util.LinkedList<>(Arrays.asList('0', '1', '2'));
+        final CharSeq actual = tabulate(3, i -> chars.remove());
         assertThat(actual).isEqualTo(of('0', '1', '2'));
     }
 
@@ -3087,8 +3087,8 @@ public class CharSeqTest {
 
     @Test
     public void shouldFillTheCharSeqCallingTheSupplierInTheRightOrder() {
-        java.util.LinkedList<Character> chars = new java.util.LinkedList<>(Arrays.asList('0', '1'));
-        CharSeq actual = fill(2, () -> chars.remove());
+        final java.util.LinkedList<Character> chars = new java.util.LinkedList<>(Arrays.asList('0', '1'));
+        final CharSeq actual = fill(2, () -> chars.remove());
         assertThat(actual).isEqualTo(of('0', '1'));
     }
 
@@ -3122,10 +3122,10 @@ public class CharSeqTest {
     @Test
     public void shouldUnfoldRightSimpleCharSeq() {
         assertThat(
-            CharSeq.unfoldRight('j', x -> x == 'a'
-                                ? Option.none()
-                                : Option.of(new Tuple2<>(new Character(x), (char)(x-1)))))
-            .isEqualTo(of("jihgfedcb"));
+                CharSeq.unfoldRight('j', x -> x == 'a'
+                                              ? Option.none()
+                                              : Option.of(new Tuple2<>(new Character(x), (char) (x - 1)))))
+                .isEqualTo(of("jihgfedcb"));
     }
 
     @Test
@@ -3136,10 +3136,10 @@ public class CharSeqTest {
     @Test
     public void shouldUnfoldLeftSimpleCharSeq() {
         assertThat(
-            CharSeq.unfoldLeft('j', x -> x == 'a'
-                               ? Option.none()
-                               : Option.of(new Tuple2<>((char)(x-1), new Character(x)))))
-            .isEqualTo(of("bcdefghij"));
+                CharSeq.unfoldLeft('j', x -> x == 'a'
+                                             ? Option.none()
+                                             : Option.of(new Tuple2<>((char) (x - 1), new Character(x)))))
+                .isEqualTo(of("bcdefghij"));
     }
 
     @Test
@@ -3150,9 +3150,9 @@ public class CharSeqTest {
     @Test
     public void shouldUnfoldSimpleCharSeq() {
         assertThat(
-            CharSeq.unfold('j', x -> x == 'a'
-                           ? Option.none()
-                           : Option.of(new Tuple2<>((char)(x-1), new Character(x)))))
-            .isEqualTo(of("bcdefghij"));
+                CharSeq.unfold('j', x -> x == 'a'
+                                         ? Option.none()
+                                         : Option.of(new Tuple2<>((char) (x - 1), new Character(x)))))
+                .isEqualTo(of("bcdefghij"));
     }
 }


### PR DESCRIPTION
Separated it from https://github.com/javaslang/javaslang/pull/1398 upon the [request](https://github.com/javaslang/javaslang/pull/1398#discussion_r68176461) of @ruslansennov.

This way the output of the benchmarks will have has the same order as its definition, not random.