### PR TITLE
Unify collection indexing: `int` or `long`

### DIFF
--- a/javaslang-benchmark/pom.xml
+++ b/javaslang-benchmark/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.javaslang</groupId>
         <artifactId>javaslang-parent</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>javaslang-benchmark</artifactId>

--- a/javaslang-match/pom.xml
+++ b/javaslang-match/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.javaslang</groupId>
         <artifactId>javaslang-parent</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>javaslang-match</artifactId>

--- a/javaslang-pure/pom.xml
+++ b/javaslang-pure/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.javaslang</groupId>
         <artifactId>javaslang-parent</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>javaslang-pure</artifactId>

--- a/javaslang-test/pom.xml
+++ b/javaslang-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.javaslang</groupId>
         <artifactId>javaslang-parent</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>javaslang-test</artifactId>

--- a/javaslang/pom.xml
+++ b/javaslang/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.javaslang</groupId>
         <artifactId>javaslang-parent</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>javaslang</artifactId>

--- a/javaslang/src/main/java/javaslang/collection/AbstractMap.java
+++ b/javaslang/src/main/java/javaslang/collection/AbstractMap.java
@@ -5,10 +5,12 @@
  */
 package javaslang.collection;
 
-import javaslang.*;
+import javaslang.Tuple;
+import javaslang.Tuple2;
 import javaslang.control.Option;
 
-import java.util.*;
+import java.util.Comparator;
+import java.util.Objects;
 import java.util.function.*;
 
 /**
@@ -84,9 +86,9 @@ abstract class AbstractMap<K, V, M extends AbstractMap<K, V, M>> implements Map<
         return createFromEntries(iterator().distinctBy(keyExtractor));
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public M drop(long n) {
+    @SuppressWarnings("unchecked")
+    public M drop(int n) {
         if (n <= 0) {
             return (M) this;
         } else if (n >= length()) {
@@ -96,9 +98,9 @@ abstract class AbstractMap<K, V, M extends AbstractMap<K, V, M>> implements Map<
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public M dropRight(long n) {
+    @SuppressWarnings("unchecked")
+    public M dropRight(int n) {
         if (n <= 0) {
             return (M) this;
         } else if (n >= length()) {
@@ -169,7 +171,7 @@ abstract class AbstractMap<K, V, M extends AbstractMap<K, V, M>> implements Map<
     }
 
     @Override
-    public Iterator<M> grouped(long size) {
+    public Iterator<M> grouped(int size) {
         return sliding(size, size);
     }
 
@@ -191,7 +193,7 @@ abstract class AbstractMap<K, V, M extends AbstractMap<K, V, M>> implements Map<
 
     @SuppressWarnings("unchecked")
     @Override
-    public M take(long n) {
+    public M take(int n) {
         if (size() <= n) {
             return (M) this;
         } else {
@@ -201,7 +203,7 @@ abstract class AbstractMap<K, V, M extends AbstractMap<K, V, M>> implements Map<
 
     @SuppressWarnings("unchecked")
     @Override
-    public M takeRight(long n) {
+    public M takeRight(int n) {
         if (size() <= n) {
             return (M) this;
         } else {
@@ -292,12 +294,12 @@ abstract class AbstractMap<K, V, M extends AbstractMap<K, V, M>> implements Map<
     }
 
     @Override
-    public Iterator<M> sliding(long size) {
+    public Iterator<M> sliding(int size) {
         return sliding(size, 1);
     }
 
     @Override
-    public Iterator<M> sliding(long size, long step) {
+    public Iterator<M> sliding(int size, int step) {
         return iterator().sliding(size, step).map(this::createFromEntries);
     }
 

--- a/javaslang/src/main/java/javaslang/collection/AbstractMultimap.java
+++ b/javaslang/src/main/java/javaslang/collection/AbstractMultimap.java
@@ -5,11 +5,14 @@
  */
 package javaslang.collection;
 
-import javaslang.*;
+import javaslang.Tuple;
+import javaslang.Tuple2;
 import javaslang.control.Option;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Objects;
 import java.util.function.*;
 
 /**
@@ -178,9 +181,9 @@ abstract class AbstractMultimap<K, V, M extends Multimap<K, V>> implements Multi
         return createFromEntries(iterator().distinctBy(keyExtractor));
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public M drop(long n) {
+    @SuppressWarnings("unchecked")
+    public M drop(int n) {
         if (n <= 0) {
             return (M) this;
         } else if (n >= length()) {
@@ -190,9 +193,9 @@ abstract class AbstractMultimap<K, V, M extends Multimap<K, V>> implements Multi
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public M dropRight(long n) {
+    @SuppressWarnings("unchecked")
+    public M dropRight(int n) {
         if (n <= 0) {
             return (M) this;
         } else if (n >= length()) {
@@ -264,7 +267,7 @@ abstract class AbstractMultimap<K, V, M extends Multimap<K, V>> implements Multi
     }
 
     @Override
-    public Iterator<Multimap<K, V>> grouped(long size) {
+    public Iterator<Multimap<K, V>> grouped(int size) {
         return sliding(size, size);
     }
 
@@ -383,12 +386,12 @@ abstract class AbstractMultimap<K, V, M extends Multimap<K, V>> implements Multi
     }
 
     @Override
-    public Iterator<Multimap<K, V>> sliding(long size) {
+    public Iterator<Multimap<K, V>> sliding(int size) {
         return sliding(size, 1);
     }
 
     @Override
-    public Iterator<Multimap<K, V>> sliding(long size, long step) {
+    public Iterator<Multimap<K, V>> sliding(int size, int step) {
         return iterator().sliding(size, step).map(this::createFromEntries);
     }
 
@@ -409,15 +412,15 @@ abstract class AbstractMultimap<K, V, M extends Multimap<K, V>> implements Multi
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public M take(long n) {
+    @SuppressWarnings("unchecked")
+    public M take(int n) {
         return (M) (size() <= n ? this : createFromEntries(iterator().take(n)));
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public M takeRight(long n) {
+    @SuppressWarnings("unchecked")
+    public M takeRight(int n) {
         return (M) (size() <= n ? this : createFromEntries(iterator().takeRight(n)));
     }
 

--- a/javaslang/src/main/java/javaslang/collection/Array.java
+++ b/javaslang/src/main/java/javaslang/collection/Array.java
@@ -632,26 +632,26 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
     }
 
     @Override
-    public Array<T> drop(long n) {
+    public Array<T> drop(int n) {
         if (n <= 0) {
             return this;
         } else if (n >= length()) {
             return empty();
         } else {
-            final Object[] arr = new Object[back.length - (int) n];
-            System.arraycopy(back, (int) n, arr, 0, arr.length);
+            final Object[] arr = new Object[back.length - n];
+            System.arraycopy(back, n, arr, 0, arr.length);
             return wrap(arr);
         }
     }
 
     @Override
-    public Array<T> dropRight(long n) {
+    public Array<T> dropRight(int n) {
         if (n <= 0) {
             return this;
         } else if (n >= length()) {
             return empty();
         } else {
-            return wrap(Arrays.copyOf(back, back.length - (int) n));
+            return wrap(Arrays.copyOf(back, back.length - n));
         }
     }
 
@@ -712,7 +712,7 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
     }
 
     @Override
-    public Iterator<Array<T>> grouped(long size) {
+    public Iterator<Array<T>> grouped(int size) {
         return sliding(size, size);
     }
 
@@ -1062,27 +1062,27 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
     }
 
     @Override
-    public Array<T> slice(long beginIndex, long endIndex) {
+    public Array<T> slice(int beginIndex, int endIndex) {
         if (beginIndex >= endIndex || beginIndex >= length() || isEmpty()) {
             return empty();
         }
         if (beginIndex <= 0 && endIndex >= length()) {
             return this;
         }
-        final int index = Math.max((int) beginIndex, 0);
-        final int length = Math.min((int) endIndex, length()) - index;
+        final int index = Math.max(beginIndex, 0);
+        final int length = Math.min(endIndex, length()) - index;
         final Object[] arr = new Object[length];
         System.arraycopy(back, index, arr, 0, length);
         return wrap(arr);
     }
 
     @Override
-    public Iterator<Array<T>> sliding(long size) {
+    public Iterator<Array<T>> sliding(int size) {
         return sliding(size, 1);
     }
 
     @Override
-    public Iterator<Array<T>> sliding(long size, long step) {
+    public Iterator<Array<T>> sliding(int size, int step) {
         return iterator().sliding(size, step).map(Array::ofAll);
     }
 
@@ -1115,7 +1115,7 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
     }
 
     @Override
-    public Tuple2<Array<T>, Array<T>> splitAt(long n) {
+    public Tuple2<Array<T>, Array<T>> splitAt(int n) {
         return Tuple.of(take(n), drop(n));
     }
 
@@ -1194,25 +1194,25 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
     }
 
     @Override
-    public Array<T> take(long n) {
+    public Array<T> take(int n) {
         if (n >= length()) {
             return this;
         } else if (n <= 0) {
             return empty();
         } else {
-            return wrap(Arrays.copyOf(back, (int) n));
+            return wrap(Arrays.copyOf(back, n));
         }
     }
 
     @Override
-    public Array<T> takeRight(long n) {
+    public Array<T> takeRight(int n) {
         if (n >= length()) {
             return this;
         } else if (n <= 0) {
             return empty();
         } else {
-            final Object[] arr = new Object[(int) n];
-            System.arraycopy(back, back.length - (int) n, arr, 0, (int) n);
+            final Object[] arr = new Object[n];
+            System.arraycopy(back, back.length - n, arr, 0, n);
             return wrap(arr);
         }
     }
@@ -1322,12 +1322,12 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
     }
 
     @Override
-    public Array<Tuple2<T, Long>> zipWithIndex() {
+    public Array<Tuple2<T, Integer>> zipWithIndex() {
         return ofAll(iterator().zipWithIndex());
     }
 
     @Override
-    public <U> Array<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper) {
+    public <U> Array<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return ofAll(iterator().zipWithIndex(mapper));
     }

--- a/javaslang/src/main/java/javaslang/collection/BitSet.java
+++ b/javaslang/src/main/java/javaslang/collection/BitSet.java
@@ -5,11 +5,15 @@
  */
 package javaslang.collection;
 
-import javaslang.*;
+import javaslang.Tuple2;
+import javaslang.Tuple3;
 import javaslang.control.Option;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.function.*;
 import java.util.stream.Collector;
 
@@ -366,10 +370,10 @@ public interface BitSet<T> extends SortedSet<T> {
     <U> BitSet<T> distinctBy(Function<? super T, ? extends U> keyExtractor);
 
     @Override
-    BitSet<T> drop(long n);
+    BitSet<T> drop(int n);
 
     @Override
-    BitSet<T> dropRight(long n);
+    BitSet<T> dropRight(int n);
 
     @Override
     default BitSet<T> dropUntil(Predicate<? super T> predicate) {
@@ -404,7 +408,7 @@ public interface BitSet<T> extends SortedSet<T> {
     <C> Map<C, BitSet<T>> groupBy(Function<? super T, ? extends C> classifier);
 
     @Override
-    default Iterator<BitSet<T>> grouped(long size) {
+    default Iterator<BitSet<T>> grouped(int size) {
         return sliding(size, size);
     }
 
@@ -503,12 +507,12 @@ public interface BitSet<T> extends SortedSet<T> {
     }
 
     @Override
-    default Iterator<BitSet<T>> sliding(long size) {
+    default Iterator<BitSet<T>> sliding(int size) {
         return sliding(size, 1);
     }
 
     @Override
-    Iterator<BitSet<T>> sliding(long size, long step);
+    Iterator<BitSet<T>> sliding(int size, int step);
 
     @Override
     Tuple2<BitSet<T>, BitSet<T>> span(Predicate<? super T> predicate);
@@ -528,10 +532,10 @@ public interface BitSet<T> extends SortedSet<T> {
     }
 
     @Override
-    BitSet<T> take(long n);
+    BitSet<T> take(int n);
 
     @Override
-    BitSet<T> takeRight(long n);
+    BitSet<T> takeRight(int n);
 
     @Override
     default BitSet<T> takeUntil(Predicate<? super T> predicate) {
@@ -593,14 +597,14 @@ public interface BitSet<T> extends SortedSet<T> {
     }
 
     @Override
-    default TreeSet<Tuple2<T, Long>> zipWithIndex() {
+    default TreeSet<Tuple2<T, Integer>> zipWithIndex() {
         final Comparator<? super T> component1Comparator = comparator();
-        final Comparator<Tuple2<T, Long>> tuple2Comparator = (t1, t2) -> component1Comparator.compare(t1._1, t2._1);
+        final Comparator<Tuple2<T, Integer>> tuple2Comparator = (t1, t2) -> component1Comparator.compare(t1._1, t2._1);
         return TreeSet.ofAll(tuple2Comparator, iterator().zipWithIndex());
     }
 
     @Override
-    default <U> TreeSet<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper) {
+    default <U> TreeSet<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return TreeSet.ofAll(naturalComparator(), iterator().zipWithIndex(mapper));
     }
@@ -689,7 +693,7 @@ interface BitSetModule {
         }
 
         @Override
-        public BitSet<T> drop(long n) {
+        public BitSet<T> drop(int n) {
             if (n <= 0) {
                 return this;
             } else if (n >= length()) {
@@ -700,7 +704,7 @@ interface BitSetModule {
         }
 
         @Override
-        public BitSet<T> dropRight(long n) {
+        public BitSet<T> dropRight(int n) {
             if (n <= 0) {
                 return this;
             } else if (n >= length()) {
@@ -734,7 +738,7 @@ interface BitSetModule {
         }
 
         @Override
-        public Iterator<BitSet<T>> sliding(long size, long step) {
+        public Iterator<BitSet<T>> sliding(int size, int step) {
             return iterator().sliding(size, step).map(this::createFromAll);
         }
 
@@ -824,7 +828,7 @@ interface BitSetModule {
         }
 
         @Override
-        public BitSet<T> take(long n) {
+        public BitSet<T> take(int n) {
             if (n <= 0) {
                 return createEmpty();
             } else if (n >= length()) {
@@ -835,7 +839,7 @@ interface BitSetModule {
         }
 
         @Override
-        public BitSet<T> takeRight(long n) {
+        public BitSet<T> takeRight(int n) {
             if (n <= 0) {
                 return createEmpty();
             } else if (n >= length()) {

--- a/javaslang/src/main/java/javaslang/collection/CharSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/CharSeq.java
@@ -9,11 +9,13 @@ import javaslang.*;
 import javaslang.collection.CharSeqModule.Combinations;
 import javaslang.control.Option;
 
-import java.io.*;
+import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.*;
 import java.util.function.*;
-import java.util.regex.*;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collector;
 
 /**
@@ -392,24 +394,24 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
     }
 
     @Override
-    public CharSeq drop(long n) {
+    public CharSeq drop(int n) {
         if (n <= 0) {
             return this;
         } else if (n >= length()) {
             return EMPTY;
         } else {
-            return of(back.substring((int) n));
+            return of(back.substring(n));
         }
     }
 
     @Override
-    public CharSeq dropRight(long n) {
+    public CharSeq dropRight(int n) {
         if (n <= 0) {
             return this;
         } else if (n >= length()) {
             return EMPTY;
         } else {
-            return of(back.substring(0, length() - (int) n));
+            return of(back.substring(0, length() - n));
         }
     }
 
@@ -483,7 +485,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
     }
 
     @Override
-    public Iterator<CharSeq> grouped(long size) {
+    public Iterator<CharSeq> grouped(int size) {
         return sliding(size, size);
     }
 
@@ -810,25 +812,25 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
     }
 
     @Override
-    public CharSeq slice(long beginIndex, long endIndex) {
-        final long from = beginIndex < 0 ? 0 : beginIndex;
-        final long to = endIndex > length() ? length() : endIndex;
+    public CharSeq slice(int beginIndex, int endIndex) {
+        final int from = beginIndex < 0 ? 0 : beginIndex;
+        final int to = endIndex > length() ? length() : endIndex;
         if (from >= to) {
             return EMPTY;
         }
         if (from <= 0 && to >= length()) {
             return this;
         }
-        return CharSeq.of(back.substring((int) from, (int) to));
+        return CharSeq.of(back.substring(from, to));
     }
 
     @Override
-    public Iterator<CharSeq> sliding(long size) {
+    public Iterator<CharSeq> sliding(int size) {
         return sliding(size, 1);
     }
 
     @Override
-    public Iterator<CharSeq> sliding(long size, long step) {
+    public Iterator<CharSeq> sliding(int size, int step) {
         return iterator().sliding(size, step).map(CharSeq::ofAll);
     }
 
@@ -905,24 +907,24 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
     }
 
     @Override
-    public CharSeq take(long n) {
+    public CharSeq take(int n) {
         if (n <= 0) {
             return EMPTY;
         } else if (n >= length()) {
             return this;
         } else {
-            return CharSeq.of(back.substring(0, (int) n));
+            return CharSeq.of(back.substring(0, n));
         }
     }
 
     @Override
-    public CharSeq takeRight(long n) {
+    public CharSeq takeRight(int n) {
         if (n <= 0) {
             return EMPTY;
         } else if (n >= length()) {
             return this;
         } else {
-            return CharSeq.of(back.substring(length() - (int) n));
+            return CharSeq.of(back.substring(length() - n));
         }
     }
 
@@ -1038,16 +1040,16 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
     }
 
     @Override
-    public IndexedSeq<Tuple2<Character, Long>> zipWithIndex() {
+    public IndexedSeq<Tuple2<Character, Integer>> zipWithIndex() {
         return zipWithIndex(Tuple::of);
     }
 
     @Override
-    public <U> IndexedSeq<U> zipWithIndex(BiFunction<? super Character, ? super Long, ? extends U> mapper) {
+    public <U> IndexedSeq<U> zipWithIndex(BiFunction<? super Character, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         IndexedSeq<U> result = Vector.empty();
         for (int i = 0; i < length(); i++) {
-            result = result.append(mapper.apply(get(i), (long) i));
+            result = result.append(mapper.apply(get(i), i));
         }
         return result;
     }
@@ -1068,13 +1070,13 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
     }
 
     @Override
-    public Tuple2<CharSeq, CharSeq> splitAt(long n) {
+    public Tuple2<CharSeq, CharSeq> splitAt(int n) {
         if (n <= 0) {
             return Tuple.of(EMPTY, this);
         } else if (n >= length()) {
             return Tuple.of(this, EMPTY);
         } else {
-            return Tuple.of(of(back.substring(0, (int) n)), of(back.substring((int) n)));
+            return Tuple.of(of(back.substring(0, n)), of(back.substring(n)));
         }
     }
 

--- a/javaslang/src/main/java/javaslang/collection/HashSet.java
+++ b/javaslang/src/main/java/javaslang/collection/HashSet.java
@@ -5,11 +5,17 @@
  */
 package javaslang.collection;
 
-import javaslang.*;
+import javaslang.Kind1;
+import javaslang.Tuple;
+import javaslang.Tuple2;
+import javaslang.Tuple3;
 import javaslang.control.Option;
 
 import java.io.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.function.*;
 import java.util.stream.Collector;
 
@@ -506,7 +512,7 @@ public final class HashSet<T> implements Kind1<HashSet<?>, T>, Set<T>, Serializa
     }
 
     @Override
-    public HashSet<T> drop(long n) {
+    public HashSet<T> drop(int n) {
         if (n <= 0) {
             return this;
         } else {
@@ -515,7 +521,7 @@ public final class HashSet<T> implements Kind1<HashSet<?>, T>, Set<T>, Serializa
     }
 
     @Override
-    public HashSet<T> dropRight(long n) {
+    public HashSet<T> dropRight(int n) {
         return drop(n);
     }
 
@@ -569,7 +575,7 @@ public final class HashSet<T> implements Kind1<HashSet<?>, T>, Set<T>, Serializa
     }
 
     @Override
-    public Iterator<HashSet<T>> grouped(long size) {
+    public Iterator<HashSet<T>> grouped(int size) {
         return sliding(size, size);
     }
 
@@ -723,12 +729,12 @@ public final class HashSet<T> implements Kind1<HashSet<?>, T>, Set<T>, Serializa
     }
 
     @Override
-    public Iterator<HashSet<T>> sliding(long size) {
+    public Iterator<HashSet<T>> sliding(int size) {
         return sliding(size, 1);
     }
 
     @Override
-    public Iterator<HashSet<T>> sliding(long size, long step) {
+    public Iterator<HashSet<T>> sliding(int size, int step) {
         return iterator().sliding(size, step).map(HashSet::ofAll);
     }
 
@@ -757,7 +763,7 @@ public final class HashSet<T> implements Kind1<HashSet<?>, T>, Set<T>, Serializa
     }
 
     @Override
-    public HashSet<T> take(long n) {
+    public HashSet<T> take(int n) {
         if (tree.size() <= n) {
             return this;
         }
@@ -765,7 +771,7 @@ public final class HashSet<T> implements Kind1<HashSet<?>, T>, Set<T>, Serializa
     }
 
     @Override
-    public HashSet<T> takeRight(long n) {
+    public HashSet<T> takeRight(int n) {
         return take(n);
     }
 
@@ -857,12 +863,12 @@ public final class HashSet<T> implements Kind1<HashSet<?>, T>, Set<T>, Serializa
     }
 
     @Override
-    public HashSet<Tuple2<T, Long>> zipWithIndex() {
+    public HashSet<Tuple2<T, Integer>> zipWithIndex() {
         return zipWithIndex(Tuple::of);
     }
 
     @Override
-    public <U> HashSet<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper) {
+    public <U> HashSet<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return HashSet.ofAll(iterator().zipWithIndex(mapper));
     }

--- a/javaslang/src/main/java/javaslang/collection/IndexedSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/IndexedSeq.java
@@ -12,11 +12,7 @@ import javaslang.control.Option;
 import java.util.Comparator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.IntUnaryOperator;
-import java.util.function.Predicate;
+import java.util.function.*;
 
 /**
  * Interface for immutable, indexed sequences.
@@ -72,10 +68,10 @@ public interface IndexedSeq<T> extends Seq<T> {
     <U> IndexedSeq<T> distinctBy(Function<? super T, ? extends U> keyExtractor);
 
     @Override
-    IndexedSeq<T> drop(long n);
+    IndexedSeq<T> drop(int n);
 
     @Override
-    IndexedSeq<T> dropRight(long n);
+    IndexedSeq<T> dropRight(int n);
 
     @Override
     IndexedSeq<T> dropUntil(Predicate<? super T> predicate);
@@ -124,7 +120,7 @@ public interface IndexedSeq<T> extends Seq<T> {
     }
 
     @Override
-    Iterator<? extends IndexedSeq<T>> grouped(long size);
+    Iterator<? extends IndexedSeq<T>> grouped(int size);
 
     @Override
     IndexedSeq<T> init();
@@ -260,13 +256,13 @@ public interface IndexedSeq<T> extends Seq<T> {
     }
 
     @Override
-    IndexedSeq<T> slice(long beginIndex, long endIndex);
+    IndexedSeq<T> slice(int beginIndex, int endIndex);
 
     @Override
-    Iterator<? extends IndexedSeq<T>> sliding(long size);
+    Iterator<? extends IndexedSeq<T>> sliding(int size);
 
     @Override
-    Iterator<? extends IndexedSeq<T>> sliding(long size, long step);
+    Iterator<? extends IndexedSeq<T>> sliding(int size, int step);
 
     @Override
     IndexedSeq<T> sorted();
@@ -325,10 +321,10 @@ public interface IndexedSeq<T> extends Seq<T> {
     Option<? extends IndexedSeq<T>> tailOption();
 
     @Override
-    IndexedSeq<T> take(long n);
+    IndexedSeq<T> take(int n);
 
     @Override
-    IndexedSeq<T> takeRight(long n);
+    IndexedSeq<T> takeRight(int n);
 
     @Override
     IndexedSeq<T> takeUntil(Predicate<? super T> predicate);
@@ -358,10 +354,10 @@ public interface IndexedSeq<T> extends Seq<T> {
     <U> IndexedSeq<Tuple2<T, U>> zipAll(Iterable<? extends U> that, T thisElem, U thatElem);
 
     @Override
-    IndexedSeq<Tuple2<T, Long>> zipWithIndex();
+    IndexedSeq<Tuple2<T, Integer>> zipWithIndex();
 
     @Override
-    <U> IndexedSeq<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper);
+    <U> IndexedSeq<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper);
 
     /**
      * Searches this sequence for a specific element using a binary search. The sequence must already be sorted into

--- a/javaslang/src/main/java/javaslang/collection/Iterator.java
+++ b/javaslang/src/main/java/javaslang/collection/Iterator.java
@@ -5,17 +5,23 @@
  */
 package javaslang.collection;
 
-import javaslang.*;
-import javaslang.collection.IteratorModule.*;
+import javaslang.Lazy;
+import javaslang.Tuple;
+import javaslang.Tuple2;
+import javaslang.Tuple3;
+import javaslang.collection.IteratorModule.ConcatIterator;
+import javaslang.collection.IteratorModule.DistinctIterator;
 import javaslang.control.Option;
 
 import java.math.BigDecimal;
 import java.util.*;
 import java.util.function.*;
 
-import static java.lang.Double.*;
+import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.POSITIVE_INFINITY;
 import static java.math.RoundingMode.HALF_UP;
-import static javaslang.collection.IteratorModule.BigDecimalHelper.*;
+import static javaslang.collection.IteratorModule.BigDecimalHelper.areEqual;
+import static javaslang.collection.IteratorModule.BigDecimalHelper.asDecimal;
 
 /**
  * {@code javaslang.collection.Iterator} is a compositional replacement for {@code java.util.Iterator}
@@ -1122,19 +1128,19 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
     }
 
     @Override
-    default Iterator<Tuple2<T, Long>> zipWithIndex() {
+    default Iterator<Tuple2<T, Integer>> zipWithIndex() {
         return zipWithIndex(Tuple::of);
     }
 
     @Override
-    default <U> Iterator<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper) {
+    default <U> Iterator<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (isEmpty()) {
             return empty();
         } else {
             final Iterator<T> it1 = this;
             return new AbstractIterator<U>() {
-                private long index = 0;
+                private int index = 0;
 
                 @Override
                 public boolean hasNext() {
@@ -1309,7 +1315,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
      * @return The empty iterator, if {@code n <= 0} or this is empty, otherwise a new iterator without the first n elements.
      */
     @Override
-    default Iterator<T> drop(long n) {
+    default Iterator<T> drop(int n) {
         if (n <= 0) {
             return this;
         } else if (!hasNext()) {
@@ -1338,7 +1344,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
     }
 
     @Override
-    default Iterator<T> dropRight(long n) {
+    default Iterator<T> dropRight(int n) {
         if (n <= 0) {
             return this;
         } else if (!hasNext()) {
@@ -1508,7 +1514,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
     }
 
     @Override
-    default Iterator<Seq<T>> grouped(long size) {
+    default Iterator<Seq<T>> grouped(int size) {
         return sliding(size, size);
     }
 
@@ -1753,12 +1759,12 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
     }
 
     @Override
-    default Iterator<Seq<T>> sliding(long size) {
+    default Iterator<Seq<T>> sliding(int size) {
         return sliding(size, 1);
     }
 
     @Override
-    default Iterator<Seq<T>> sliding(long size, long step) {
+    default Iterator<Seq<T>> sliding(int size, int step) {
         if (size <= 0 || step <= 0) {
             throw new IllegalArgumentException("size: " + size + " or step: " + step + " not positive");
         }
@@ -1841,7 +1847,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
      * @return The empty iterator, if {@code n <= 0} or this is empty, otherwise a new iterator without the first n elements.
      */
     @Override
-    default Iterator<T> take(long n) {
+    default Iterator<T> take(int n) {
         if (n <= 0 || !hasNext()) {
             return empty();
         } else {
@@ -1865,7 +1871,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
     }
 
     @Override
-    default Iterator<T> takeRight(long n) {
+    default Iterator<T> takeRight(int n) {
         if (n <= 0) {
             return empty();
         } else {

--- a/javaslang/src/main/java/javaslang/collection/LinearSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/LinearSeq.java
@@ -11,11 +11,7 @@ import javaslang.control.Option;
 
 import java.util.Comparator;
 import java.util.Objects;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.function.ToIntFunction;
+import java.util.function.*;
 
 /**
  * Interface for immutable, linear sequences.
@@ -71,10 +67,10 @@ public interface LinearSeq<T> extends Seq<T> {
     <U> LinearSeq<T> distinctBy(Function<? super T, ? extends U> keyExtractor);
 
     @Override
-    LinearSeq<T> drop(long n);
+    LinearSeq<T> drop(int n);
 
     @Override
-    LinearSeq<T> dropRight(long n);
+    LinearSeq<T> dropRight(int n);
 
     @Override
     LinearSeq<T> dropUntil(Predicate<? super T> predicate);
@@ -92,7 +88,7 @@ public interface LinearSeq<T> extends Seq<T> {
     <C> Map<C, ? extends LinearSeq<T>> groupBy(Function<? super T, ? extends C> classifier);
 
     @Override
-    Iterator<? extends LinearSeq<T>> grouped(long size);
+    Iterator<? extends LinearSeq<T>> grouped(int size);
 
     @Override
     default int indexWhere(Predicate<? super T> predicate, int from) {
@@ -229,13 +225,13 @@ public interface LinearSeq<T> extends Seq<T> {
     }
 
     @Override
-    LinearSeq<T> slice(long beginIndex, long endIndex);
+    LinearSeq<T> slice(int beginIndex, int endIndex);
 
     @Override
-    Iterator<? extends LinearSeq<T>> sliding(long size);
+    Iterator<? extends LinearSeq<T>> sliding(int size);
 
     @Override
-    Iterator<? extends LinearSeq<T>> sliding(long size, long step);
+    Iterator<? extends LinearSeq<T>> sliding(int size, int step);
 
     @Override
     LinearSeq<T> sorted();
@@ -265,10 +261,10 @@ public interface LinearSeq<T> extends Seq<T> {
     Option<? extends LinearSeq<T>> tailOption();
 
     @Override
-    LinearSeq<T> take(long n);
+    LinearSeq<T> take(int n);
 
     @Override
-    LinearSeq<T> takeRight(long n);
+    LinearSeq<T> takeRight(int n);
 
     @Override
     LinearSeq<T> takeUntil(Predicate<? super T> predicate);
@@ -295,10 +291,10 @@ public interface LinearSeq<T> extends Seq<T> {
     <U> LinearSeq<Tuple2<T, U>> zipAll(Iterable<? extends U> that, T thisElem, U thatElem);
 
     @Override
-    LinearSeq<Tuple2<T, Long>> zipWithIndex();
+    LinearSeq<Tuple2<T, Integer>> zipWithIndex();
 
     @Override
-    <U> LinearSeq<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper);
+    <U> LinearSeq<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper);
 
     /**
      * Searches this sequence for a specific element using a linear search. The sequence must already be sorted into

--- a/javaslang/src/main/java/javaslang/collection/LinkedHashSet.java
+++ b/javaslang/src/main/java/javaslang/collection/LinkedHashSet.java
@@ -5,11 +5,17 @@
  */
 package javaslang.collection;
 
-import javaslang.*;
+import javaslang.Kind1;
+import javaslang.Tuple;
+import javaslang.Tuple2;
+import javaslang.Tuple3;
 import javaslang.control.Option;
 
 import java.io.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.function.*;
 import java.util.stream.Collector;
 
@@ -504,7 +510,7 @@ public final class LinkedHashSet<T> implements Kind1<LinkedHashSet<?>, T>, Set<T
     }
 
     @Override
-    public LinkedHashSet<T> drop(long n) {
+    public LinkedHashSet<T> drop(int n) {
         if (n <= 0) {
             return this;
         } else {
@@ -513,7 +519,7 @@ public final class LinkedHashSet<T> implements Kind1<LinkedHashSet<?>, T>, Set<T
     }
 
     @Override
-    public LinkedHashSet<T> dropRight(long n) {
+    public LinkedHashSet<T> dropRight(int n) {
         if (n <= 0) {
             return this;
         } else {
@@ -565,7 +571,7 @@ public final class LinkedHashSet<T> implements Kind1<LinkedHashSet<?>, T>, Set<T
     }
 
     @Override
-    public Iterator<LinkedHashSet<T>> grouped(long size) {
+    public Iterator<LinkedHashSet<T>> grouped(int size) {
         return sliding(size, size);
     }
 
@@ -718,12 +724,12 @@ public final class LinkedHashSet<T> implements Kind1<LinkedHashSet<?>, T>, Set<T
     }
 
     @Override
-    public Iterator<LinkedHashSet<T>> sliding(long size) {
+    public Iterator<LinkedHashSet<T>> sliding(int size) {
         return sliding(size, 1);
     }
 
     @Override
-    public Iterator<LinkedHashSet<T>> sliding(long size, long step) {
+    public Iterator<LinkedHashSet<T>> sliding(int size, int step) {
         return iterator().sliding(size, step).map(LinkedHashSet::ofAll);
     }
 
@@ -748,7 +754,7 @@ public final class LinkedHashSet<T> implements Kind1<LinkedHashSet<?>, T>, Set<T
     }
 
     @Override
-    public LinkedHashSet<T> take(long n) {
+    public LinkedHashSet<T> take(int n) {
         if (map.size() <= n) {
             return this;
         }
@@ -756,7 +762,7 @@ public final class LinkedHashSet<T> implements Kind1<LinkedHashSet<?>, T>, Set<T
     }
 
     @Override
-    public LinkedHashSet<T> takeRight(long n) {
+    public LinkedHashSet<T> takeRight(int n) {
         if (map.size() <= n) {
             return this;
         }
@@ -851,12 +857,12 @@ public final class LinkedHashSet<T> implements Kind1<LinkedHashSet<?>, T>, Set<T
     }
 
     @Override
-    public LinkedHashSet<Tuple2<T, Long>> zipWithIndex() {
+    public LinkedHashSet<Tuple2<T, Integer>> zipWithIndex() {
         return zipWithIndex(Tuple::of);
     }
 
     @Override
-    public <U> LinkedHashSet<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper) {
+    public <U> LinkedHashSet<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return LinkedHashSet.ofAll(iterator().zipWithIndex(mapper));
     }

--- a/javaslang/src/main/java/javaslang/collection/List.java
+++ b/javaslang/src/main/java/javaslang/collection/List.java
@@ -7,7 +7,8 @@ package javaslang.collection;
 
 import javaslang.*;
 import javaslang.collection.List.Nil;
-import javaslang.collection.ListModule.*;
+import javaslang.collection.ListModule.Combinations;
+import javaslang.collection.ListModule.SplitAt;
 import javaslang.control.Option;
 
 import java.io.*;
@@ -684,7 +685,7 @@ public interface List<T> extends Kind1<List<?>, T>, LinearSeq<T>, Stack<T> {
     }
 
     @Override
-    default List<T> drop(long n) {
+    default List<T> drop(int n) {
         List<T> list = this;
         for (long i = n; i > 0 && !list.isEmpty(); i--) {
             list = list.tail();
@@ -693,7 +694,7 @@ public interface List<T> extends Kind1<List<?>, T>, LinearSeq<T>, Stack<T> {
     }
 
     @Override
-    default List<T> dropRight(long n) {
+    default List<T> dropRight(int n) {
         if (n <= 0) {
             return this;
         }
@@ -773,7 +774,7 @@ public interface List<T> extends Kind1<List<?>, T>, LinearSeq<T>, Stack<T> {
     }
 
     @Override
-    default Iterator<List<T>> grouped(long size) {
+    default Iterator<List<T>> grouped(int size) {
         return sliding(size, size);
     }
 
@@ -1182,7 +1183,7 @@ public interface List<T> extends Kind1<List<?>, T>, LinearSeq<T>, Stack<T> {
     }
 
     @Override
-    default List<T> slice(long beginIndex, long endIndex) {
+    default List<T> slice(int beginIndex, int endIndex) {
         if (beginIndex >= endIndex || beginIndex >= length() || isEmpty()) {
             return empty();
         } else {
@@ -1201,12 +1202,12 @@ public interface List<T> extends Kind1<List<?>, T>, LinearSeq<T>, Stack<T> {
     }
 
     @Override
-    default Iterator<List<T>> sliding(long size) {
+    default Iterator<List<T>> sliding(int size) {
         return sliding(size, 1);
     }
 
     @Override
-    default Iterator<List<T>> sliding(long size, long step) {
+    default Iterator<List<T>> sliding(int size, int step) {
         return iterator().sliding(size, step).map(List::ofAll);
     }
 
@@ -1242,7 +1243,7 @@ public interface List<T> extends Kind1<List<?>, T>, LinearSeq<T>, Stack<T> {
     }
 
     @Override
-    default Tuple2<List<T>, List<T>> splitAt(long n) {
+    default Tuple2<List<T>, List<T>> splitAt(int n) {
         if (isEmpty()) {
             return Tuple.of(empty(), empty());
         } else {
@@ -1336,7 +1337,7 @@ public interface List<T> extends Kind1<List<?>, T>, LinearSeq<T>, Stack<T> {
     }
 
     @Override
-    default List<T> take(long n) {
+    default List<T> take(int n) {
         if (n >= length()) {
             return this;
         }
@@ -1352,7 +1353,7 @@ public interface List<T> extends Kind1<List<?>, T>, LinearSeq<T>, Stack<T> {
     }
 
     @Override
-    default List<T> takeRight(long n) {
+    default List<T> takeRight(int n) {
         if (n >= length()) {
             return this;
         }
@@ -1472,12 +1473,12 @@ public interface List<T> extends Kind1<List<?>, T>, LinearSeq<T>, Stack<T> {
     }
 
     @Override
-    default List<Tuple2<T, Long>> zipWithIndex() {
+    default List<Tuple2<T, Integer>> zipWithIndex() {
         return zipWithIndex(Tuple::of);
     }
 
     @Override
-    default <U> List<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper) {
+    default <U> List<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return ofAll(iterator().zipWithIndex(mapper));
     }

--- a/javaslang/src/main/java/javaslang/collection/Map.java
+++ b/javaslang/src/main/java/javaslang/collection/Map.java
@@ -299,10 +299,10 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
     <U> Map<K, V> distinctBy(Function<? super Tuple2<K, V>, ? extends U> keyExtractor);
 
     @Override
-    Map<K, V> drop(long n);
+    Map<K, V> drop(int n);
 
     @Override
-    Map<K, V> dropRight(long n);
+    Map<K, V> dropRight(int n);
 
     @Override
     Map<K, V> dropUntil(Predicate<? super Tuple2<K, V>> predicate);
@@ -394,7 +394,7 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
     <C> Map<C, ? extends Map<K, V>> groupBy(Function<? super Tuple2<K, V>, ? extends C> classifier);
 
     @Override
-    Iterator<? extends Map<K, V>> grouped(long size);
+    Iterator<? extends Map<K, V>> grouped(int size);
 
     @Override
     default boolean hasDefiniteSize() {
@@ -504,10 +504,10 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
     }
 
     @Override
-    Iterator<? extends Map<K, V>> sliding(long size);
+    Iterator<? extends Map<K, V>> sliding(int size);
 
     @Override
-    Iterator<? extends Map<K, V>> sliding(long size, long step);
+    Iterator<? extends Map<K, V>> sliding(int size, int step);
 
     @Override
     Tuple2<? extends Map<K, V>, ? extends Map<K, V>> span(Predicate<? super Tuple2<K, V>> predicate);
@@ -524,10 +524,10 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
     Option<? extends Map<K, V>> tailOption();
 
     @Override
-    Map<K, V> take(long n);
+    Map<K, V> take(int n);
 
     @Override
-    Map<K, V> takeRight(long n);
+    Map<K, V> takeRight(int n);
 
     @Override
     Map<K, V> takeUntil(Predicate<? super Tuple2<K, V>> predicate);
@@ -567,12 +567,12 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
     }
 
     @Override
-    default Seq<Tuple2<Tuple2<K, V>, Long>> zipWithIndex() {
+    default Seq<Tuple2<Tuple2<K, V>, Integer>> zipWithIndex() {
         return zipWithIndex(Tuple::of);
     }
 
     @Override
-    default <U> Seq<U> zipWithIndex(BiFunction<? super Tuple2<K, V>, ? super Long, ? extends U> mapper) {
+    default <U> Seq<U> zipWithIndex(BiFunction<? super Tuple2<K, V>, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return Stream.ofAll(iterator().zipWithIndex(mapper));
     }

--- a/javaslang/src/main/java/javaslang/collection/Multimap.java
+++ b/javaslang/src/main/java/javaslang/collection/Multimap.java
@@ -251,10 +251,10 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
     <U> Multimap<K, V> distinctBy(Function<? super Tuple2<K, V>, ? extends U> keyExtractor);
 
     @Override
-    Multimap<K, V> drop(long n);
+    Multimap<K, V> drop(int n);
 
     @Override
-    Multimap<K, V> dropRight(long n);
+    Multimap<K, V> dropRight(int n);
 
     @Override
     Multimap<K, V> dropUntil(Predicate<? super Tuple2<K, V>> predicate);
@@ -346,7 +346,7 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
     <C> Map<C, ? extends Multimap<K, V>> groupBy(Function<? super Tuple2<K, V>, ? extends C> classifier);
 
     @Override
-    Iterator<? extends Multimap<K, V>> grouped(long size);
+    Iterator<? extends Multimap<K, V>> grouped(int size);
 
     @Override
     default boolean hasDefiniteSize() {
@@ -448,10 +448,10 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
     }
 
     @Override
-    Iterator<? extends Multimap<K, V>> sliding(long size);
+    Iterator<? extends Multimap<K, V>> sliding(int size);
 
     @Override
-    Iterator<? extends Multimap<K, V>> sliding(long size, long step);
+    Iterator<? extends Multimap<K, V>> sliding(int size, int step);
 
     @Override
     Tuple2<? extends Multimap<K, V>, ? extends Multimap<K, V>> span(Predicate<? super Tuple2<K, V>> predicate);
@@ -468,10 +468,10 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
     Option<? extends Multimap<K, V>> tailOption();
 
     @Override
-    Multimap<K, V> take(long n);
+    Multimap<K, V> take(int n);
 
     @Override
-    Multimap<K, V> takeRight(long n);
+    Multimap<K, V> takeRight(int n);
 
     @Override
     Multimap<K, V> takeUntil(Predicate<? super Tuple2<K, V>> predicate);
@@ -511,12 +511,12 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
     }
 
     @Override
-    default Seq<Tuple2<Tuple2<K, V>, Long>> zipWithIndex() {
+    default Seq<Tuple2<Tuple2<K, V>, Integer>> zipWithIndex() {
         return zipWithIndex(Tuple::of);
     }
 
     @Override
-    default <U> Seq<U> zipWithIndex(BiFunction<? super Tuple2<K, V>, ? super Long, ? extends U> mapper) {
+    default <U> Seq<U> zipWithIndex(BiFunction<? super Tuple2<K, V>, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return Stream.ofAll(iterator().zipWithIndex(mapper));
     }

--- a/javaslang/src/main/java/javaslang/collection/PriorityQueue.java
+++ b/javaslang/src/main/java/javaslang/collection/PriorityQueue.java
@@ -5,7 +5,10 @@
  */
 package javaslang.collection;
 
-import javaslang.*;
+import javaslang.Kind1;
+import javaslang.Tuple;
+import javaslang.Tuple2;
+import javaslang.Tuple3;
 import javaslang.collection.Comparators.SerializableComparator;
 import javaslang.collection.PriorityQueue.PriorityQueueBase.*;
 
@@ -265,7 +268,7 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
     }
 
     @Override
-    public PriorityQueue<T> drop(long n) {
+    public PriorityQueue<T> drop(int n) {
         PriorityQueue<T> result = this;
         for (long i = n; i > 0 && !result.isEmpty(); i--) {
             result = result.tail();
@@ -274,7 +277,7 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
     }
 
     @Override
-    public PriorityQueue<T> dropRight(long n) {
+    public PriorityQueue<T> dropRight(int n) {
         if (n <= 0) {
             return this;
         } else if (n >= length()) {
@@ -341,7 +344,7 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
     }
 
     @Override
-    public Iterator<? extends PriorityQueue<T>> grouped(long size) {
+    public Iterator<? extends PriorityQueue<T>> grouped(int size) {
         return sliding(size, size);
     }
 
@@ -451,12 +454,12 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
     }
 
     @Override
-    public Iterator<? extends PriorityQueue<T>> sliding(long size) {
+    public Iterator<? extends PriorityQueue<T>> sliding(int size) {
         return iterator().sliding(size).map(v -> ofAll(comparator, v));
     }
 
     @Override
-    public Iterator<? extends PriorityQueue<T>> sliding(long size, long step) {
+    public Iterator<? extends PriorityQueue<T>> sliding(int size, int step) {
         return iterator().sliding(size, step).map(v -> ofAll(comparator, v));
     }
 
@@ -467,12 +470,12 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
     }
 
     @Override
-    public PriorityQueue<T> take(long n) {
+    public PriorityQueue<T> take(int n) {
         return ofAll(comparator, iterator().take(n));
     }
 
     @Override
-    public PriorityQueue<T> takeRight(long n) {
+    public PriorityQueue<T> takeRight(int n) {
         return ofAll(comparator, toList().takeRight(n));
     }
 
@@ -516,12 +519,12 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
     }
 
     @Override
-    public PriorityQueue<Tuple2<T, Long>> zipWithIndex() {
+    public PriorityQueue<Tuple2<T, Integer>> zipWithIndex() {
         return zipWithIndex(Tuple::of);
     }
 
     @Override
-    public <U> PriorityQueue<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper) {
+    public <U> PriorityQueue<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return ofAll(naturalComparator(), iterator().zipWithIndex(mapper));
     }

--- a/javaslang/src/main/java/javaslang/collection/Queue.java
+++ b/javaslang/src/main/java/javaslang/collection/Queue.java
@@ -639,7 +639,7 @@ public final class Queue<T> extends AbstractsQueue<T, Queue<T>> implements Linea
     }
 
     @Override
-    public Queue<T> drop(long n) {
+    public Queue<T> drop(int n) {
         if (n <= 0) {
             return this;
         }
@@ -650,7 +650,7 @@ public final class Queue<T> extends AbstractsQueue<T, Queue<T>> implements Linea
     }
 
     @Override
-    public Queue<T> dropRight(long n) {
+    public Queue<T> dropRight(int n) {
         if (n <= 0) {
             return this;
         }
@@ -726,7 +726,7 @@ public final class Queue<T> extends AbstractsQueue<T, Queue<T>> implements Linea
     }
 
     @Override
-    public Iterator<Queue<T>> grouped(long size) {
+    public Iterator<Queue<T>> grouped(int size) {
         return sliding(size, size);
     }
 
@@ -968,17 +968,17 @@ public final class Queue<T> extends AbstractsQueue<T, Queue<T>> implements Linea
     }
 
     @Override
-    public Queue<T> slice(long beginIndex, long endIndex) {
+    public Queue<T> slice(int beginIndex, int endIndex) {
         return ofAll(toList().slice(beginIndex, endIndex));
     }
 
     @Override
-    public Iterator<Queue<T>> sliding(long size) {
+    public Iterator<Queue<T>> sliding(int size) {
         return sliding(size, 1);
     }
 
     @Override
-    public Iterator<Queue<T>> sliding(long size, long step) {
+    public Iterator<Queue<T>> sliding(int size, int step) {
         return iterator().sliding(size, step).map(Queue::ofAll);
     }
 
@@ -1013,7 +1013,7 @@ public final class Queue<T> extends AbstractsQueue<T, Queue<T>> implements Linea
     }
 
     @Override
-    public Tuple2<Queue<T>, Queue<T>> splitAt(long n) {
+    public Tuple2<Queue<T>, Queue<T>> splitAt(int n) {
         return toList().splitAt(n).map(List::toQueue, List::toQueue);
     }
 
@@ -1057,7 +1057,7 @@ public final class Queue<T> extends AbstractsQueue<T, Queue<T>> implements Linea
     }
 
     @Override
-    public Queue<T> take(long n) {
+    public Queue<T> take(int n) {
         if (n <= 0) {
             return empty();
         }
@@ -1075,7 +1075,7 @@ public final class Queue<T> extends AbstractsQueue<T, Queue<T>> implements Linea
     }
 
     @Override
-    public Queue<T> takeRight(long n) {
+    public Queue<T> takeRight(int n) {
         if (n <= 0) {
             return empty();
         }
@@ -1155,12 +1155,12 @@ public final class Queue<T> extends AbstractsQueue<T, Queue<T>> implements Linea
     }
 
     @Override
-    public Queue<Tuple2<T, Long>> zipWithIndex() {
+    public Queue<Tuple2<T, Integer>> zipWithIndex() {
         return zipWithIndex(Tuple::of);
     }
 
     @Override
-    public <U> Queue<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper) {
+    public <U> Queue<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return ofAll(toList().zipWithIndex(mapper));
     }

--- a/javaslang/src/main/java/javaslang/collection/Seq.java
+++ b/javaslang/src/main/java/javaslang/collection/Seq.java
@@ -5,11 +5,18 @@
  */
 package javaslang.collection;
 
-import javaslang.*;
+import javaslang.Function1;
+import javaslang.Tuple;
+import javaslang.Tuple2;
+import javaslang.Tuple3;
 import javaslang.control.Option;
 
-import java.util.*;
-import java.util.function.*;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * Interface for immutable sequential data structures.
@@ -51,7 +58,7 @@ import java.util.function.*;
  * <li>{@link #indexOf(Object, int)}</li>
  * <li>{@link #lastIndexOf(Object)}</li>
  * <li>{@link #lastIndexOf(Object, int)}</li>
- * <li>{@link #slice(long, long)}</li>
+ * <li>{@link #slice(int, int)}</li>
  * <li>{@link #subSequence(int)}</li>
  * <li>{@link #subSequence(int, int)}</li>
  * </ul>
@@ -70,7 +77,7 @@ import java.util.function.*;
  * <li>{@link #reverse()}</li>
  * <li>{@link #sorted()}</li>
  * <li>{@link #sorted(Comparator)}</li>
- * <li>{@link #splitAt(long)}</li>
+ * <li>{@link #splitAt(int)}</li>
  * <li>{@link #unzip(Function)}</li>
  * <li>{@link #zip(Iterable)}</li>
  * <li>{@link #zipAll(Iterable, Object, Object)}</li>
@@ -231,7 +238,7 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T> {
     default <U> Iterator<Tuple2<T, U>> crossProduct(Iterable<? extends U> that) {
         Objects.requireNonNull(that, "that is null");
         final Stream<U> other = Stream.ofAll(that);
-        return Iterator.ofAll(this).flatMap(a -> other.map((Function<U, Tuple2<T, U>>) b -> Tuple.of(a, b)));
+        return Iterator.ofAll(this).flatMap(a -> other.map(b -> Tuple.of(a, b)));
     }
 
     /**
@@ -797,7 +804,7 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T> {
      * @param endIndex   the end index, exclusive
      * @return the specified slice
      */
-    Seq<T> slice(long beginIndex, long endIndex);
+    Seq<T> slice(int beginIndex, int endIndex);
 
     /**
      * Sorts this elements according to their natural order. If this elements are not
@@ -843,7 +850,7 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T> {
      * @param n An index.
      * @return A Tuple containing the first n and the remaining elements.
      */
-    Tuple2<? extends Seq<T>, ? extends Seq<T>> splitAt(long n);
+    Tuple2<? extends Seq<T>, ? extends Seq<T>> splitAt(int n);
 
     /**
      * Splits a sequence at the first element which satisfies the {@link Predicate}, e.g. Tuple(init, element+tail).
@@ -909,7 +916,7 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T> {
      * </code>
      * </pre>
      *
-     * See also {@link #drop(long)} which is similar but does not throw.
+     * See also {@link #drop(int)} which is similar but does not throw.
      *
      * @param beginIndex the beginning index, inclusive
      * @return the specified subsequence
@@ -935,7 +942,7 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T> {
      * </code>
      * </pre>
      *
-     * See also {@link #slice(long, long)} which returns an empty sequence instead of throwing.
+     * See also {@link #slice(int, int)} which returns an empty sequence instead of throwing.
      *
      * @param beginIndex the beginning index, inclusive
      * @param endIndex   the end index, exclusive
@@ -1002,10 +1009,10 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T> {
     <U> Seq<T> distinctBy(Function<? super T, ? extends U> keyExtractor);
 
     @Override
-    Seq<T> drop(long n);
+    Seq<T> drop(int n);
 
     @Override
-    Seq<T> dropRight(long n);
+    Seq<T> dropRight(int n);
 
     @Override
     Seq<T> dropUntil(Predicate<? super T> predicate);
@@ -1029,7 +1036,7 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T> {
     <C> Map<C, ? extends Seq<T>> groupBy(Function<? super T, ? extends C> classifier);
 
     @Override
-    Iterator<? extends Seq<T>> grouped(long size);
+    Iterator<? extends Seq<T>> grouped(int size);
 
     @Override
     Seq<T> init();
@@ -1065,10 +1072,10 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T> {
     <U> Seq<U> scanRight(U zero, BiFunction<? super T, ? super U, ? extends U> operation);
 
     @Override
-    Iterator<? extends Seq<T>> sliding(long size);
+    Iterator<? extends Seq<T>> sliding(int size);
 
     @Override
-    Iterator<? extends Seq<T>> sliding(long size, long step);
+    Iterator<? extends Seq<T>> sliding(int size, int step);
 
     @Override
     Tuple2<? extends Seq<T>, ? extends Seq<T>> span(Predicate<? super T> predicate);
@@ -1080,10 +1087,10 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T> {
     Option<? extends Seq<T>> tailOption();
 
     @Override
-    Seq<T> take(long n);
+    Seq<T> take(int n);
 
     @Override
-    Seq<T> takeRight(long n);
+    Seq<T> takeRight(int n);
 
     @Override
     Seq<T> takeUntil(Predicate<? super T> predicate);
@@ -1107,10 +1114,10 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T> {
     <U> Seq<Tuple2<T, U>> zipAll(Iterable<? extends U> that, T thisElem, U thatElem);
 
     @Override
-    Seq<Tuple2<T, Long>> zipWithIndex();
+    Seq<Tuple2<T, Integer>> zipWithIndex();
 
     @Override
-    <U> Seq<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper);
+    <U> Seq<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper);
 
     /**
      * Turns this sequence from a partial function into a total function that

--- a/javaslang/src/main/java/javaslang/collection/Set.java
+++ b/javaslang/src/main/java/javaslang/collection/Set.java
@@ -142,10 +142,10 @@ public interface Set<T> extends Traversable<T>, Function1<T, Boolean> {
     <U> Set<T> distinctBy(Function<? super T, ? extends U> keyExtractor);
 
     @Override
-    Set<T> drop(long n);
+    Set<T> drop(int n);
 
     @Override
-    Set<T> dropRight(long n);
+    Set<T> dropRight(int n);
 
     @Override
     Set<T> dropUntil(Predicate<? super T> predicate);
@@ -163,7 +163,7 @@ public interface Set<T> extends Traversable<T>, Function1<T, Boolean> {
     <C> Map<C, ? extends Set<T>> groupBy(Function<? super T, ? extends C> classifier);
 
     @Override
-    Iterator<? extends Set<T>> grouped(long size);
+    Iterator<? extends Set<T>> grouped(int size);
 
     @Override
     Set<T> init();
@@ -205,10 +205,10 @@ public interface Set<T> extends Traversable<T>, Function1<T, Boolean> {
     <U> Set<U> scanRight(U zero, BiFunction<? super T, ? super U, ? extends U> operation);
 
     @Override
-    Iterator<? extends Set<T>> sliding(long size);
+    Iterator<? extends Set<T>> sliding(int size);
 
     @Override
-    Iterator<? extends Set<T>> sliding(long size, long step);
+    Iterator<? extends Set<T>> sliding(int size, int step);
 
     @Override
     Tuple2<? extends Set<T>, ? extends Set<T>> span(Predicate<? super T> predicate);
@@ -225,10 +225,10 @@ public interface Set<T> extends Traversable<T>, Function1<T, Boolean> {
     Option<? extends Set<T>> tailOption();
 
     @Override
-    Set<T> take(long n);
+    Set<T> take(int n);
 
     @Override
-    Set<T> takeRight(long n);
+    Set<T> takeRight(int n);
 
     @Override
     Set<T> takeUntil(Predicate<? super T> predicate);
@@ -252,8 +252,8 @@ public interface Set<T> extends Traversable<T>, Function1<T, Boolean> {
     <U> Set<Tuple2<T, U>> zipAll(Iterable<? extends U> that, T thisElem, U thatElem);
 
     @Override
-    Set<Tuple2<T, Long>> zipWithIndex();
+    Set<Tuple2<T, Integer>> zipWithIndex();
 
     @Override
-    <U> Set<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper);
+    <U> Set<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper);
 }

--- a/javaslang/src/main/java/javaslang/collection/SortedMap.java
+++ b/javaslang/src/main/java/javaslang/collection/SortedMap.java
@@ -5,7 +5,6 @@
  */
 package javaslang.collection;
 
-import javaslang.Function2;
 import javaslang.Tuple2;
 import javaslang.control.Option;
 
@@ -104,10 +103,10 @@ public interface SortedMap<K, V> extends Map<K, V> {
     <U> SortedMap<K, V> distinctBy(Function<? super Tuple2<K, V>, ? extends U> keyExtractor);
 
     @Override
-    SortedMap<K, V> drop(long n);
+    SortedMap<K, V> drop(int n);
 
     @Override
-    SortedMap<K, V> dropRight(long n);
+    SortedMap<K, V> dropRight(int n);
 
     @Override
     SortedMap<K, V> dropUntil(Predicate<? super Tuple2<K, V>> predicate);
@@ -143,7 +142,7 @@ public interface SortedMap<K, V> extends Map<K, V> {
     <C> Map<C, ? extends SortedMap<K, V>> groupBy(Function<? super Tuple2<K, V>, ? extends C> classifier);
 
     @Override
-    Iterator<? extends SortedMap<K, V>> grouped(long size);
+    Iterator<? extends SortedMap<K, V>> grouped(int size);
 
     @Override
     SortedMap<K, V> init();
@@ -208,10 +207,10 @@ public interface SortedMap<K, V> extends Map<K, V> {
     SortedMap<K, V> scan(Tuple2<K, V> zero, BiFunction<? super Tuple2<K, V>, ? super Tuple2<K, V>, ? extends Tuple2<K, V>> operation);
 
     @Override
-    Iterator<? extends SortedMap<K, V>> sliding(long size);
+    Iterator<? extends SortedMap<K, V>> sliding(int size);
 
     @Override
-    Iterator<? extends SortedMap<K, V>> sliding(long size, long step);
+    Iterator<? extends SortedMap<K, V>> sliding(int size, int step);
 
     @Override
     Tuple2<? extends SortedMap<K, V>, ? extends SortedMap<K, V>> span(Predicate<? super Tuple2<K, V>> predicate);
@@ -223,10 +222,10 @@ public interface SortedMap<K, V> extends Map<K, V> {
     Option<? extends SortedMap<K, V>> tailOption();
 
     @Override
-    SortedMap<K, V> take(long n);
+    SortedMap<K, V> take(int n);
 
     @Override
-    SortedMap<K, V> takeRight(long n);
+    SortedMap<K, V> takeRight(int n);
 
     @Override
     SortedMap<K, V> takeUntil(Predicate<? super Tuple2<K, V>> predicate);

--- a/javaslang/src/main/java/javaslang/collection/SortedSet.java
+++ b/javaslang/src/main/java/javaslang/collection/SortedSet.java
@@ -93,10 +93,10 @@ public interface SortedSet<T> extends Set<T> {
     <U> SortedSet<T> distinctBy(Function<? super T, ? extends U> keyExtractor);
 
     @Override
-    SortedSet<T> drop(long n);
+    SortedSet<T> drop(int n);
 
     @Override
-    SortedSet<T> dropRight(long n);
+    SortedSet<T> dropRight(int n);
 
     @Override
     SortedSet<T> dropUntil(Predicate<? super T> predicate);
@@ -114,7 +114,7 @@ public interface SortedSet<T> extends Set<T> {
     <C> Map<C, ? extends SortedSet<T>> groupBy(Function<? super T, ? extends C> classifier);
 
     @Override
-    Iterator<? extends SortedSet<T>> grouped(long size);
+    Iterator<? extends SortedSet<T>> grouped(int size);
 
     @Override
     SortedSet<T> init();
@@ -166,10 +166,10 @@ public interface SortedSet<T> extends Set<T> {
     <U> Set<U> scanRight(U zero, BiFunction<? super T, ? super U, ? extends U> operation);
 
     @Override
-    Iterator<? extends SortedSet<T>> sliding(long size);
+    Iterator<? extends SortedSet<T>> sliding(int size);
 
     @Override
-    Iterator<? extends SortedSet<T>> sliding(long size, long step);
+    Iterator<? extends SortedSet<T>> sliding(int size, int step);
 
     @Override
     Tuple2<? extends SortedSet<T>, ? extends SortedSet<T>> span(Predicate<? super T> predicate);
@@ -181,10 +181,10 @@ public interface SortedSet<T> extends Set<T> {
     Option<? extends SortedSet<T>> tailOption();
 
     @Override
-    SortedSet<T> take(long n);
+    SortedSet<T> take(int n);
 
     @Override
-    SortedSet<T> takeRight(long n);
+    SortedSet<T> takeRight(int n);
 
     @Override
     SortedSet<T> takeUntil(Predicate<? super T> predicate);
@@ -214,8 +214,8 @@ public interface SortedSet<T> extends Set<T> {
     <U> SortedSet<Tuple2<T, U>> zipAll(Iterable<? extends U> that, T thisElem, U thatElem);
 
     @Override
-    SortedSet<Tuple2<T, Long>> zipWithIndex();
+    SortedSet<Tuple2<T, Integer>> zipWithIndex();
 
     @Override
-    <U> SortedSet<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper);
+    <U> SortedSet<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper);
 }

--- a/javaslang/src/main/java/javaslang/collection/Stream.java
+++ b/javaslang/src/main/java/javaslang/collection/Stream.java
@@ -6,7 +6,8 @@
 package javaslang.collection;
 
 import javaslang.*;
-import javaslang.collection.Stream.*;
+import javaslang.collection.Stream.Cons;
+import javaslang.collection.Stream.Empty;
 import javaslang.collection.StreamModule.*;
 import javaslang.control.Option;
 
@@ -855,7 +856,7 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> drop(long n) {
+    default Stream<T> drop(int n) {
         Stream<T> stream = this;
         while (n-- > 0 && !stream.isEmpty()) {
             stream = stream.tail();
@@ -864,7 +865,7 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> dropRight(long n) {
+    default Stream<T> dropRight(int n) {
         if (n <= 0) {
             return this;
         } else {
@@ -948,7 +949,7 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
     }
 
     @Override
-    default Iterator<Stream<T>> grouped(long size) {
+    default Iterator<Stream<T>> grouped(int size) {
         return sliding(size, size);
     }
 
@@ -1244,11 +1245,11 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> slice(long beginIndex, long endIndex) {
+    default Stream<T> slice(int beginIndex, int endIndex) {
         if (beginIndex >= endIndex || isEmpty()) {
             return empty();
         } else {
-            final long lowerBound = Math.max(beginIndex, 0);
+            final int lowerBound = Math.max(beginIndex, 0);
             if (lowerBound == 0) {
                 return cons(head(), () -> tail().slice(0, endIndex - 1));
             } else {
@@ -1258,12 +1259,12 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
     }
 
     @Override
-    default Iterator<Stream<T>> sliding(long size) {
+    default Iterator<Stream<T>> sliding(int size) {
         return sliding(size, 1);
     }
 
     @Override
-    default Iterator<Stream<T>> sliding(long size, long step) {
+    default Iterator<Stream<T>> sliding(int size, int step) {
         return iterator().sliding(size, step).map(Stream::ofAll);
     }
 
@@ -1298,7 +1299,7 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
     }
 
     @Override
-    default Tuple2<Stream<T>, Stream<T>> splitAt(long n) {
+    default Tuple2<Stream<T>, Stream<T>> splitAt(int n) {
         return Tuple.of(take(n), drop(n));
     }
 
@@ -1368,7 +1369,7 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> take(long n) {
+    default Stream<T> take(int n) {
         if (n < 1 || isEmpty()) {
             return Empty.instance();
         } else if (n == 1) {
@@ -1379,7 +1380,7 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> takeRight(long n) {
+    default Stream<T> takeRight(int n) {
         Stream<T> right = this;
         Stream<T> remaining = drop(n);
         while (!remaining.isEmpty()) {
@@ -1491,12 +1492,12 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
     }
 
     @Override
-    default Stream<Tuple2<T, Long>> zipWithIndex() {
+    default Stream<Tuple2<T, Integer>> zipWithIndex() {
         return zipWithIndex(Tuple::of);
     }
 
     @Override
-    default <U> Stream<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper) {
+    default <U> Stream<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return Stream.ofAll(iterator().zipWithIndex(mapper));
     }

--- a/javaslang/src/main/java/javaslang/collection/Traversable.java
+++ b/javaslang/src/main/java/javaslang/collection/Traversable.java
@@ -5,12 +5,19 @@
  */
 package javaslang.collection;
 
-import javaslang.*;
+import javaslang.Tuple2;
+import javaslang.Tuple3;
+import javaslang.Value;
 import javaslang.control.Option;
 
 import java.math.BigInteger;
-import java.util.*;
-import java.util.function.*;
+import java.util.Comparator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * An interface for inherently recursive, multi-valued data structures. The order of elements is determined by
@@ -38,10 +45,10 @@ import java.util.function.*;
  * Iteration:
  *
  * <ul>
- * <li>{@link #grouped(long)}</li>
+ * <li>{@link #grouped(int)}</li>
  * <li>{@link #iterator()}</li>
- * <li>{@link #sliding(long)}</li>
- * <li>{@link #sliding(long, long)}</li>
+ * <li>{@link #sliding(int)}</li>
+ * <li>{@link #sliding(int, int)}</li>
  * </ul>
  *
  * Numeric operations:
@@ -79,8 +86,8 @@ import java.util.function.*;
  * Selection:
  *
  * <ul>
- * <li>{@link #drop(long)}</li>
- * <li>{@link #dropRight(long)}</li>
+ * <li>{@link #drop(int)}</li>
+ * <li>{@link #dropRight(int)}</li>
  * <li>{@link #dropUntil(Predicate)}</li>
  * <li>{@link #dropWhile(Predicate)}</li>
  * <li>{@link #filter(Predicate)}</li>
@@ -89,8 +96,8 @@ import java.util.function.*;
  * <li>{@link #groupBy(Function)}</li>
  * <li>{@link #partition(Predicate)}</li>
  * <li>{@link #retainAll(Iterable)}</li>
- * <li>{@link #take(long)}</li>
- * <li>{@link #takeRight(long)}</li>
+ * <li>{@link #take(int)}</li>
+ * <li>{@link #takeRight(int)}</li>
  * <li>{@link #takeUntil(Predicate)}</li>
  * <li>{@link #takeWhile(Predicate)}</li>
  * </ul>
@@ -255,7 +262,7 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      * @return a new instance consisting of all elements of this except the first n ones, or else the empty instance,
      * if this has less than n elements.
      */
-    Traversable<T> drop(long n);
+    Traversable<T> drop(int n);
 
     /**
      * Drops the last n elements of this or all elements, if this length &lt; n.
@@ -264,7 +271,7 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      * @return a new instance consisting of all elements of this except the last n ones, or else the empty instance,
      * if this has less than n elements.
      */
-    Traversable<T> dropRight(long n);
+    Traversable<T> dropRight(int n);
 
     /**
      * Drops elements until the predicate holds for the current element.
@@ -467,14 +474,14 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      * </code>
      * </pre>
      *
-     * Please note that {@code grouped(int)} is a special case of {@linkplain #sliding(long, long)}, i.e.
+     * Please note that {@code grouped(int)} is a special case of {@linkplain #sliding(int, int)}, i.e.
      * {@code grouped(size)} is the same as {@code sliding(size, size)}.
      *
      * @param size a positive block size
      * @return A new Iterator of grouped blocks of the given size
      * @throws IllegalArgumentException if {@code size} is negative or zero
      */
-    Iterator<? extends Traversable<T>> grouped(long size);
+    Iterator<? extends Traversable<T>> grouped(int size);
 
     /**
      * Checks if this Traversable is known to have a finite size.
@@ -992,13 +999,13 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
 
     /**
      * Slides a window of a specific {@code size} and step size 1 over this {@code Traversable} by calling
-     * {@link #sliding(long, long)}.
+     * {@link #sliding(int, int)}.
      *
      * @param size a positive window size
      * @return a new Iterator of windows of a specific size using step size 1
      * @throws IllegalArgumentException if {@code size} is negative or zero
      */
-    Iterator<? extends Traversable<T>> sliding(long size);
+    Iterator<? extends Traversable<T>> sliding(int size);
 
     /**
      * Slides a window of a specific {@code size} and {@code step} size over this {@code Traversable}.
@@ -1019,7 +1026,7 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      * @return a new Iterator of windows of a specific size using a specific step size
      * @throws IllegalArgumentException if {@code size} or {@code step} are negative or zero
      */
-    Iterator<? extends Traversable<T>> sliding(long size, long step);
+    Iterator<? extends Traversable<T>> sliding(int size, int step);
 
     /**
      * Returns a tuple where the first element is the longest prefix of elements that satisfy the given
@@ -1095,7 +1102,7 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      * @param n The number of elements to take.
      * @return A new instance consisting the first n elements of this or all elements, if this has less than n elements.
      */
-    Traversable<T> take(long n);
+    Traversable<T> take(int n);
 
     /**
      * Takes the last n elements of this or all elements, if this length &lt; n.
@@ -1108,7 +1115,7 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      * @param n The number of elements to take.
      * @return A new instance consisting the first n elements of this or all elements, if this has less than n elements.
      */
-    Traversable<T> takeRight(long n);
+    Traversable<T> takeRight(int n);
 
     /**
      * Takes elements until the predicate holds for the current element.
@@ -1218,7 +1225,7 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      *
      * @return A new traversable containing all elements of this traversable paired with their index, starting with 0.
      */
-    Traversable<Tuple2<T, Long>> zipWithIndex();
+    Traversable<Tuple2<T, Integer>> zipWithIndex();
 
     /**
      * Returns a traversable formed from this traversable and another Iterable collection by mapping elements.
@@ -1232,6 +1239,6 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      * @return a new traversable containing mapped elements of this traversable and {@code that} iterable.
      * @throws NullPointerException if {@code mapper} is null
      */
-    <U> Traversable<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper);
+    <U> Traversable<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper);
 
 }

--- a/javaslang/src/main/java/javaslang/collection/Tree.java
+++ b/javaslang/src/main/java/javaslang/collection/Tree.java
@@ -5,7 +5,9 @@
  */
 package javaslang.collection;
 
-import javaslang.*;
+import javaslang.Tuple;
+import javaslang.Tuple2;
+import javaslang.Tuple3;
 import javaslang.collection.List.Nil;
 import javaslang.collection.Tree.*;
 import javaslang.collection.TreeModule.*;
@@ -369,7 +371,7 @@ public interface Tree<T> extends Traversable<T> {
     }
 
     @Override
-    default Seq<T> drop(long n) {
+    default Seq<T> drop(int n) {
         if (n >= length()) {
             return Stream.empty();
         } else {
@@ -378,7 +380,7 @@ public interface Tree<T> extends Traversable<T> {
     }
 
     @Override
-    default Seq<T> dropRight(long n) {
+    default Seq<T> dropRight(int n) {
         if (n >= length()) {
             return Stream.empty();
         } else {
@@ -435,7 +437,7 @@ public interface Tree<T> extends Traversable<T> {
     }
 
     @Override
-    default Iterator<Seq<T>> grouped(long size) {
+    default Iterator<Seq<T>> grouped(int size) {
         return sliding(size, size);
     }
 
@@ -541,12 +543,12 @@ public interface Tree<T> extends Traversable<T> {
     }
 
     @Override
-    default Iterator<Seq<T>> sliding(long size) {
+    default Iterator<Seq<T>> sliding(int size) {
         return sliding(size, 1);
     }
 
     @Override
-    default Iterator<Seq<T>> sliding(long size, long step) {
+    default Iterator<Seq<T>> sliding(int size, int step) {
         return iterator().sliding(size, step);
     }
 
@@ -587,7 +589,7 @@ public interface Tree<T> extends Traversable<T> {
     }
 
     @Override
-    default Seq<T> take(long n) {
+    default Seq<T> take(int n) {
         if (isEmpty()) {
             return Stream.empty();
         } else {
@@ -596,7 +598,7 @@ public interface Tree<T> extends Traversable<T> {
     }
 
     @Override
-    default Seq<T> takeRight(long n) {
+    default Seq<T> takeRight(int n) {
         if (isEmpty()) {
             return Stream.empty();
         } else {
@@ -676,14 +678,14 @@ public interface Tree<T> extends Traversable<T> {
     }
 
     @Override
-    default Tree<Tuple2<T, Long>> zipWithIndex() {
+    default Tree<Tuple2<T, Integer>> zipWithIndex() {
         return zipWithIndex(Tuple::of);
     }
 
     @Override
-   default  <U> Tree<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper){
+    default <U> Tree<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return zipWith(Iterator.from(0L), mapper);
+        return zipWith(Iterator.from(0), mapper);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/TreeSet.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeSet.java
@@ -5,11 +5,17 @@
  */
 package javaslang.collection;
 
-import javaslang.*;
+import javaslang.Kind1;
+import javaslang.Tuple;
+import javaslang.Tuple2;
+import javaslang.Tuple3;
 import javaslang.control.Option;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.function.*;
 import java.util.stream.Collector;
 
@@ -560,7 +566,7 @@ public final class TreeSet<T> implements Kind1<TreeSet<?>, T>, SortedSet<T>, Ser
     }
 
     @Override
-    public TreeSet<T> drop(long n) {
+    public TreeSet<T> drop(int n) {
         if (n <= 0) {
             return this;
         } else if (n >= length()) {
@@ -571,7 +577,7 @@ public final class TreeSet<T> implements Kind1<TreeSet<?>, T>, SortedSet<T>, Ser
     }
 
     @Override
-    public TreeSet<T> dropRight(long n) {
+    public TreeSet<T> dropRight(int n) {
         if (n <= 0) {
             return this;
         } else if (n >= length()) {
@@ -625,7 +631,7 @@ public final class TreeSet<T> implements Kind1<TreeSet<?>, T>, SortedSet<T>, Ser
     }
 
     @Override
-    public Iterator<TreeSet<T>> grouped(long size) {
+    public Iterator<TreeSet<T>> grouped(int size) {
         return sliding(size, size);
     }
 
@@ -796,12 +802,12 @@ public final class TreeSet<T> implements Kind1<TreeSet<?>, T>, SortedSet<T>, Ser
     }
 
     @Override
-    public Iterator<TreeSet<T>> sliding(long size) {
+    public Iterator<TreeSet<T>> sliding(int size) {
         return sliding(size, 1);
     }
 
     @Override
-    public Iterator<TreeSet<T>> sliding(long size, long step) {
+    public Iterator<TreeSet<T>> sliding(int size, int step) {
         return iterator().sliding(size, step).map(seq -> TreeSet.ofAll(tree.comparator(), seq));
     }
 
@@ -827,7 +833,7 @@ public final class TreeSet<T> implements Kind1<TreeSet<?>, T>, SortedSet<T>, Ser
     }
 
     @Override
-    public TreeSet<T> take(long n) {
+    public TreeSet<T> take(int n) {
         if (n <= 0) {
             return empty(tree.comparator());
         } else if (n >= length()) {
@@ -838,7 +844,7 @@ public final class TreeSet<T> implements Kind1<TreeSet<?>, T>, SortedSet<T>, Ser
     }
 
     @Override
-    public TreeSet<T> takeRight(long n) {
+    public TreeSet<T> takeRight(int n) {
         if (n <= 0) {
             return empty(tree.comparator());
         } else if (n >= length()) {
@@ -930,14 +936,14 @@ public final class TreeSet<T> implements Kind1<TreeSet<?>, T>, SortedSet<T>, Ser
     }
 
     @Override
-    public TreeSet<Tuple2<T, Long>> zipWithIndex() {
+    public TreeSet<Tuple2<T, Integer>> zipWithIndex() {
         final Comparator<? super T> component1Comparator = tree.comparator();
-        final Comparator<Tuple2<T, Long>> tuple2Comparator = (t1, t2) -> component1Comparator.compare(t1._1, t2._1);
+        final Comparator<Tuple2<T, Integer>> tuple2Comparator = (t1, t2) -> component1Comparator.compare(t1._1, t2._1);
         return TreeSet.ofAll(tuple2Comparator, iterator().zipWithIndex());
     }
 
     @Override
-    public <U> SortedSet<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper) {
+    public <U> SortedSet<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         return TreeSet.ofAll(naturalComparator(), iterator().zipWithIndex(mapper));
     }
 

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -606,7 +606,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public Vector<T> drop(long n) {
+    public Vector<T> drop(int n) {
         if (n <= 0) {
             return this;
         }
@@ -614,14 +614,14 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
             return empty();
         }
         HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        for (int i = (int) n; i < length(); i++) {
-            trie = trie.put(i - (int) n, get(i));
+        for (int i = n; i < length(); i++) {
+            trie = trie.put(i - n, get(i));
         }
         return wrap(trie);
     }
 
     @Override
-    public Vector<T> dropRight(long n) {
+    public Vector<T> dropRight(int n) {
         if (n <= 0) {
             return this;
         }
@@ -710,7 +710,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public Iterator<Vector<T>> grouped(long size) {
+    public Iterator<Vector<T>> grouped(int size) {
         return sliding(size, size);
     }
 
@@ -1085,29 +1085,29 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public Vector<T> slice(long beginIndex, long endIndex) {
+    public Vector<T> slice(int beginIndex, int endIndex) {
         if (beginIndex >= endIndex || beginIndex >= length() || isEmpty()) {
             return Vector.empty();
         }
         if (beginIndex <= 0 && endIndex >= length()) {
             return this;
         }
-        final long index = Math.max(beginIndex, 0);
-        final long length = Math.min(endIndex, length());
+        final int index = Math.max(beginIndex, 0);
+        final int length = Math.min(endIndex, length());
         HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        for (int i = (int) index; i < length; i++) {
+        for (int i = index; i < length; i++) {
             trie = trie.put(trie.size(), get(i));
         }
         return wrap(trie);
     }
 
     @Override
-    public Iterator<Vector<T>> sliding(long size) {
+    public Iterator<Vector<T>> sliding(int size) {
         return sliding(size, 1);
     }
 
     @Override
-    public Iterator<Vector<T>> sliding(long size, long step) {
+    public Iterator<Vector<T>> sliding(int size, int step) {
         return iterator().sliding(size, step).map(Vector::ofAll);
     }
 
@@ -1142,7 +1142,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public Tuple2<Vector<T>, Vector<T>> splitAt(long n) {
+    public Tuple2<Vector<T>, Vector<T>> splitAt(int n) {
         return Tuple.of(take(n), drop(n));
     }
 
@@ -1220,7 +1220,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public Vector<T> take(long n) {
+    public Vector<T> take(int n) {
         if (n >= length()) {
             return this;
         }
@@ -1235,7 +1235,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public Vector<T> takeRight(long n) {
+    public Vector<T> takeRight(int n) {
         if (n >= length()) {
             return this;
         }
@@ -1244,7 +1244,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
         }
         HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
         for (int i = 0; i < n; i++) {
-            trie = trie.put(i, get(length() - (int) n + i));
+            trie = trie.put(i, get(length() - n + i));
         }
         return new Vector<>(trie);
     }
@@ -1346,12 +1346,12 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public Vector<Tuple2<T, Long>> zipWithIndex() {
+    public Vector<Tuple2<T, Integer>> zipWithIndex() {
         return zipWithIndex(Tuple::of);
     }
 
     @Override
-    public <U> Vector<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper) {
+    public <U> Vector<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return Vector.ofAll(iterator().zipWithIndex(mapper));
     }

--- a/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
@@ -638,13 +638,13 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
 
     @Test
     public void shouldZipNonNilWithIndex() {
-        final Seq<Tuple2<Tuple2<Integer, Integer>, Long>> actual = emptyIntInt()
+        final Seq<Tuple2<Tuple2<Integer, Integer>, Integer>> actual = emptyIntInt()
                 .put(0, 0)
                 .put(1, 1)
                 .put(2, 2)
                 .zipWithIndex();
         assertThat(actual).isEqualTo(
-                Stream.of(Tuple.of(Tuple.of(0, 0), 0L), Tuple.of(Tuple.of(1, 1), 1L), Tuple.of(Tuple.of(2, 2), 2L)));
+                Stream.of(Tuple.of(Tuple.of(0, 0), 0), Tuple.of(Tuple.of(1, 1), 1), Tuple.of(Tuple.of(2, 2), 2)));
     }
 
     // -- zipAll

--- a/javaslang/src/test/java/javaslang/collection/AbstractMultimapTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractMultimapTest.java
@@ -607,13 +607,13 @@ public abstract class AbstractMultimapTest extends AbstractTraversableTest {
 
     @Test
     public void shouldZipNonNilWithIndex() {
-        final Seq<Tuple2<Tuple2<Integer, Integer>, Long>> actual = emptyIntInt()
+        final Seq<Tuple2<Tuple2<Integer, Integer>, Integer>> actual = emptyIntInt()
                 .put(0, 0)
                 .put(1, 1)
                 .put(2, 2)
                 .zipWithIndex();
         assertThat(actual).isEqualTo(
-                Stream.of(Tuple.of(Tuple.of(0, 0), 0L), Tuple.of(Tuple.of(1, 1), 1L), Tuple.of(Tuple.of(2, 2), 2L)));
+                Stream.of(Tuple.of(Tuple.of(0, 0), 0), Tuple.of(Tuple.of(1, 1), 1), Tuple.of(Tuple.of(2, 2), 2)));
     }
 
     // -- zipAll

--- a/javaslang/src/test/java/javaslang/collection/AbstractTraversableTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractTraversableTest.java
@@ -5,19 +5,25 @@
  */
 package javaslang.collection;
 
-import javaslang.*;
+import javaslang.AbstractValueTest;
+import javaslang.Tuple;
+import javaslang.Tuple2;
 import javaslang.control.Option;
 import org.junit.Test;
 
 import java.io.*;
-import java.math.*;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.*;
-import java.util.function.*;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collector;
 
 import static java.lang.System.lineSeparator;
-import static javaslang.Serializables.*;
-import static org.assertj.core.api.Assertions.*;
+import static javaslang.Serializables.deserialize;
+import static javaslang.Serializables.serialize;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.within;
 
 public abstract class AbstractTraversableTest extends AbstractValueTest {
 
@@ -2019,9 +2025,9 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
 
     @Test
     public void shouldZipNonNilWithIndex() {
-        final Traversable<Tuple2<String, Long>> actual = of("a", "b", "c").zipWithIndex();
+        final Traversable<Tuple2<String, Integer>> actual = of("a", "b", "c").zipWithIndex();
         @SuppressWarnings("unchecked")
-        final Traversable<Tuple2<String, Long>> expected = of(Tuple.of("a", 0L), Tuple.of("b", 1L), Tuple.of("c", 2L));
+        final Traversable<Tuple2<String, Integer>> expected = of(Tuple.of("a", 0), Tuple.of("b", 1), Tuple.of("c", 2));
         assertThat(actual).isEqualTo(expected);
     }
 

--- a/javaslang/src/test/java/javaslang/collection/CharSeqTest.java
+++ b/javaslang/src/test/java/javaslang/collection/CharSeqTest.java
@@ -5,17 +5,21 @@
  */
 package javaslang.collection;
 
-import javaslang.*;
+import javaslang.Tuple;
+import javaslang.Tuple2;
 import javaslang.control.Option;
 import org.assertj.core.api.*;
 import org.junit.Test;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
-import static javaslang.Serializables.*;
+import static javaslang.Serializables.deserialize;
+import static javaslang.Serializables.serialize;
 import static javaslang.collection.CharSeq.*;
 
 public class CharSeqTest {
@@ -2994,8 +2998,8 @@ public class CharSeqTest {
 
     @Test
     public void shouldZipNonNilWithIndex() {
-        final IndexedSeq<Tuple2<Character, Long>> actual = of("abc").zipWithIndex();
-        final IndexedSeq<Tuple2<Character, Long>> expected = Vector.of(Tuple.of('a', 0L), Tuple.of('b', 1L), Tuple.of('c', 2L));
+        final IndexedSeq<Tuple2<Character, Integer>> actual = of("abc").zipWithIndex();
+        final IndexedSeq<Tuple2<Character, Integer>> expected = Vector.of(Tuple.of('a', 0), Tuple.of('b', 1), Tuple.of('c', 2));
         assertThat(actual).isEqualTo(expected);
     }
 

--- a/javaslang/src/test/java/javaslang/collection/HashSetTest.java
+++ b/javaslang/src/test/java/javaslang/collection/HashSetTest.java
@@ -14,7 +14,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.*;
+import java.util.stream.Collector;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.assertTrue;
@@ -281,8 +281,8 @@ public class HashSetTest extends AbstractSetTest {
 
     @Test
     public void shouldZipNonNilWithIndex() {
-        final HashSet<Tuple2<String, Long>> actual = of("a", "b", "c").zipWithIndex();
-        final HashSet<Tuple2<String, Long>> expected = of(Tuple.of("a", 0L), Tuple.of("b", 1L), Tuple.of("c", 2L));
+        final HashSet<Tuple2<String, Integer>> actual = of("a", "b", "c").zipWithIndex();
+        final HashSet<Tuple2<String, Integer>> expected = of(Tuple.of("a", 0), Tuple.of("b", 1), Tuple.of("c", 2));
         assertThat(actual).isEqualTo(expected);
     }
 

--- a/javaslang/src/test/java/javaslang/collection/IntMap.java
+++ b/javaslang/src/test/java/javaslang/collection/IntMap.java
@@ -5,12 +5,19 @@
  */
 package javaslang.collection;
 
-import javaslang.*;
+import javaslang.Tuple;
+import javaslang.Tuple2;
+import javaslang.Tuple3;
 import javaslang.control.Option;
 
 import java.io.Serializable;
-import java.util.*;
-import java.util.function.*;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 public class IntMap<T> implements Traversable<T>, Serializable {
 
@@ -74,13 +81,13 @@ public class IntMap<T> implements Traversable<T>, Serializable {
     }
 
     @Override
-    public IntMap<T> drop(long n) {
+    public IntMap<T> drop(int n) {
         final Map<Integer, T> dropped = original.drop(n);
         return dropped == original ? this : IntMap.of(dropped);
     }
 
     @Override
-    public IntMap<T> dropRight(long n) {
+    public IntMap<T> dropRight(int n) {
         final Map<Integer, T> dropped = original.dropRight(n);
         return dropped == original ? this : IntMap.of(dropped);
     }
@@ -117,7 +124,7 @@ public class IntMap<T> implements Traversable<T>, Serializable {
     }
 
     @Override
-    public Iterator<IntMap<T>> grouped(long size) {
+    public Iterator<IntMap<T>> grouped(int size) {
         return original.grouped(size).map(IntMap::of);
     }
 
@@ -220,12 +227,12 @@ public class IntMap<T> implements Traversable<T>, Serializable {
     }
 
     @Override
-    public Iterator<IntMap<T>> sliding(long size) {
+    public Iterator<IntMap<T>> sliding(int size) {
         return original.sliding(size).map(IntMap::of);
     }
 
     @Override
-    public Iterator<IntMap<T>> sliding(long size, long step) {
+    public Iterator<IntMap<T>> sliding(int size, int step) {
         return original.sliding(size, step).map(IntMap::of);
     }
 
@@ -276,12 +283,12 @@ public class IntMap<T> implements Traversable<T>, Serializable {
     }
 
     @Override
-    public IntMap<T> take(long n) {
+    public IntMap<T> take(int n) {
         return IntMap.of(original.take(n));
     }
 
     @Override
-    public IntMap<T> takeRight(long n) {
+    public IntMap<T> takeRight(int n) {
         return IntMap.of(original.takeRight(n));
     }
 
@@ -326,12 +333,12 @@ public class IntMap<T> implements Traversable<T>, Serializable {
     }
 
     @Override
-    public Seq<Tuple2<T, Long>> zipWithIndex() {
+    public Seq<Tuple2<T, Integer>> zipWithIndex() {
         return  zipWithIndex(Tuple::of);
     }
 
     @Override
-    public <U> Seq<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper) {
+    public <U> Seq<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return Stream.ofAll(iterator().zipWithIndex(mapper));
     }

--- a/javaslang/src/test/java/javaslang/collection/IntMultimap.java
+++ b/javaslang/src/test/java/javaslang/collection/IntMultimap.java
@@ -5,7 +5,6 @@
  */
 package javaslang.collection;
 
-import javaslang.API;
 import javaslang.Tuple;
 import javaslang.Tuple2;
 import javaslang.Tuple3;
@@ -78,13 +77,13 @@ public class IntMultimap<T> implements Traversable<T>, Serializable {
     }
 
     @Override
-    public IntMultimap<T> drop(long n) {
+    public IntMultimap<T> drop(int n) {
         final Multimap<Integer, T> dropped = original.drop(n);
         return dropped == original ? this : IntMultimap.of(dropped);
     }
 
     @Override
-    public IntMultimap<T> dropRight(long n) {
+    public IntMultimap<T> dropRight(int n) {
         final Multimap<Integer, T> dropped = original.dropRight(n);
         return dropped == original ? this : IntMultimap.of(dropped);
     }
@@ -121,7 +120,7 @@ public class IntMultimap<T> implements Traversable<T>, Serializable {
     }
 
     @Override
-    public Iterator<IntMultimap<T>> grouped(long size) {
+    public Iterator<IntMultimap<T>> grouped(int size) {
         return original.grouped(size).map(IntMultimap::of);
     }
 
@@ -224,12 +223,12 @@ public class IntMultimap<T> implements Traversable<T>, Serializable {
     }
 
     @Override
-    public Iterator<IntMultimap<T>> sliding(long size) {
+    public Iterator<IntMultimap<T>> sliding(int size) {
         return original.sliding(size).map(IntMultimap::of);
     }
 
     @Override
-    public Iterator<IntMultimap<T>> sliding(long size, long step) {
+    public Iterator<IntMultimap<T>> sliding(int size, int step) {
         return original.sliding(size, step).map(IntMultimap::of);
     }
 
@@ -280,12 +279,12 @@ public class IntMultimap<T> implements Traversable<T>, Serializable {
     }
 
     @Override
-    public IntMultimap<T> take(long n) {
+    public IntMultimap<T> take(int n) {
         return IntMultimap.of(original.take(n));
     }
 
     @Override
-    public IntMultimap<T> takeRight(long n) {
+    public IntMultimap<T> takeRight(int n) {
         return IntMultimap.of(original.takeRight(n));
     }
 
@@ -330,12 +329,12 @@ public class IntMultimap<T> implements Traversable<T>, Serializable {
     }
 
     @Override
-    public Seq<Tuple2<T, Long>> zipWithIndex() {
+    public Seq<Tuple2<T, Integer>> zipWithIndex() {
         return zipWithIndex(Tuple::of);
     }
 
     @Override
-    public <U> Seq<U> zipWithIndex(BiFunction<? super T, ? super Long, ? extends U> mapper) {
+    public <U> Seq<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return Stream.ofAll(iterator().zipWithIndex(mapper));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@ Note: The maven build currently needs to be started from the javaslang root dir
     </parent>
     <groupId>io.javaslang</groupId>
     <artifactId>javaslang-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Javaslang Parent</name>
     <description>Javaslang is a Java standard library extension built for Java 8 and above.</description>


### PR DESCRIPTION
Fixes https://github.com/javaslang/javaslang/issues/1417 on 3.0.0 (with rebase)