### PR TITLE
Implemented `Vector` as bit-mapped trie, with primitive support

### DIFF
--- a/javaslang-benchmark/src/test/java/javaslang/BenchmarkPerformanceReporter.java
+++ b/javaslang-benchmark/src/test/java/javaslang/BenchmarkPerformanceReporter.java
@@ -227,7 +227,7 @@ public class BenchmarkPerformanceReporter {
                 return "";
             }
             final double ratio = baseResult.getScore() / alternativeScore;
-            return ratio == 1.0 ? "" : PERFORMANCE_FORMAT.format(ratio) + "x";
+            return ratio == 1.0 ? "" : PERFORMANCE_FORMAT.format(ratio) + "×";
         }
     }
 
@@ -365,7 +365,7 @@ public class BenchmarkPerformanceReporter {
                 final Option<TestExecution> baseExecution = baseImplExecutions.find(e -> e.getParamKey().equals(paramKey));
                 final String paramRatio = alternativeExecution.isEmpty() || baseExecution.isEmpty() || baseExecution.get().getScore() == 0.0
                                           ? ""
-                                          : PERFORMANCE_FORMAT.format(alternativeExecution.get().getScore() / baseExecution.get().getScore()) + "x";
+                                          : PERFORMANCE_FORMAT.format(alternativeExecution.get().getScore() / baseExecution.get().getScore()) + "×";
                 ratioStings = ratioStings.append(padRight(paramRatio, paramKeySize));
             }
             return ratioStings.mkString(" ");

--- a/javaslang-benchmark/src/test/java/javaslang/JmhRunner.java
+++ b/javaslang-benchmark/src/test/java/javaslang/JmhRunner.java
@@ -4,9 +4,14 @@ import javaslang.collection.*;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.runner.Runner;
-import org.openjdk.jmh.runner.options.*;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+import org.openjdk.jmh.runner.options.VerboseMode;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 public class JmhRunner {
@@ -15,7 +20,7 @@ public class JmhRunner {
      * Note: it takes about 3 hours.
      */
     public static void main(String[] args) {
-        JmhRunner.runSlowNoAsserts(Array.of(
+        final Array<Class<?>> CLASSES = Array.of(
                 ArrayBenchmark.class,
                 BitSetBenchmark.class,
                 CharSeqBenchmark.class,
@@ -23,68 +28,83 @@ public class JmhRunner {
                 ListBenchmark.class,
                 PriorityQueueBenchmark.class,
                 VectorBenchmark.class
-        ));
+        );
+        runDebugWithAsserts(CLASSES);
+        runSlowNoAsserts(CLASSES);
     }
 
     /** enables debugging and assertions for benchmarks and production code - the speed results will be totally unreliable */
     public static void runDebugWithAsserts(Array<Class<?>> groups) {
         final Array<String> classNames = groups.map(Class::getCanonicalName);
-        run(classNames, 0, 1, 1, 0, VerboseMode.SILENT, Assertions.Enable);
+        run(classNames, 0, 1, 1, ForkJvm.DISABLE, VerboseMode.SILENT, Assertions.ENABLE, PrintInlining.DISABLE);
 
         MemoryUsage.printAndReset();
     }
 
     @SuppressWarnings("unused")
     public static void runQuickNoAsserts(Array<Class<?>> groups) {
-        runAndReport(groups, 10, 10, 10, 1, VerboseMode.NORMAL, Assertions.Disable);
+        runAndReport(groups, 5, 5, 10, ForkJvm.ENABLE, VerboseMode.NORMAL, Assertions.DISABLE, PrintInlining.DISABLE);
     }
 
     @SuppressWarnings("unused")
     public static void runNormalNoAsserts(Array<Class<?>> groups) {
-        runAndReport(groups, 15, 10, 100, 1, VerboseMode.NORMAL, Assertions.Disable);
+        runAndReport(groups, 10, 10, 200, ForkJvm.ENABLE, VerboseMode.NORMAL, Assertions.DISABLE, PrintInlining.DISABLE);
     }
 
     @SuppressWarnings("unused")
     public static void runSlowNoAsserts(Array<Class<?>> groups) {
-        runAndReport(groups, 15, 15, 300, 1, VerboseMode.EXTRA, Assertions.Disable);
+        runAndReport(groups, 25, 15, 500, ForkJvm.ENABLE, VerboseMode.EXTRA, Assertions.DISABLE, PrintInlining.DISABLE);
     }
 
-    public static void runAndReport(Array<Class<?>> groups, int warmupIterations, int measurementIterations, int millis, int forks, VerboseMode silent, Assertions assertions) {
+    public static void runAndReport(Array<Class<?>> groups, int warmupIterations, int measurementIterations, int millis, ForkJvm forkJvm, VerboseMode silent, Assertions assertions, PrintInlining printInlining) {
         final Array<String> classNames = groups.map(Class::getCanonicalName);
-        final Array<RunResult> results = run(classNames, warmupIterations, measurementIterations, millis, forks, silent, assertions);
+        final Array<RunResult> results = run(classNames, warmupIterations, measurementIterations, millis, forkJvm, silent, assertions, printInlining);
         BenchmarkPerformanceReporter.of(classNames, results).print();
-
-        MemoryUsage.printAndReset();
     }
 
-    private static Array<RunResult> run(Array<String> classNames, int warmupIterations, int measurementIterations, int millis, int forks, VerboseMode verboseMode, Assertions assertions) {
-        final ChainedOptionsBuilder builder = new OptionsBuilder()
-                .shouldDoGC(true)
-                .verbosity(verboseMode)
-                .shouldFailOnError(true)
-                .mode(Mode.Throughput)
-                .timeUnit(TimeUnit.SECONDS)
-                .warmupTime(TimeValue.milliseconds(millis))
-                .warmupIterations(warmupIterations)
-                .measurementTime(TimeValue.milliseconds(millis))
-                .measurementIterations(measurementIterations)
-                .forks(forks)
-                // We are using 2Gb and setting NewGen to 100% to avoid GC during testing.
-                // Any GC during testing will destroy the iteration (i.e. introduce unreliable noise in the measurement), which should get ignored as an outlier
-                .jvmArgsAppend("-XX:+UseG1GC", "-Xss100m", "-Xms2g", "-Xmx2g", "-XX:MaxGCPauseMillis=1000", "-XX:+UnlockExperimentalVMOptions", "-XX:G1NewSizePercent=100", "-XX:G1MaxNewSizePercent=100", assertions.vmArg);
-
-        classNames.forEach(builder::include);
-
+    private static Array<RunResult> run(Array<String> classNames, int warmupIterations, int measurementIterations, int millis, ForkJvm forkJvm, VerboseMode verboseMode, Assertions assertions, PrintInlining printInlining) {
         try {
+            final ChainedOptionsBuilder builder = new OptionsBuilder()
+                    .shouldDoGC(true)
+                    .verbosity(verboseMode)
+                    .shouldFailOnError(true)
+                    .mode(Mode.Throughput)
+                    .timeUnit(TimeUnit.SECONDS)
+                    .warmupTime(TimeValue.milliseconds(millis))
+                    .warmupIterations(warmupIterations)
+                    .measurementTime(TimeValue.milliseconds(millis))
+                    .measurementIterations(measurementIterations)
+                    .forks(forkJvm.forkCount)
+                  /* We are using 4Gb and setting NewGen to 100% to avoid GC during testing.
+                     Any GC during testing will destroy the iteration (i.e. introduce unreliable noise in the measurement), which should get ignored as an outlier */
+                    .jvmArgsAppend("-XX:+UseG1GC", "-Xss100m", "-Xms4g", "-Xmx4g", "-XX:MaxGCPauseMillis=1000", "-XX:+UnlockExperimentalVMOptions", "-XX:G1NewSizePercent=100", "-XX:G1MaxNewSizePercent=100", assertions.vmArg);
+            classNames.forEach(builder::include);
+
+            if (printInlining == PrintInlining.ENABLE) {
+                builder.jvmArgsAppend("-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining"); /* might help in deciding when the JVM is properly warmed up - or where to optimize the code */
+            }
+
             return Array.ofAll(new Runner(builder.build()).run());
-        } catch (Exception e) {
-            throw new RuntimeException(e.getMessage(), e);
+        } catch (RunnerException e) {
+            throw new RuntimeException(e);
         }
     }
 
-    public enum Assertions {
-        Enable("-enableassertions"),
-        Disable("-disableassertions");
+    /* Options */
+    private enum ForkJvm {
+        ENABLE(1),
+        DISABLE(0);
+
+        final int forkCount;
+
+        ForkJvm(int forkCount) {
+            this.forkCount = forkCount;
+        }
+    }
+
+    private enum Assertions {
+        ENABLE("-enableassertions"),
+        DISABLE("-disableassertions");
 
         final String vmArg;
 
@@ -93,13 +113,22 @@ public class JmhRunner {
         }
     }
 
+    private enum PrintInlining {
+        ENABLE,
+        DISABLE;
+    }
+
+    /* Helper methods */
+
     public static Integer[] getRandomValues(int size, int seed) {
         return getRandomValues(size, seed, false);
     }
 
     public static Integer[] getRandomValues(int size, int seed, boolean nonNegative) {
-        final Random random = new Random(seed);
+        return getRandomValues(size, nonNegative, new Random(seed));
+    }
 
+    public static Integer[] getRandomValues(int size, boolean nonNegative, Random random) {
         final Integer[] results = new Integer[size];
         for (int i = 0; i < size; i++) {
             final int value = random.nextInt(size) - (nonNegative ? 0 : (size / 2));

--- a/javaslang-benchmark/src/test/java/javaslang/MemoryUsage.java
+++ b/javaslang-benchmark/src/test/java/javaslang/MemoryUsage.java
@@ -1,6 +1,7 @@
 package javaslang;
 
-import javaslang.collection.*;
+import javaslang.collection.List;
+import javaslang.collection.TreeMultimap;
 
 import java.text.DecimalFormat;
 import java.util.Comparator;
@@ -9,7 +10,7 @@ import static com.carrotsearch.sizeof.RamUsageEstimator.*;
 
 public class MemoryUsage {
     private static final DecimalFormat RATIO_FORMAT = new DecimalFormat("#0.0");
-    private static TreeMultimap<Integer, String> memoryUsages = TreeMultimap.withSeq().empty(Comparator.reverseOrder());
+    private static TreeMultimap<Integer, String> memoryUsages = TreeMultimap.withSeq().empty(Comparator.reverseOrder()); // if forked, this will be reset every time
 
     /** Calculate the occupied memory of different internals */
     static void printAndReset() {

--- a/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java
@@ -6,14 +6,19 @@ import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 import scala.compat.java8.JFunction;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
-import static javaslang.JmhRunner.*;
+import static javaslang.JmhRunner.create;
+import static javaslang.JmhRunner.getRandomValues;
 import static javaslang.collection.Collections.areEqual;
-import static scala.collection.JavaConversions.*;
+import static scala.collection.JavaConversions.asJavaCollection;
+import static scala.collection.JavaConversions.asScalaBuffer;
 
+@SuppressWarnings({"ALL", "unchecked"})
 public class VectorBenchmark {
     static final Array<Class<?>> CLASSES = Array.of(
             Create.class,
@@ -34,30 +39,34 @@ public class VectorBenchmark {
     }
 
     public static void main(String... args) {
+        JmhRunner.runDebugWithAsserts(CLASSES);
         JmhRunner.runNormalNoAsserts(CLASSES);
     }
 
     @State(Scope.Benchmark)
     public static class Base {
-        @Param({ "32", "1024", "32768"/*, "1048576"*/ }) // i.e. depth 1,2,3(,4) for a branching factor of 32
+        @Param({"32", "1024", "32768" /*, "1048576", "33554432", "1073741824" */}) /* i.e. depth 1,2,3(,4,5,6) for a branching factor of 32 */
         public int CONTAINER_SIZE;
 
         int EXPECTED_AGGREGATE;
         Integer[] ELEMENTS;
+        int[] RANDOMIZED_INDICES;
 
         /* Only use this for non-mutating operations */
         java.util.ArrayList<Integer> javaMutable;
 
-        fj.data.Seq<Integer> fjavaPersistent = fj.data.Seq.empty();
-        org.pcollections.PVector<Integer> pcollectionsPersistent = org.pcollections.TreePVector.empty();
         scala.collection.immutable.Vector<Integer> scalaPersistent;
         clojure.lang.PersistentVector clojurePersistent;
+        fj.data.Seq<Integer> fjavaPersistent;
+        org.pcollections.PVector<Integer> pcollectionsPersistent;
         javaslang.collection.Vector<Integer> slangPersistent;
 
         @Setup
-        @SuppressWarnings("unchecked")
         public void setup() {
-            ELEMENTS = getRandomValues(CONTAINER_SIZE, 0);
+            final Random random = new Random(0);
+            ELEMENTS = getRandomValues(CONTAINER_SIZE, false, random);
+            RANDOMIZED_INDICES = Arrays2.shuffle(Array.range(0, CONTAINER_SIZE).toJavaStream().mapToInt(Integer::intValue).toArray(), random);
+
             EXPECTED_AGGREGATE = Array.of(ELEMENTS).reduce(JmhRunner::aggregate);
 
             javaMutable = create(java.util.ArrayList::new, asList(ELEMENTS), v -> areEqual(v, asList(ELEMENTS)));
@@ -69,6 +78,7 @@ public class VectorBenchmark {
         }
     }
 
+    /** Bulk creation from array based, boxed source */
     public static class Create extends Base {
         @Benchmark
         public Object java_mutable() {
@@ -157,7 +167,6 @@ public class VectorBenchmark {
         }
     }
 
-    @SuppressWarnings("Convert2MethodRef")
     public static class Tail extends Base {
         @State(Scope.Thread)
         public static class Initialized {
@@ -177,9 +186,9 @@ public class VectorBenchmark {
 
         @Benchmark
         public Object java_mutable(Initialized state) {
-            final java.util.ArrayList<Integer> values = state.javaMutable;
+            java.util.List<Integer> values = state.javaMutable;
             for (int i = 0; i < CONTAINER_SIZE; i++) {
-                values.remove(0);
+                values = values.subList(1, values.size()); // remove(0) would copy everything, but this will slow access down because of nesting
             }
             assert values.isEmpty();
             return values;
@@ -190,16 +199,6 @@ public class VectorBenchmark {
             scala.collection.immutable.Vector<Integer> values = scalaPersistent;
             for (int i = 0; i < CONTAINER_SIZE; i++) {
                 values = values.tail();
-            }
-            assert values.isEmpty();
-            return values;
-        }
-
-        @Benchmark
-        public Object clojure_persistent() {
-            clojure.lang.PersistentVector values = clojurePersistent;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                values = values.pop();
             }
             assert values.isEmpty();
             return values;
@@ -236,11 +235,12 @@ public class VectorBenchmark {
         }
     }
 
+    /** Aggregated, randomized access to every element */
     public static class Get extends Base {
         @Benchmark
         public int java_mutable() {
             int aggregate = 0;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
+            for (int i : RANDOMIZED_INDICES) {
                 aggregate ^= javaMutable.get(i);
             }
             assert aggregate == EXPECTED_AGGREGATE;
@@ -250,7 +250,7 @@ public class VectorBenchmark {
         @Benchmark
         public int scala_persistent() {
             int aggregate = 0;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
+            for (int i : RANDOMIZED_INDICES) {
                 aggregate ^= scalaPersistent.apply(i);
             }
             assert aggregate == EXPECTED_AGGREGATE;
@@ -260,7 +260,7 @@ public class VectorBenchmark {
         @Benchmark
         public int clojure_persistent() {
             int aggregate = 0;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
+            for (int i : RANDOMIZED_INDICES) {
                 aggregate ^= (int) clojurePersistent.get(i);
             }
             assert aggregate == EXPECTED_AGGREGATE;
@@ -270,7 +270,7 @@ public class VectorBenchmark {
         @Benchmark
         public int fjava_persistent() {
             int aggregate = 0;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
+            for (int i : RANDOMIZED_INDICES) {
                 aggregate ^= fjavaPersistent.index(i);
             }
             assert aggregate == EXPECTED_AGGREGATE;
@@ -280,7 +280,7 @@ public class VectorBenchmark {
         @Benchmark
         public int pcollections_persistent() {
             int aggregate = 0;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
+            for (int i : RANDOMIZED_INDICES) {
                 aggregate ^= pcollectionsPersistent.get(i);
             }
             assert aggregate == EXPECTED_AGGREGATE;
@@ -290,7 +290,7 @@ public class VectorBenchmark {
         @Benchmark
         public int slang_persistent() {
             int aggregate = 0;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
+            for (int i : RANDOMIZED_INDICES) {
                 aggregate ^= slangPersistent.get(i);
             }
             assert aggregate == EXPECTED_AGGREGATE;
@@ -298,6 +298,7 @@ public class VectorBenchmark {
         }
     }
 
+    /** Randomized update of every element */
     public static class Update extends Base {
         @State(Scope.Thread)
         public static class Initialized {
@@ -318,7 +319,7 @@ public class VectorBenchmark {
         @Benchmark
         public Object java_mutable(Initialized state) {
             final java.util.ArrayList<Integer> values = state.javaMutable;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
+            for (int i : RANDOMIZED_INDICES) {
                 values.set(i, 0);
             }
             assert Array.ofAll(values).forAll(e -> e == 0);
@@ -328,7 +329,7 @@ public class VectorBenchmark {
         @Benchmark
         public Object scala_persistent() {
             scala.collection.immutable.Vector<Integer> values = scalaPersistent;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
+            for (int i : RANDOMIZED_INDICES) {
                 values = values.updateAt(i, 0);
             }
             assert Array.ofAll(asJavaCollection(values)).forAll(e -> e == 0);
@@ -338,7 +339,7 @@ public class VectorBenchmark {
         @Benchmark
         public Object clojure_persistent() {
             clojure.lang.PersistentVector values = clojurePersistent;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
+            for (int i : RANDOMIZED_INDICES) {
                 values = values.assocN(i, 0);
             }
             assert Array.of(values.toArray()).forAll(e -> Objects.equals(e, 0));
@@ -348,7 +349,7 @@ public class VectorBenchmark {
         @Benchmark
         public Object fjava_persistent() {
             fj.data.Seq<Integer> values = fjavaPersistent;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
+            for (int i : RANDOMIZED_INDICES) {
                 values = values.update(i, 0);
             }
             assert Array.ofAll(values).forAll(e -> e == 0);
@@ -358,7 +359,7 @@ public class VectorBenchmark {
         @Benchmark
         public Object pcollections_persistent() {
             org.pcollections.PVector<Integer> values = pcollectionsPersistent;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
+            for (int i : RANDOMIZED_INDICES) {
                 values = values.with(i, 0);
             }
             assert Array.ofAll(values).forAll(e -> e == 0);
@@ -368,7 +369,7 @@ public class VectorBenchmark {
         @Benchmark
         public Object slang_persistent() {
             javaslang.collection.Vector<Integer> values = slangPersistent;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
+            for (int i : RANDOMIZED_INDICES) {
                 values = values.update(i, 0);
             }
             assert values.forAll(e -> e == 0);
@@ -376,11 +377,10 @@ public class VectorBenchmark {
         }
     }
 
-    @SuppressWarnings("ManualArrayToCollectionCopy")
     public static class Prepend extends Base {
         @Benchmark
         public Object java_mutable() {
-            final java.util.ArrayList<Integer> values = new java.util.ArrayList<>(CONTAINER_SIZE);
+            final java.util.ArrayList<Integer> values = new java.util.ArrayList<>(); // no initial value, as we're simulating dynamic usage
             for (Integer element : ELEMENTS) {
                 values.add(0, element);
             }
@@ -395,6 +395,20 @@ public class VectorBenchmark {
                 values = values.appendFront(element);
             }
             assert areEqual(Array.ofAll(asJavaCollection(values)).reverse(), javaMutable);
+            return values;
+        }
+
+        @Benchmark
+        public Object clojure_persistent() {
+            clojure.lang.PersistentVector values = clojure.lang.PersistentVector.EMPTY;
+            for (int i = 0; i < ELEMENTS.length; i++) {
+                clojure.lang.PersistentVector prepended = clojure.lang.PersistentVector.create(ELEMENTS[i]);
+                for (Object value : values) {
+                    prepended = prepended.cons(value); // rebuild everything via append
+                }
+                values = prepended;
+            }
+            assert areEqual(Array.ofAll(values).reverse(), javaMutable);
             return values;
         }
 
@@ -429,11 +443,10 @@ public class VectorBenchmark {
         }
     }
 
-    @SuppressWarnings("ManualArrayToCollectionCopy")
     public static class Append extends Base {
         @Benchmark
         public Object java_mutable() {
-            final java.util.ArrayList<Integer> values = new java.util.ArrayList<>(CONTAINER_SIZE);
+            final java.util.ArrayList<Integer> values = new java.util.ArrayList<>(); // no initial value as we're simulating dynamic usage
             for (Integer element : ELEMENTS) {
                 values.add(element);
             }
@@ -445,7 +458,9 @@ public class VectorBenchmark {
         public Object scala_persistent() {
             scala.collection.immutable.Vector<Integer> values = scala.collection.immutable.Vector$.MODULE$.empty();
             for (Integer element : ELEMENTS) {
-                values = values.appendBack(element);
+                final scala.collection.immutable.Vector<Integer> newValues = values.appendBack(element);
+                assert values != newValues;
+                values = newValues;
             }
             assert areEqual(asJavaCollection(values), javaMutable);
             return values;
@@ -455,7 +470,9 @@ public class VectorBenchmark {
         public Object clojure_persistent() {
             clojure.lang.PersistentVector values = clojure.lang.PersistentVector.EMPTY;
             for (Integer element : ELEMENTS) {
-                values = values.cons(element);
+                final clojure.lang.PersistentVector newValues = values.cons(element);
+                assert values != newValues;
+                values = newValues;
             }
             assert areEqual(values, javaMutable);
             return values;
@@ -465,7 +482,9 @@ public class VectorBenchmark {
         public Object fjava_persistent() {
             fj.data.Seq<Integer> values = fj.data.Seq.empty();
             for (Integer element : ELEMENTS) {
-                values = values.snoc(element);
+                final fj.data.Seq<Integer> newValues = values.snoc(element);
+                assert values != newValues;
+                values = newValues;
             }
             assert areEqual(values, javaMutable);
             return values;
@@ -475,7 +494,9 @@ public class VectorBenchmark {
         public Object pcollections_persistent() {
             org.pcollections.PVector<Integer> values = org.pcollections.TreePVector.empty();
             for (Integer element : ELEMENTS) {
-                values = values.plus(element);
+                final org.pcollections.PVector<Integer> newValues = values.plus(element);
+                assert values != newValues;
+                values = newValues;
             }
             assert areEqual(values, javaMutable);
             return values;
@@ -485,7 +506,9 @@ public class VectorBenchmark {
         public Object slang_persistent() {
             javaslang.collection.Vector<Integer> values = javaslang.collection.Vector.empty();
             for (Integer element : ELEMENTS) {
-                values = values.append(element);
+                final Vector<Integer> newValues = values.append(element);
+                assert values != newValues;
+                values = newValues;
             }
             assert areEqual(values, javaMutable);
             return values;
@@ -509,36 +532,50 @@ public class VectorBenchmark {
         }
     }
 
+    /** Consume the vector one-by-one, from the front and back */
     public static class Slice extends Base {
         @Benchmark
-        public void java_mutable(Blackhole bh) {
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                for (int j = i; j < Math.min(CONTAINER_SIZE, 100); j++) {
-                    bh.consume(javaMutable.subList(i, j));
-                }
+        public void java_mutable(Blackhole bh) { // stores the whole list underneath
+            java.util.List<Integer> values = javaMutable;
+            while (!values.isEmpty()) {
+                values = values.subList(1, values.size());
+                values = values.subList(0, values.size() - 1);
+                bh.consume(values);
+            }
+        }
+
+        @Benchmark
+        public void clojure_persistent(Blackhole bh) { // stores the whole list underneath
+            java.util.List<?> values = clojurePersistent;
+            while (!values.isEmpty()) {
+                values = values.subList(1, values.size());
+                values = values.subList(0, values.size() - 1);
+                bh.consume(values);
             }
         }
 
         @Benchmark
         public void scala_persistent(Blackhole bh) {
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                for (int j = i; j < Math.min(CONTAINER_SIZE, 100); j++) {
-                    bh.consume(scalaPersistent.slice(i, j));
-                }
+            scala.collection.immutable.Vector<Integer> values = this.scalaPersistent;
+            while (!values.isEmpty()) {
+                values = values.slice(1, values.size());
+                values = values.slice(0, values.size() - 1);
+                bh.consume(values);
             }
         }
 
         @Benchmark
         public void slang_persistent(Blackhole bh) {
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                for (int j = i; j < Math.min(CONTAINER_SIZE, 100); j++) {
-                    bh.consume(slangPersistent.slice(i, j));
-                }
+            javaslang.collection.Vector<Integer> values = this.slangPersistent;
+            while (!values.isEmpty()) {
+                values = values.slice(1, values.size());
+                values = values.slice(0, values.size() - 1);
+                bh.consume(values);
             }
         }
     }
 
-    @SuppressWarnings("ForLoopReplaceableByForEach")
+    /* Sequential access for all elements */
     public static class Iterate extends Base {
         @State(Scope.Thread)
         public static class Initialized {
@@ -577,7 +614,6 @@ public class VectorBenchmark {
         }
 
         @Benchmark
-        @SuppressWarnings("unchecked")
         public int clojure_persistent() {
             int aggregate = 0;
             for (final java.util.Iterator<Integer> iterator = clojurePersistent.iterator(); iterator.hasNext(); ) {

--- a/javaslang/src/main/java/javaslang/collection/Arrays2.java
+++ b/javaslang/src/main/java/javaslang/collection/Arrays2.java
@@ -68,6 +68,12 @@ final class Arrays2 { // TODO reuse these in `Array` also
         return copy;
     }
 
+    static <T> T[] drop(T[] array, int index) {
+        final T[] copy = (T[]) new Object[array.length];
+        System.arraycopy(array, index, copy, index, array.length - index);
+        return copy;
+    }
+
     static <T> T[] take(T[] array, int length) {
         return (length <= 0) ? emptyArray()
                              : copyOfRange(array, 0, length);

--- a/javaslang/src/main/java/javaslang/collection/Arrays2.java
+++ b/javaslang/src/main/java/javaslang/collection/Arrays2.java
@@ -68,6 +68,13 @@ final class Arrays2 { // TODO reuse these in `Array` also
         return copy;
     }
 
+    static <T> T[] copyAppend(T[] array, T element) {
+        final T[] copy = (T[]) new Object[array.length + 1];
+        System.arraycopy(array, 0, copy, 0, array.length); // why is this a *LOT* slower than prepend???
+        copy[array.length] = element;
+        return copy;
+    }
+
     static <T> T[] drop(T[] array, int index) {
         final T[] copy = (T[]) new Object[array.length];
         System.arraycopy(array, index, copy, index, array.length - index);

--- a/javaslang/src/main/java/javaslang/collection/Arrays2.java
+++ b/javaslang/src/main/java/javaslang/collection/Arrays2.java
@@ -7,6 +7,8 @@ package javaslang.collection;
 
 import java.util.Random;
 
+import static java.util.Arrays.copyOfRange;
+
 /**
  * Internal class, containing helpers.
  *
@@ -19,6 +21,12 @@ final class Arrays2 { // TODO reuse these in `Array` also
 
     static <T> T[] emptyArray()                  { return (T[]) EMPTY; }
     static boolean isNullOrEmpty(Object[] array) { return (array == null) || (array.length == 0); }
+
+    static <T> T getOrDefault(Object[] array, int i, T defaultValue) {
+        return (isNullOrEmpty(array) || (i < 0) || (i >= array.length))
+               ? defaultValue
+               : (T) array[i];
+    }
 
     /** Repeatedly group an array into equal sized sub-trees */
     static Object[] grouped(Object[] array, int length, int size) {
@@ -50,6 +58,19 @@ final class Arrays2 { // TODO reuse these in `Array` also
             array[i] = it.next();
         }
         return array;
+    }
+
+    static <T> T[] copyUpdate(T[] array, int index, T element) {
+        if (array == null) { array = emptyArray(); }
+        final T[] copy = (T[]) new Object[Math.max(array.length, index + 1)];
+        System.arraycopy(array, 0, copy, 0, array.length);
+        copy[index] = element;
+        return copy;
+    }
+
+    static <T> T[] take(T[] array, int length) {
+        return (length <= 0) ? emptyArray()
+                             : copyOfRange(array, 0, length);
     }
 
     /** Randomly mutate array positions */

--- a/javaslang/src/main/java/javaslang/collection/Arrays2.java
+++ b/javaslang/src/main/java/javaslang/collection/Arrays2.java
@@ -7,8 +7,6 @@ package javaslang.collection;
 
 import java.util.Random;
 
-import static java.util.Arrays.copyOfRange;
-
 /**
  * Internal class, containing helpers.
  *
@@ -19,30 +17,31 @@ import static java.util.Arrays.copyOfRange;
 final class Arrays2 { // TODO reuse these in `Array` also
     private static final Object[] EMPTY = {};
 
-    static <T> T[] emptyArray()                  { return (T[]) EMPTY; }
-    static boolean isNullOrEmpty(Object[] array) { return (array == null) || (array.length == 0); }
+    static <T> T[] emptyArray()                { return (T[]) EMPTY; }
+    static boolean isNullOrEmpty(Object array) { return (array == null) || (getLength(array) == 0); }
 
-    static <T> T getOrDefault(Object[] array, int i, T defaultValue) {
-        return (isNullOrEmpty(array) || (i < 0) || (i >= array.length))
+    static <T> T getOrDefault(Object array, int i, T defaultValue) {
+        return (isNullOrEmpty(array) || (i < 0) || (i >= getLength(array)))
                ? defaultValue
-               : (T) array[i];
+               : (T) getAt(array, i);
     }
 
     /** Repeatedly group an array into equal sized sub-trees */
-    static Object[] grouped(Object[] array, int length, int size) {
-        Object[] results = new Object[Math.min(size, length)];
-        System.arraycopy(array, 0, results, 0, results.length);
+    static Object grouped(Object array, int length, int groupSize) {
+        final Class<?> type = arrayType(array);
 
-        if (results.length < array.length) {
-            final Object[] parentArray = new Object[1 + ((length - 1) / size)];
+        final int firstSize = Math.min(groupSize, length);
+        Object results = arrayCopy(type, firstSize, array, 0, 0, firstSize);
+
+        if (firstSize < length) {
+            final Object[] parentArray = new Object[1 + ((length - 1) / groupSize)];
             parentArray[0] = results;
 
-            for (int start = results.length, i = 1; start < array.length; i++) {
-                final int nextLength = Math.min(size, length - (i * size));
-                Object[] next = new Object[nextLength];
-                System.arraycopy(array, start, next, 0, nextLength);
+            for (int start = firstSize, i = 1; start < length; i++) {
+                final int nextSize = Math.min(groupSize, length - (i * groupSize));
+                final Object next = arrayCopy(type, nextSize, array, start, 0, nextSize);
                 parentArray[i] = next;
-                start += nextLength;
+                start += nextSize;
             }
 
             results = parentArray;
@@ -60,37 +59,138 @@ final class Arrays2 { // TODO reuse these in `Array` also
         return array;
     }
 
-    static <T> T[] copyPrepend(T[] array, T element) {
-        final T[] copy = (T[]) new Object[array.length + 1];
-        System.arraycopy(array, 0, copy, 1, array.length);
-        copy[0] = element;
+    static Object asArray(Class<?> type, Object element) {
+        final Object copy = arrayCopy(type, 1, null, 0, 0, 0);
+        setAt(copy, 0, element);
         return copy;
     }
 
-    static <T> T[] copyUpdate(T[] array, int index, T element) {
+    static Object copyRange(Object array, int from, int to) {
+        final int length = to - from;
+        return arrayCopy(arrayType(array), length, array, from, 0, length);
+    }
+
+    static <T> Object copyPrepend(Class<?> type, Object array, T element) {
+        final int length = getLength(array);
+        final Object copy = arrayCopy(type, length + 1, array, 0, 1, length);
+        setAt(copy, 0, element);
+        return copy;
+    }
+
+    static <T> Object copyUpdate(Object array, int index, T element) {
         if (array == null) { array = emptyArray(); }
-        final T[] copy = (T[]) new Object[Math.max(array.length, index + 1)];
-        System.arraycopy(array, 0, copy, 0, array.length);
-        copy[index] = element;
+        final int length = getLength(array);
+        final Object copy = arrayCopy(arrayType(array), Math.max(length, index + 1), array, 0, 0, length);
+        setAt(copy, index, element);
         return copy;
     }
 
-    static <T> T[] copyAppend(T[] array, T element) {
-        final T[] copy = (T[]) new Object[array.length + 1];
-        System.arraycopy(array, 0, copy, 0, array.length); // why is this a *LOT* slower than prepend???
-        copy[array.length] = element;
+    static <T> Object copyAppend(Class<?> type, Object array, T element) {
+        final int length = getLength(array);
+        final Object copy = arrayCopy(type, length + 1, array, 0, 0, length);
+        setAt(copy, length, element);
         return copy;
     }
 
-    static <T> T[] drop(T[] array, int index) {
-        final T[] copy = (T[]) new Object[array.length];
-        System.arraycopy(array, index, copy, index, array.length - index);
-        return copy;
+    static <T> Object copyDrop(Object array, int index) {
+        final int length = getLength(array);
+        return arrayCopy(arrayType(array), length, array, index, index, length - index);
     }
 
-    static <T> T[] take(T[] array, int length) {
+    static Object copyTake(Object array, int length) {
         return (length <= 0) ? emptyArray()
-                             : copyOfRange(array, 0, length);
+                             : copyRange(array, 0, length);
+    }
+
+    static Class<?> arrayType(Object array) {
+        return array.getClass().getComponentType();
+    }
+
+    /** for performance reasons the array allocation and the System.arraycopy must be next to each other - even an if (size > 0) will make it slower */
+    @SuppressWarnings("ObjectEquality")
+    static Object arrayCopy(Class<?> type, int arraySize, Object source, int sourceFrom, int destinationFrom, int size) {
+        assert arraySize >= size;
+        if (!type.isPrimitive()) {
+            if (size == 0) {
+                return new Object[arraySize];
+            } else {
+                final Object[] result = new Object[arraySize];
+                System.arraycopy(source, sourceFrom, result, destinationFrom, size);
+                return result;
+            }
+        } else if (type == int.class) {
+            if (size == 0) {
+                return new int[arraySize];
+            } else {
+                final int[] result = new int[arraySize];
+                System.arraycopy(source, sourceFrom, result, destinationFrom, size);
+                return result;
+            }
+        } else if (type == char.class) {
+            if (size == 0) {
+                return new char[arraySize];
+            } else {
+                final char[] result = new char[arraySize];
+                System.arraycopy(source, sourceFrom, result, destinationFrom, size);
+                return result;
+            }
+        } else {
+            final Object result = java.lang.reflect.Array.newInstance(type, arraySize);
+            if (size > 0) {
+                System.arraycopy(source, sourceFrom, result, destinationFrom, size);
+            }
+            return result;
+        }
+    }
+
+    static int getLength(Object array) {
+        if (array instanceof Object[]) return ((Object[]) array).length;
+        else if (array instanceof int[]) return ((int[]) array).length;
+        else if (array instanceof char[]) return ((char[]) array).length;
+        else return java.lang.reflect.Array.getLength(array);
+    }
+
+    static <T> T getAt(Object array, int index) {
+        if (array instanceof Object[]) return (T) ((Object[]) array)[index];
+        else if (array instanceof int[]) return (T) (Object) ((int[]) array)[index];
+        else if (array instanceof char[]) return (T) (Object) ((char[]) array)[index];
+        else return (T) java.lang.reflect.Array.get(array, index);
+    }
+
+    static void setAt(Object array, int index, Object value) {
+        if (array instanceof Object[]) ((Object[]) array)[index] = value;
+        else if (array instanceof int[]) ((int[]) array)[index] = (int) value;
+        else if (array instanceof char[]) ((char[]) array)[index] = (char) value;
+        else java.lang.reflect.Array.set(array, index, value);
+    }
+
+    static <T> T toPrimitiveArray(Class<?> type, Object[] array) {
+        assert isNullOrEmpty(array) || (type == toPrimitive(array[0].getClass()));
+        assert !type.isArray();
+        final Object results = arrayCopy(type, array.length, null, 0, 0, 0);
+        for (int i = 0; i < array.length; i++) {
+            setAt(results, i, array[i]);
+        }
+        return (T) results;
+    }
+
+    /* convert to primitive */
+    private static final Class<?>[] WRAPPERS = {Boolean.class, Byte.class, Character.class, Double.class, Float.class, Integer.class, Long.class, Short.class, Void.class};
+    private static final Class<?>[] PRIMITIVES = {boolean.class, byte.class, char.class, double.class, float.class, int.class, long.class, short.class, void.class};
+
+    static Class<?> toPrimitive(Class<?> wrapper) {
+        final int i = primitiveIndex(wrapper);
+        return (i < 0) ? wrapper
+                       : PRIMITIVES[i];
+    }
+
+    private static int primitiveIndex(Class<?> wrapper) { /* linear search is faster than binary search here */
+        for (int j = 0; j < WRAPPERS.length; j++) {
+            if (wrapper == WRAPPERS[j]) {
+                return j;
+            }
+        }
+        return -1;
     }
 
     /** Randomly mutate array positions */

--- a/javaslang/src/main/java/javaslang/collection/Arrays2.java
+++ b/javaslang/src/main/java/javaslang/collection/Arrays2.java
@@ -60,6 +60,13 @@ final class Arrays2 { // TODO reuse these in `Array` also
         return array;
     }
 
+    static <T> T[] copyPrepend(T[] array, T element) {
+        final T[] copy = (T[]) new Object[array.length + 1];
+        System.arraycopy(array, 0, copy, 1, array.length);
+        copy[0] = element;
+        return copy;
+    }
+
     static <T> T[] copyUpdate(T[] array, int index, T element) {
         if (array == null) { array = emptyArray(); }
         final T[] copy = (T[]) new Object[Math.max(array.length, index + 1)];

--- a/javaslang/src/main/java/javaslang/collection/Arrays2.java
+++ b/javaslang/src/main/java/javaslang/collection/Arrays2.java
@@ -17,6 +17,41 @@ import java.util.Random;
 final class Arrays2 { // TODO reuse these in `Array` also
     private static final Object[] EMPTY = {};
 
+    static <T> T[] emptyArray()                  { return (T[]) EMPTY; }
+    static boolean isNullOrEmpty(Object[] array) { return (array == null) || (array.length == 0); }
+
+    /** Repeatedly group an array into equal sized sub-trees */
+    static Object[] grouped(Object[] array, int length, int size) {
+        Object[] results = new Object[Math.min(size, length)];
+        System.arraycopy(array, 0, results, 0, results.length);
+
+        if (results.length < array.length) {
+            final Object[] parentArray = new Object[1 + ((length - 1) / size)];
+            parentArray[0] = results;
+
+            for (int start = results.length, i = 1; start < array.length; i++) {
+                final int nextLength = Math.min(size, length - (i * size));
+                Object[] next = new Object[nextLength];
+                System.arraycopy(array, start, next, 0, nextLength);
+                parentArray[i] = next;
+                start += nextLength;
+            }
+
+            results = parentArray;
+        }
+
+        return results;
+    }
+
+    /** Store the content of an iterable in an array */
+    static <T> T[] asArray(java.util.Iterator<T> it, int length) {
+        final T[] array = (T[]) new Object[length];
+        for (int i = 0; i < length; i++) {
+            array[i] = it.next();
+        }
+        return array;
+    }
+
     /** Randomly mutate array positions */
     static <T> int[] shuffle(int[] array, Random random) {
         for (int i = array.length; i > 1; i--) {

--- a/javaslang/src/main/java/javaslang/collection/Arrays2.java
+++ b/javaslang/src/main/java/javaslang/collection/Arrays2.java
@@ -1,0 +1,33 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2016 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+import java.util.Random;
+
+/**
+ * Internal class, containing helpers.
+ *
+ * @author Pap Lőrinc
+ * @since 3.0.0
+ */
+@SuppressWarnings({"unchecked", "SuspiciousArrayCast"})
+final class Arrays2 { // TODO reuse these in `Array` also
+    private static final Object[] EMPTY = {};
+
+    /** Randomly mutate array positions */
+    static <T> int[] shuffle(int[] array, Random random) {
+        for (int i = array.length; i > 1; i--) {
+            swap(array, i - 1, random.nextInt(i));
+        }
+        return array;
+    }
+
+    static <T> void swap(int[] array, int i, int j) {
+        final int temp = array[i];
+        array[i] = array[j];
+        array[j] = temp;
+    }
+}

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -9,42 +9,60 @@ import javaslang.*;
 import javaslang.collection.VectorModule.Combinations;
 import javaslang.control.Option;
 
+import java.io.Serializable;
 import java.util.*;
 import java.util.Set;
 import java.util.function.*;
 import java.util.stream.Collector;
 
+import static java.util.Arrays.copyOfRange;
+import static javaslang.collection.Arrays2.asArray;
+import static javaslang.collection.Arrays2.emptyArray;
 import static javaslang.collection.Collections.*;
+import static javaslang.collection.Vector.VectorTree.create;
+import static javaslang.collection.Vector.VectorTree.emptyTree;
 
 /**
- * Vector is the default Seq implementation. It provides the best performance in between Array (with constant time element access)
- * and List (with constant time element addition).
+ * Vector is the default Seq implementation that provides effectively constant time access to any element.
+ * Many other operations (e.g. `tail`, `drop`, `slice`) are also effectively constant.
+ * <p>
+ * It's implemented using a `bit-mapped vector trie`, i.e. a tree where each node has 32 children.
+ * For integers this means that the tree's depth will be ≤ 6.
+ * <p>
+ * For symmetrically fast beginning and end operations (e.g. `drop` vs `dropRight`) two small arrays are used as depthless staging areas.
+ * The leading and trailing arrays have dynamic lengths (their max size equals the branching factor),
+ * but the middle tree's leafs only contain full blocks - though the first one may be padded by an offset.
+ * The leading is only empty if everything is empty; if the trailing is empty, so is the middle.
  *
  * @param <T> Component type of the Vector.
- * @author Ruslan Sennov
- * @since 2.0.0
+ * @author Pap Lőrinc
+ * @since 3.0.0
  */
 @SuppressWarnings({"SuspiciousArrayCast", "unchecked"})
-public class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
+public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
     private static final long serialVersionUID = 1L;
 
-    static final Vector<?> EMPTY = new Vector<>(HashArrayMappedTrie.empty());
+    static int BRANCHING_BASE = 5;
+    static int branchingFactor()                   { return (1 << BRANCHING_BASE); }
+    static int firstDigit(int num, int depthShift) { return num >> depthShift; }
+    static int digit(int num, int depthShift)      { return lastDigit(num >> depthShift); }
+    static int lastDigit(int num)                  { return (num & (-1 >>> -BRANCHING_BASE)); }
 
-    private final HashArrayMappedTrie<Integer, T> trie;
-    private final int indexShift;
+    private static final Vector<?> EMPTY = new Vector<>(emptyArray(), emptyTree(), emptyArray());
 
-    private static <T> Vector<T> wrap(HashArrayMappedTrie<Integer, T> trie) {
-        return trie.isEmpty() ? empty() : new Vector<>(trie);
+    final VectorTree<T> middle;
+    final T[] leading, trailing;
+
+    private Vector(T[] leading, VectorTree<T> middle, T[] trailing) {
+        this.leading = leading;
+        this.middle = middle;
+        this.trailing = trailing;
+
+        assert (leading.length <= branchingFactor()) && (trailing.length <= branchingFactor());
+        assert (leadingLength() == 0) || (length() > 0);
     }
 
-    private Vector(HashArrayMappedTrie<Integer, T> trie) {
-        this(0, trie);
-    }
-
-    private Vector(int indexShift, HashArrayMappedTrie<Integer, T> trie) {
-        this.trie = trie;
-        this.indexShift = indexShift;
-    }
+    private int leadingLength() { return leading.length; }
 
     /**
      * Returns the empty Vector.
@@ -95,7 +113,8 @@ public class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
      * @return A new Vector instance containing the given element
      */
     public static <T> Vector<T> of(T element) {
-        return ofAll(List.of(element));
+        final T[] leading = (T[]) new Object[] {element};
+        return new Vector<T>(leading, emptyTree(), emptyArray());
     }
 
     /**
@@ -157,12 +176,42 @@ public class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
         if (elements instanceof Vector) {
             return (Vector<T>) elements;
         } else {
-            HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-            for (T element : elements) {
-                trie = trie.put(trie.size(), element);
-            }
-            return wrap(trie);
+            final Seq<? extends T> seq = seq(elements);
+            return seq.isEmpty() ? empty()
+                                 : ofAll(seq, seq.size());
         }
+    }
+
+    public static <T> Vector<T> ofAll(Collection<? extends T> elements) {
+        Objects.requireNonNull(elements, "elements is null");
+        return elements.isEmpty() ? empty()
+                                  : ofAll(elements, elements.size());
+    }
+
+    public static <T> Vector<T> ofAll(Iterable<? extends T> iterable, int size) {
+        Object[] array = (iterable instanceof ArrayList) ? ((ArrayList<?>) iterable).toArray()
+                                                         : asArray(iterable.iterator(), size);
+        if (array.length <= branchingFactor()) {
+            return new Vector<>((T[]) array, emptyTree(), emptyArray());
+        }
+
+        final T[] leading = (T[]) copyOfRange(array, 0, Math.min(size, branchingFactor()));
+        final int remaining = size - leading.length;
+        int trailingSize = lastDigit(remaining);
+        if (trailingSize == 0) { trailingSize += branchingFactor(); }
+        final T[] trailing = (T[]) copyOfRange(array, array.length - trailingSize, array.length);
+        final int middleSize = remaining - trailingSize;
+        if (middleSize == 0) {
+            return new Vector<>(leading, emptyTree(), trailing);
+        }
+
+        int depthShift = 0;
+        for (array = copyOfRange(array, leading.length, leading.length + middleSize); array.length > branchingFactor(); depthShift += BRANCHING_BASE) {
+            array = Arrays2.grouped(array, array.length, branchingFactor());
+        }
+
+        final VectorTree<T> middle = create(array, 0, middleSize, depthShift);
+        return new Vector<>(leading, middle, trailing);
     }
 
     /**
@@ -558,7 +607,7 @@ public class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
 
     @Override
     public Vector<T> append(T element) {
-        return new Vector<>(indexShift, trie.put(length() + indexShift, element));
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -618,11 +667,7 @@ public class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
         } else if (n >= length()) {
             return empty();
         } else {
-            HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-            for (int i = n; i < length(); i++) {
-                trie = trie.put(i - n, get(i));
-            }
-            return wrap(trie);
+            throw new UnsupportedOperationException();
         }
     }
 
@@ -700,15 +745,28 @@ public class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
         if ((index < 0) || (index >= length())) {
             throw new IndexOutOfBoundsException("get(" + index + ")");
         }
-        return trie.get(index + indexShift).get();
+
+        if (index < leadingLength()) {
+            return leading[index];
+        } else if (index < trailingStartIndex()) {
+            index -= leadingLength();
+            final Object[] leaf = middle.getLeaf(index);
+            return (T) leaf[lastDigit(middle.offset() + index)];
+        } else {
+            index -= trailingStartIndex();
+            assert index < trailing.length;
+            return trailing[index];
+        }
     }
+
+    private int trailingStartIndex() { return leadingLength() + middle.length(); }
 
     @Override
     public T head() {
         if (isEmpty()) {
             throw new NoSuchElementException("head of empty Vector");
         } else {
-            return get(0);
+            return leading[0];
         }
     }
 
@@ -774,7 +832,7 @@ public class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
 
     @Override
     public boolean isEmpty() {
-        return length() == 0;
+        return leadingLength() == 0;
     }
 
     @Override
@@ -784,20 +842,7 @@ public class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
 
     @Override
     public Iterator<T> iterator() {
-        return new AbstractIterator<T>() {
-            private int index = indexShift;
-            private final int size = trie.size() + indexShift;
-
-            @Override
-            public boolean hasNext() {
-                return index < size;
-            }
-
-            @Override
-            public T getNext() {
-                return trie.get(index++).get();
-            }
-        };
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -812,7 +857,7 @@ public class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
 
     @Override
     public int length() {
-        return trie.size();
+        return leadingLength() + middle.length() + trailing.length;
     }
 
     @Override
@@ -899,8 +944,7 @@ public class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
         if (isEmpty()) {
             return of(element);
         } else {
-            final int newIndexShift = indexShift - 1;
-            return new Vector<>(newIndexShift, trie.put(newIndexShift, element));
+            throw new UnsupportedOperationException();
         }
     }
 
@@ -1143,11 +1187,7 @@ public class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
         } else if (n <= 0) {
             return empty();
         } else {
-            HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-            for (int i = 0; i < n; i++) {
-                trie = trie.put(i, get(i));
-            }
-            return new Vector<>(trie);
+            throw new UnsupportedOperationException();
         }
     }
 
@@ -1231,7 +1271,7 @@ public class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
         if ((index < 0) || (index >= length())) {
             throw new IndexOutOfBoundsException("update(" + index + ")");
         } else {
-            return new Vector<>(indexShift, trie.put(index + indexShift, element));
+            throw new UnsupportedOperationException();
         }
     }
 
@@ -1284,6 +1324,68 @@ public class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
     @Override
     public String toString() {
         return mkString(stringPrefix() + "(", ", ", ")");
+    }
+
+    static final class VectorTree<T> implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private static final VectorTree<?> EMPTY = new VectorTree<>(emptyArray(), 0, 0, 0);
+        static <T> VectorTree<T> emptyTree() { return (VectorTree<T>) EMPTY; }
+
+        private final Object[] array;
+        private final int offset, length;
+        private final int depthShift;
+
+        static <T> VectorTree<T> create(Object[] array, int offset, int length, int depthShift) {
+            if (array.length == 0) {
+                assert (offset == 0) && (length == 0) && (depthShift == 0);
+                return (VectorTree<T>) EMPTY;
+            } else {
+                return new VectorTree<T>(array, offset, length, depthShift);
+            }
+        }
+
+        private VectorTree(Object[] array, int offset, int length, int depthShift) {
+            this.array = array;
+            this.offset = offset;
+            this.length = length;
+            this.depthShift = depthShift;
+
+            assert length() <= treeSize(branchingFactor(), depthShift);
+        }
+
+        static int treeSize(int branchCount, int depthShift) {
+            final int fullBranchSize = 1 << depthShift;
+            return branchCount * fullBranchSize;
+        }
+
+        int offset() { return offset; }
+
+        T[] getLeaf(int index) {
+            index += offset;
+            assert index >= 0;
+
+            if (depthShift == 0) {
+                return (T[]) array;
+            } else if (depthShift == BRANCHING_BASE) {
+                return (T[]) array[firstDigit(index, depthShift)];
+            } else {
+                Object[] root = (Object[]) array[firstDigit(index, depthShift)];
+
+                int depthShift = this.depthShift - BRANCHING_BASE;
+                root = (Object[]) root[digit(index, depthShift)];
+
+                while (depthShift > BRANCHING_BASE) {
+                    depthShift -= BRANCHING_BASE;
+                    root = (Object[]) root[digit(index, depthShift)];
+                }
+
+                assert root != null;
+                return (T[]) root;
+            }
+        }
+
+        int length() { return length; }
     }
 }
 

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -654,6 +654,21 @@ public class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
         }
     }
 
+    public Vector<T> dropRightWhile(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return dropRightUntil(predicate.negate());
+    }
+
+    public Vector<T> dropRightUntil(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        for (int i = length() - 1; i >= 0; i--) {
+            if (predicate.test(get(i))) {
+                return take(i + 1);
+            }
+        }
+        return empty();
+    }
+
     @Override
     public Vector<T> filter(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -1323,7 +1323,16 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
         if ((index < 0) || (index >= length())) {
             throw new IndexOutOfBoundsException("update(" + index + ")");
         } else {
-            throw new UnsupportedOperationException();
+            if (index < leadingLength()) {
+                final T[] newLeading = copyUpdate(leading, index, element);
+                return new Vector<>(newLeading, middle, trailing, trailingLength);
+            } else if (index < trailingStartIndex()) {
+                final VectorTree<T> newMiddle = middle.update(index - leadingLength(), element);
+                return new Vector<>(leading, newMiddle, trailing, trailingLength);
+            } else {
+                final T[] newTrailing = copyUpdate(collapsedTrailing(), index - trailingStartIndex(), element);
+                return new Vector<>(leading, middle, newTrailing, newTrailing.length);
+            }
         }
     }
 
@@ -1415,6 +1424,25 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
             final boolean shouldCollapse = (toExclusive - fromInclusive) < array.length;
             return shouldCollapse ? copyOfRange(array, fromInclusive, toExclusive)
                                   : array;
+        }
+
+        VectorTree<T> update(int index, T element) {
+            final Object[] root = recursiveSet(array, offset + index, depthShift, element, 0);
+            return create(root, offset, length(), depthShift);
+        }
+
+        /** Since the depth of the tree is always small, a non-tailrecursive call is actually faster than pre-calculating the path (is probably unrolled) */
+        static <T> Object[] recursiveSet(Object arrayObject, int index, int depthShift, T element, int endShift) {
+            final Object[] array = (Object[]) arrayObject;
+            final int childIndex = digit(index, depthShift);
+            if (depthShift <= endShift) {
+                return copyUpdate(array, childIndex, element);
+            } else {
+                final int childShift = depthShift - BRANCHING_BASE;
+                Object[] childArray = getOrDefault(array, childIndex, emptyArray());
+                childArray = recursiveSet(childArray, index, childShift, element, endShift);
+                return copyUpdate(array, childIndex, childArray);
+            }
         }
 
         VectorTree<T> take(int n) {

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -1053,7 +1053,21 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
         if (isEmpty()) {
             return of(element);
         } else {
-            throw new UnsupportedOperationException();
+            if (leadingLength() < branchingFactor()) {
+                final T[] newLeading = copyPrepend(collapsedLeading(), element);
+                return new Vector<>(newLeading, 0, middle, trailing, trailingLength);
+            } else {
+                final T[] newLeading = (T[]) new Object[] {element};
+                if (trailingLength == 0) {
+                    assert middle.length() == 0;
+                    final T[] newTrailing = collapsedLeading();
+                    final int newTrailingLength = newTrailing.length;
+                    return new Vector<>(newLeading, 0, emptyTree(), newTrailing, newTrailingLength);
+                } else {
+                    final VectorTree<T> newMiddle = middle.prependLeaf(collapsedLeading());
+                    return new Vector<>(newLeading, 0, newMiddle, trailing, trailingLength);
+                }
+            }
         }
     }
 
@@ -1491,6 +1505,31 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
             final boolean shouldCollapse = (toExclusive - fromInclusive) < array.length;
             return shouldCollapse ? copyOfRange(array, fromInclusive, toExclusive)
                                   : array;
+        }
+
+        VectorTree<T> prependLeaf(T[] leading) {
+            assert leading.length == branchingFactor();
+
+            final int newSize = length() + leading.length;
+            int offset = this.offset;
+            Object[] array = leading;
+            int depthShift = this.depthShift;
+            if (length() > 0) {
+                array = this.array;
+                if (offset == 0) {
+                    final Object[] newArray = new Object[branchingFactor()];
+                    newArray[newArray.length - 1] = array;
+                    array = newArray;
+
+                    depthShift += BRANCHING_BASE;
+                    offset = treeSize(branchingFactor() - 1, depthShift);
+                }
+
+                offset -= leading.length;
+                array = recursiveSet(array, offset, depthShift, leading, BRANCHING_BASE);
+            }
+
+            return create(array, offset, newSize, depthShift);
         }
 
         VectorTree<T> appendLeaf(T[] trailing) {

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -9,10 +9,12 @@ import javaslang.*;
 import javaslang.collection.VectorModule.Combinations;
 import javaslang.control.Option;
 
-import java.io.Serializable;
 import java.util.*;
+import java.util.Set;
 import java.util.function.*;
 import java.util.stream.Collector;
+
+import static javaslang.collection.Collections.*;
 
 /**
  * Vector is the default Seq implementation. It provides the best performance in between Array (with constant time element access)
@@ -22,14 +24,18 @@ import java.util.stream.Collector;
  * @author Ruslan Sennov
  * @since 2.0.0
  */
-public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Serializable {
-
+@SuppressWarnings({"SuspiciousArrayCast", "unchecked"})
+public class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
     private static final long serialVersionUID = 1L;
 
-    private static final Vector<?> EMPTY = new Vector<>(HashArrayMappedTrie.empty());
+    static final Vector<?> EMPTY = new Vector<>(HashArrayMappedTrie.empty());
 
     private final HashArrayMappedTrie<Integer, T> trie;
     private final int indexShift;
+
+    private static <T> Vector<T> wrap(HashArrayMappedTrie<Integer, T> trie) {
+        return trie.isEmpty() ? empty() : new Vector<>(trie);
+    }
 
     private Vector(HashArrayMappedTrie<Integer, T> trie) {
         this(0, trie);
@@ -46,14 +52,13 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @param <T> Component type.
      * @return The empty Vector.
      */
-    @SuppressWarnings("unchecked")
     public static <T> Vector<T> empty() {
         return (Vector<T>) EMPTY;
     }
 
     /**
-     * Returns a {@link java.util.stream.Collector} which may be used in conjunction with
-     * {@link java.util.stream.Stream#collect(java.util.stream.Collector)} to obtain a {@link javaslang.collection.Vector}.
+     * Returns a {@link Collector} which may be used in conjunction with
+     * {@link java.util.stream.Stream#collect(Collector)} to obtain a {@link Vector}.
      *
      * @param <T> Component type of the Vector.
      * @return A javaslang.collection.List Collector.
@@ -78,7 +83,6 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @param <T>    Component type of the {@code Vector}.
      * @return the given {@code vector} instance as narrowed type {@code Vector<T>}.
      */
-    @SuppressWarnings("unchecked")
     public static <T> Vector<T> narrow(Vector<? extends T> vector) {
         return (Vector<T>) vector;
     }
@@ -91,7 +95,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @return A new Vector instance containing the given element
      */
     public static <T> Vector<T> of(T element) {
-        return new Vector<>(HashArrayMappedTrie.<Integer, T> empty().put(0, element));
+        return ofAll(List.of(element));
     }
 
     /**
@@ -103,13 +107,9 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @throws NullPointerException if {@code elements} is null
      */
     @SafeVarargs
+    @SuppressWarnings("varargs")
     public static <T> Vector<T> of(T... elements) {
-        Objects.requireNonNull(elements, "elements is null");
-        HashArrayMappedTrie<Integer, T> result = HashArrayMappedTrie.empty();
-        for (T element : elements) {
-            result = result.put(result.size(), element);
-        }
-        return wrap(result);
+        return ofAll(List.of(elements));
     }
 
     /**
@@ -124,7 +124,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      */
     public static <T> Vector<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
         Objects.requireNonNull(f, "f is null");
-        return Collections.tabulate(n, f, Vector.empty(), Vector::of);
+        return Collections.tabulate(n, f, empty(), Vector::of);
     }
 
     /**
@@ -138,7 +138,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      */
     public static <T> Vector<T> fill(int n, Supplier<? extends T> s) {
         Objects.requireNonNull(s, "s is null");
-        return Collections.fill(n, s, Vector.empty(), Vector::of);
+        return Collections.fill(n, s, empty(), Vector::of);
     }
 
     /**
@@ -152,7 +152,6 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @return A vector containing the given elements in the same order.
      * @throws NullPointerException if {@code elements} is null
      */
-    @SuppressWarnings("unchecked")
     public static <T> Vector<T> ofAll(Iterable<? extends T> elements) {
         Objects.requireNonNull(elements, "elements is null");
         if (elements instanceof Vector) {
@@ -186,7 +185,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      */
     public static Vector<Boolean> ofAll(boolean[] array) {
         Objects.requireNonNull(array, "array is null");
-        return Vector.ofAll(Iterator.ofAll(array));
+        return ofAll(Iterator.ofAll(array));
     }
 
     /**
@@ -197,7 +196,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      */
     public static Vector<Byte> ofAll(byte[] array) {
         Objects.requireNonNull(array, "array is null");
-        return Vector.ofAll(Iterator.ofAll(array));
+        return ofAll(Iterator.ofAll(array));
     }
 
     /**
@@ -208,7 +207,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      */
     public static Vector<Character> ofAll(char[] array) {
         Objects.requireNonNull(array, "array is null");
-        return Vector.ofAll(Iterator.ofAll(array));
+        return ofAll(Iterator.ofAll(array));
     }
 
     /**
@@ -219,7 +218,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      */
     public static Vector<Double> ofAll(double[] array) {
         Objects.requireNonNull(array, "array is null");
-        return Vector.ofAll(Iterator.ofAll(array));
+        return ofAll(Iterator.ofAll(array));
     }
 
     /**
@@ -230,7 +229,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      */
     public static Vector<Float> ofAll(float[] array) {
         Objects.requireNonNull(array, "array is null");
-        return Vector.ofAll(Iterator.ofAll(array));
+        return ofAll(Iterator.ofAll(array));
     }
 
     /**
@@ -241,7 +240,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      */
     public static Vector<Integer> ofAll(int[] array) {
         Objects.requireNonNull(array, "array is null");
-        return Vector.ofAll(Iterator.ofAll(array));
+        return ofAll(Iterator.ofAll(array));
     }
 
     /**
@@ -252,7 +251,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      */
     public static Vector<Long> ofAll(long[] array) {
         Objects.requireNonNull(array, "array is null");
-        return Vector.ofAll(Iterator.ofAll(array));
+        return ofAll(Iterator.ofAll(array));
     }
 
     /**
@@ -263,20 +262,20 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      */
     public static Vector<Short> ofAll(short[] array) {
         Objects.requireNonNull(array, "array is null");
-        return Vector.ofAll(Iterator.ofAll(array));
+        return ofAll(Iterator.ofAll(array));
     }
 
     public static Vector<Character> range(char from, char toExclusive) {
-        return Vector.ofAll(Iterator.range(from, toExclusive));
+        return ofAll(Iterator.range(from, toExclusive));
     }
 
     public static Vector<Character> rangeBy(char from, char toExclusive, int step) {
-        return Vector.ofAll(Iterator.rangeBy(from, toExclusive, step));
+        return ofAll(Iterator.rangeBy(from, toExclusive, step));
     }
 
     @GwtIncompatible
     public static Vector<Double> rangeBy(double from, double toExclusive, double step) {
-        return Vector.ofAll(Iterator.rangeBy(from, toExclusive, step));
+        return ofAll(Iterator.rangeBy(from, toExclusive, step));
     }
 
     /**
@@ -296,7 +295,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @return a range of int values as specified or the empty range if {@code from >= toExclusive}
      */
     public static Vector<Integer> range(int from, int toExclusive) {
-        return Vector.ofAll(Iterator.range(from, toExclusive));
+        return ofAll(Iterator.range(from, toExclusive));
     }
 
     /**
@@ -322,7 +321,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @throws IllegalArgumentException if {@code step} is zero
      */
     public static Vector<Integer> rangeBy(int from, int toExclusive, int step) {
-        return Vector.ofAll(Iterator.rangeBy(from, toExclusive, step));
+        return ofAll(Iterator.rangeBy(from, toExclusive, step));
     }
 
     /**
@@ -342,7 +341,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @return a range of long values as specified or the empty range if {@code from >= toExclusive}
      */
     public static Vector<Long> range(long from, long toExclusive) {
-        return Vector.ofAll(Iterator.range(from, toExclusive));
+        return ofAll(Iterator.range(from, toExclusive));
     }
 
     /**
@@ -368,20 +367,20 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @throws IllegalArgumentException if {@code step} is zero
      */
     public static Vector<Long> rangeBy(long from, long toExclusive, long step) {
-        return Vector.ofAll(Iterator.rangeBy(from, toExclusive, step));
+        return ofAll(Iterator.rangeBy(from, toExclusive, step));
     }
 
     public static Vector<Character> rangeClosed(char from, char toInclusive) {
-        return Vector.ofAll(Iterator.rangeClosed(from, toInclusive));
+        return ofAll(Iterator.rangeClosed(from, toInclusive));
     }
 
     public static Vector<Character> rangeClosedBy(char from, char toInclusive, int step) {
-        return Vector.ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
+        return ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
     }
 
     @GwtIncompatible
     public static Vector<Double> rangeClosedBy(double from, double toInclusive, double step) {
-        return Vector.ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
+        return ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
     }
 
     /**
@@ -401,7 +400,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @return a range of int values as specified or the empty range if {@code from > toInclusive}
      */
     public static Vector<Integer> rangeClosed(int from, int toInclusive) {
-        return Vector.ofAll(Iterator.rangeClosed(from, toInclusive));
+        return ofAll(Iterator.rangeClosed(from, toInclusive));
     }
 
     /**
@@ -427,7 +426,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @throws IllegalArgumentException if {@code step} is zero
      */
     public static Vector<Integer> rangeClosedBy(int from, int toInclusive, int step) {
-        return Vector.ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
+        return ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
     }
 
     /**
@@ -447,7 +446,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @return a range of long values as specified or the empty range if {@code from > toInclusive}
      */
     public static Vector<Long> rangeClosed(long from, long toInclusive) {
-        return Vector.ofAll(Iterator.rangeClosed(from, toInclusive));
+        return ofAll(Iterator.rangeClosed(from, toInclusive));
     }
 
     /**
@@ -473,7 +472,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @throws IllegalArgumentException if {@code step} is zero
      */
     public static Vector<Long> rangeClosedBy(long from, long toInclusive, long step) {
-        return Vector.ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
+        return ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
     }
 
     /**
@@ -564,16 +563,23 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public Vector<T> appendAll(Iterable<? extends T> elements) {
-        HashArrayMappedTrie<Integer, T> result = trie;
-        for (T element : elements) {
-            result = result.put(result.size() + indexShift, element);
+        Objects.requireNonNull(elements, "elements is null");
+        if (!elements.iterator().hasNext()) {
+            return this;
+        } else if (isEmpty()) {
+            return ofAll(elements);
+        } else {
+            Vector<T> result = this;
+            for (T element : elements) {
+                result = result.append(element);
+            }
+            return result;
         }
-        return new Vector<>(indexShift, result);
     }
 
     @Override
     public Vector<Vector<T>> combinations() {
-        return Vector.rangeClosed(0, length()).map(this::combinations).flatMap(Function.identity());
+        return rangeClosed(0, length()).map(this::combinations).flatMap(Function.identity());
     }
 
     @Override
@@ -583,7 +589,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public Iterator<Vector<T>> crossProduct(int power) {
-        return Collections.crossProduct(Vector.empty(), this, power);
+        return Collections.crossProduct(empty(), this, power);
     }
 
     @Override
@@ -594,14 +600,14 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     @Override
     public Vector<T> distinctBy(Comparator<? super T> comparator) {
         Objects.requireNonNull(comparator, "comparator is null");
-        final java.util.Set<T> seen = new java.util.TreeSet<>(comparator);
+        final Set<T> seen = new java.util.TreeSet<>(comparator);
         return filter(seen::add);
     }
 
     @Override
     public <U> Vector<T> distinctBy(Function<? super T, ? extends U> keyExtractor) {
         Objects.requireNonNull(keyExtractor, "keyExtractor is null");
-        final java.util.Set<U> seen = new java.util.HashSet<>();
+        final Set<U> seen = new java.util.HashSet<>();
         return filter(t -> seen.add(keyExtractor.apply(t)));
     }
 
@@ -609,43 +615,28 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     public Vector<T> drop(int n) {
         if (n <= 0) {
             return this;
-        }
-        if (n >= length()) {
+        } else if (n >= length()) {
             return empty();
+        } else {
+            HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
+            for (int i = n; i < length(); i++) {
+                trie = trie.put(i - n, get(i));
+            }
+            return wrap(trie);
         }
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        for (int i = n; i < length(); i++) {
-            trie = trie.put(i - n, get(i));
-        }
-        return wrap(trie);
-    }
-
-    @Override
-    public Vector<T> dropRight(int n) {
-        if (n <= 0) {
-            return this;
-        }
-        if (n >= length()) {
-            return empty();
-        }
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        for (int i = 0; i < length() - n; i++) {
-            trie = trie.put(trie.size(), get(i));
-        }
-        return wrap(trie);
-    }
-
-    @Override
-    public Vector<T> dropUntil(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
-        return dropWhile(predicate.negate());
     }
 
     @Override
     public Vector<T> dropWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
+        return dropUntil(predicate.negate());
+    }
+
+    @Override
+    public Vector<T> dropUntil(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
         for (int i = 0; i < length(); i++) {
-            if (!predicate.test(get(i))) {
+            if (predicate.test(get(i))) {
                 return drop(i);
             }
         }
@@ -653,21 +644,27 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
+    public Vector<T> dropRight(int n) {
+        if (n <= 0) {
+            return this;
+        } else if (n >= length()) {
+            return empty();
+        } else {
+            return take(length() - n);
+        }
+    }
+
+    @Override
     public Vector<T> filter(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        HashArrayMappedTrie<Integer, T> filtered = HashArrayMappedTrie.empty();
-        for (T t : this) {
-            if (predicate.test(t)) {
-                filtered = filtered.put(filtered.size(), t);
-            }
-        }
 
-        if (filtered.isEmpty()) {
-            return Vector.empty();
-        } else if (filtered.size() == size()) {
+        final Vector<T> results = ofAll(iterator().filter(predicate));
+        if (results.isEmpty()) {
+            return empty();
+        } else if (results.length() == length()) {
             return this;
         } else {
-            return wrap(filtered);
+            return results;
         }
     }
 
@@ -677,19 +674,15 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
         if (isEmpty()) {
             return empty();
         } else {
-            HashArrayMappedTrie<Integer, U> trie = HashArrayMappedTrie.empty();
-            for (int i = 0; i < length(); i++) {
-                for (U u : mapper.apply(get(i))) {
-                    trie = trie.put(trie.size(), u);
-                }
-            }
-            return wrap(trie);
+            final Iterator<? extends U> results = iterator().flatMap(mapper);
+            return results.isEmpty() ? empty()
+                                     : ofAll(results);
         }
     }
 
     @Override
     public T get(int index) {
-        if (index < 0 || index >= length()) {
+        if ((index < 0) || (index >= length())) {
             throw new IndexOutOfBoundsException("get(" + index + ")");
         }
         return trie.get(index + indexShift).get();
@@ -698,7 +691,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     @Override
     public T head() {
         if (isEmpty()) {
-            throw new NoSuchElementException("head of empty vector");
+            throw new NoSuchElementException("head of empty Vector");
         } else {
             return get(0);
         }
@@ -732,9 +725,10 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     @Override
     public Vector<T> init() {
         if (isEmpty()) {
-            throw new UnsupportedOperationException("init of empty vector");
+            throw new UnsupportedOperationException("init of empty Vector");
+        } else {
+            return dropRight(1);
         }
-        return new Vector<>(indexShift, trie.remove(length() + indexShift - 1));
     }
 
     @Override
@@ -744,61 +738,28 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public Vector<T> insert(int index, T element) {
-        if (index < 0) {
-            throw new IndexOutOfBoundsException("insert(" + index + ", e)");
-        }
-        if (index > length()) {
-            throw new IndexOutOfBoundsException("insert(" + index + ", e) on Vector of length " + length());
-        }
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        for (int i = 0; i <= length(); i++) {
-            if (i == index) {
-                trie = trie.put(trie.size(), element);
-            }
-            if (i < length()) {
-                trie = trie.put(trie.size(), get(i));
-            }
-        }
-        return new Vector<>(trie);
+        return insertAll(index, List.of(element));
     }
 
     @Override
     public Vector<T> insertAll(int index, Iterable<? extends T> elements) {
-        if (index < 0) {
-            throw new IndexOutOfBoundsException("insert(" + index + ", e)");
-        }
-        if (index > length()) {
+        if ((index < 0) || (index > length())) {
             throw new IndexOutOfBoundsException("insert(" + index + ", e) on Vector of length " + length());
         }
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        for (int i = 0; i <= length(); i++) {
-            if (i == index) {
-                for (T element : elements) {
-                    trie = trie.put(trie.size(), element);
-                }
-            }
-            if (i < length()) {
-                trie = trie.put(trie.size(), get(i));
-            }
-        }
-        return new Vector<>(trie);
+
+        final Vector<T> begin = take(index);
+        final Vector<T> end = drop(index);
+        return begin.appendAll(elements).appendAll(end);
     }
 
     @Override
     public Vector<T> intersperse(T element) {
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        for (int i = 0; i < length(); i++) {
-            if (i > 0) {
-                trie = trie.put(trie.size(), element);
-            }
-            trie = trie.put(trie.size(), get(i));
-        }
-        return wrap(trie);
+        return ofAll(iterator().intersperse(element));
     }
 
     @Override
     public boolean isEmpty() {
-        return trie.isEmpty();
+        return length() == 0;
     }
 
     @Override
@@ -842,37 +803,39 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     @Override
     public <U> Vector<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        HashArrayMappedTrie<Integer, U> trie = HashArrayMappedTrie.empty();
-        for (int i = 0; i < length(); i++) {
-            trie = trie.put(i, mapper.apply(get(i)));
+
+        if (isEmpty()) {
+            return empty();
+        } else {
+            final Iterator<? extends U> results = iterator().map(mapper);
+            return results.isEmpty() ? empty()
+                                     : ofAll(results);
         }
-        return wrap(trie);
     }
 
     @Override
     public Vector<T> padTo(int length, T element) {
         final int actualLength = length();
-        if (length <= actualLength) {
-            return this;
-        } else {
-            return appendAll(Iterator.continually(element).take(length - actualLength));
-        }
+        return (length <= actualLength) ? this
+                                        : appendAll(Iterator.continually(element)
+                                                            .take(length - actualLength));
     }
 
     @Override
     public Vector<T> leftPadTo(int length, T element) {
-        final int actualLength = length();
-        if (length <= actualLength) {
+        if (length <= length()) {
             return this;
         } else {
-            return prependAll(Iterator.continually(element).take(length - actualLength));
+            final Iterator<T> prefix = Iterator.continually(element).take(length - length());
+            return prependAll(prefix);
         }
     }
 
     @Override
     public Vector<T> patch(int from, Iterable<? extends T> that, int replaced) {
-        from = from < 0 ? 0 : from;
-        replaced = replaced < 0 ? 0 : replaced;
+        from = Math.max(from, 0);
+        replaced = Math.max(replaced, 0);
+
         Vector<T> result = take(from).appendAll(that);
         from += replaced;
         result = result.appendAll(drop(from));
@@ -882,12 +845,12 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     @Override
     public Tuple2<Vector<T>, Vector<T>> partition(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        final java.util.List<T> left = new ArrayList<>(), right = new ArrayList<>();
+        final ArrayList<T> left = new ArrayList<>(), right = new ArrayList<>();
         for (int i = 0; i < length(); i++) {
             final T t = get(i);
             (predicate.test(t) ? left : right).add(t);
         }
-        return Tuple.of(Vector.ofAll(left), Vector.ofAll(right));
+        return Tuple.of(ofAll(left), ofAll(right));
     }
 
     @Override
@@ -902,76 +865,65 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     @Override
     public Vector<Vector<T>> permutations() {
         if (isEmpty()) {
-            return Vector.empty();
+            return empty();
+        } else if (length() == 1) {
+            return of(this);
         } else {
-            final Vector<T> tail = tail();
-            if (tail.isEmpty()) {
-                return Vector.of(this);
-            } else {
-                final Vector<Vector<T>> zero = empty();
-                return distinct().foldLeft(zero, (xs, x) -> {
-                    final Function<Vector<T>, Vector<T>> prepend = l -> l.prepend(x);
-                    return xs.appendAll(remove(x).permutations().map(prepend));
-                });
+            Vector<Vector<T>> results = empty();
+            for (T t : distinct()) {
+                for (Vector<T> ts : remove(t).permutations()) {
+                    results = results.append(of(t).appendAll(ts));
+                }
             }
+            return results;
         }
     }
 
     @Override
     public Vector<T> prepend(T element) {
-        final int newIndexShift = indexShift - 1;
-        return new Vector<>(newIndexShift, trie.put(newIndexShift, element));
+        if (isEmpty()) {
+            return of(element);
+        } else {
+            final int newIndexShift = indexShift - 1;
+            return new Vector<>(newIndexShift, trie.put(newIndexShift, element));
+        }
     }
 
     @Override
     public Vector<T> prependAll(Iterable<? extends T> elements) {
-        List<T> list = List.ofAll(elements);
-        final int newIndexShift = indexShift - list.length();
-        HashArrayMappedTrie<Integer, T> newTrie = trie;
-        for (int i = newIndexShift; !list.isEmpty(); i++) {
-            newTrie = newTrie.put(i, list.head());
-            list = list.tail();
+        Objects.requireNonNull(elements, "elements is null");
+        if (!elements.iterator().hasNext()) {
+            return this;
+        } else if (isEmpty()) {
+            return ofAll(elements);
+        } else {
+            Vector<T> result = this;
+            for (T element : seq(elements).reverse()) {
+                result = result.prepend(element);
+            }
+            return result;
         }
-        return new Vector<>(newIndexShift, newTrie);
     }
 
     @Override
     public Vector<T> remove(T element) {
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        boolean found = false;
         for (int i = 0; i < length(); i++) {
-            final T value = get(i);
-            if (found) {
-                trie = trie.put(trie.size(), value);
-            } else {
-                if (element.equals(value)) {
-                    found = true;
-                } else {
-                    trie = trie.put(trie.size(), value);
-                }
+            if (Objects.equals(get(i), element)) {
+                return removeAt(i);
             }
         }
-        return trie.size() == length() ? this : wrap(trie);
+        return this;
     }
 
     @Override
     public Vector<T> removeFirst(Predicate<T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        boolean found = false;
         for (int i = 0; i < length(); i++) {
-            final T value = get(i);
-            if (found) {
-                trie = trie.put(trie.size(), value);
-            } else {
-                if (predicate.test(value)) {
-                    found = true;
-                } else {
-                    trie = trie.put(trie.size(), value);
-                }
+            if (predicate.test(get(i))) {
+                return removeAt(i);
             }
         }
-        return trie.size() == length() ? this : wrap(trie);
+        return this;
     }
 
     @Override
@@ -987,19 +939,13 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public Vector<T> removeAt(int index) {
-        if (index < 0) {
+        if ((index < 0) || (index >= length())) {
             throw new IndexOutOfBoundsException("removeAt(" + index + ")");
+        } else {
+            final Vector<T> begin = take(index);
+            final Vector<T> end = drop(index + 1);
+            return begin.appendAll(end);
         }
-        if (index >= length()) {
-            throw new IndexOutOfBoundsException("removeAt(" + index + ")");
-        }
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        for (int i = 0; i < length(); i++) {
-            if (i != index) {
-                trie = trie.put(trie.size(), get(i));
-            }
-        }
-        return wrap(trie);
     }
 
     @Override
@@ -1013,44 +959,27 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public IndexedSeq<T> removeAll(Predicate<? super T> predicate) {
+    public Vector<T> removeAll(Predicate<? super T> predicate) {
         return Collections.removeAll(this, predicate);
     }
 
     @Override
     public Vector<T> replace(T currentElement, T newElement) {
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        boolean found = false;
-        for (int i = 0; i < length(); i++) {
-            final T value = get(i);
-            if (found) {
-                trie = trie.put(trie.size(), value);
-            } else {
-                if (currentElement.equals(value)) {
-                    trie = trie.put(trie.size(), newElement);
-                    found = true;
-                } else {
-                    trie = trie.put(trie.size(), value);
-                }
-            }
-        }
-        return found ? new Vector<>(trie) : this;
+        return indexOfOption(currentElement).map(i -> update(i, newElement))
+                                            .getOrElse(this);
     }
 
     @Override
     public Vector<T> replaceAll(T currentElement, T newElement) {
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        boolean changed = false;
-        for (int i = 0; i < length(); i++) {
-            final T value = get(i);
-            if (currentElement.equals(value)) {
-                trie = trie.put(trie.size(), newElement);
-                changed = true;
-            } else {
-                trie = trie.put(trie.size(), value);
+        Vector<T> result = this;
+        int index = 0;
+        for (T value : iterator()) {
+            if (Objects.equals(value, currentElement)) {
+                result = result.update(index, newElement);
             }
+            index++;
         }
-        return changed ? wrap(trie) : this;
+        return result;
     }
 
     @Override
@@ -1060,11 +989,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public Vector<T> reverse() {
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        for (int i = 0; i < length(); i++) {
-            trie = trie.put(i, get(length() - 1 - i));
-        }
-        return trie.isEmpty() ? empty() : new Vector<>(trie);
+        return (length() <= 1) ? this : ofAll(reverseIterator());
     }
 
     @Override
@@ -1075,30 +1000,24 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     @Override
     public <U> Vector<U> scanLeft(U zero, BiFunction<? super U, ? super T, ? extends U> operation) {
         Objects.requireNonNull(operation, "operation is null");
-        return Collections.scanLeft(this, zero, operation, Vector.empty(), Vector::append, Function.identity());
+        return Collections.scanLeft(this, zero, operation, empty(), Vector::append, Function.identity());
     }
 
     @Override
     public <U> Vector<U> scanRight(U zero, BiFunction<? super T, ? super U, ? extends U> operation) {
         Objects.requireNonNull(operation, "operation is null");
-        return Collections.scanRight(this, zero, operation, Vector.empty(), Vector::prepend, Function.identity());
+        return Collections.scanRight(this, zero, operation, empty(), Vector::prepend, Function.identity());
     }
 
     @Override
     public Vector<T> slice(int beginIndex, int endIndex) {
-        if (beginIndex >= endIndex || beginIndex >= length() || isEmpty()) {
-            return Vector.empty();
-        }
-        if (beginIndex <= 0 && endIndex >= length()) {
+        if ((beginIndex >= endIndex) || (beginIndex >= size()) || isEmpty()) {
+            return empty();
+        } else if ((beginIndex <= 0) && (endIndex >= length())) {
             return this;
+        } else {
+            return take(endIndex).drop(beginIndex);
         }
-        final int index = Math.max(beginIndex, 0);
-        final int length = Math.min(endIndex, length());
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        for (int i = index; i < length; i++) {
-            trie = trie.put(trie.size(), get(i));
-        }
-        return wrap(trie);
     }
 
     @Override
@@ -1113,13 +1032,13 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public Vector<T> sorted() {
-        return isEmpty() ? this : toJavaStream().sorted().collect(Vector.collector());
+        return isEmpty() ? this : toJavaStream().sorted().collect(collector());
     }
 
     @Override
     public Vector<T> sorted(Comparator<? super T> comparator) {
         Objects.requireNonNull(comparator, "comparator is null");
-        return isEmpty() ? this : toJavaStream().sorted(comparator).collect(Vector.collector());
+        return isEmpty() ? this : toJavaStream().sorted(comparator).collect(collector());
     }
 
     @Override
@@ -1130,9 +1049,8 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     @Override
     public <U> Vector<T> sortBy(Comparator<? super U> comparator, Function<? super T, ? extends U> mapper) {
         final Function<? super T, ? extends U> domain = Function1.of(mapper::apply).memoized();
-        return toJavaStream()
-                .sorted((e1, e2) -> comparator.compare(domain.apply(e1), domain.apply(e2)))
-                .collect(collector());
+        return toJavaStream().sorted((e1, e2) -> comparator.compare(domain.apply(e1), domain.apply(e2)))
+                             .collect(collector());
     }
 
     @Override
@@ -1150,21 +1068,17 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     public Tuple2<Vector<T>, Vector<T>> splitAt(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         final Vector<T> init = takeWhile(predicate.negate());
-        return Tuple.of(init, drop(init.length()));
+        return Tuple.of(init, drop(init.size()));
     }
 
     @Override
     public Tuple2<Vector<T>, Vector<T>> splitAtInclusive(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        HashArrayMappedTrie<Integer, T> init = HashArrayMappedTrie.empty();
-        for (T t : this) {
-            init = init.put(init.size(), t);
-            if (predicate.test(t)) {
-                if (init.size() == length()) {
-                    return Tuple.of(this, empty());
-                } else {
-                    return Tuple.of(new Vector<>(init), drop(init.size()));
-                }
+        for (int i = 0; i < length(); i++) {
+            final T value = get(i);
+            if (predicate.test(value)) {
+                return (i == (length() - 1)) ? Tuple.of(this, empty())
+                                             : Tuple.of(take(i + 1), drop(i + 1));
             }
         }
         return Tuple.of(this, empty());
@@ -1177,40 +1091,28 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public Vector<T> subSequence(int beginIndex) {
-        if (beginIndex < 0) {
-            throw new IndexOutOfBoundsException("slice(" + beginIndex + ")");
+        if ((beginIndex < 0) || (beginIndex > length())) {
+            throw new IndexOutOfBoundsException("subSequence(" + beginIndex + ")");
+        } else {
+            return drop(beginIndex);
         }
-        if (beginIndex > length()) {
-            throw new IndexOutOfBoundsException("slice(" + beginIndex + ")");
-        }
-        return drop(beginIndex);
     }
 
     @Override
     public Vector<T> subSequence(int beginIndex, int endIndex) {
-        if (beginIndex < 0 || beginIndex > endIndex || endIndex > length()) {
-            throw new IndexOutOfBoundsException("slice(" + beginIndex + ", " + endIndex + ") on Vector of length " + length());
+        if ((beginIndex < 0) || (beginIndex > endIndex) || (endIndex > length())) {
+            throw new IndexOutOfBoundsException("subSequence(" + beginIndex + ", " + endIndex + ") on Vector of size " + length());
+        } else {
+            return slice(beginIndex, endIndex);
         }
-        if (beginIndex == endIndex) {
-            return Vector.empty();
-        }
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        for (int i = beginIndex; i < endIndex; i++) {
-            trie = trie.put(trie.size(), get(i));
-        }
-        return wrap(trie);
     }
 
     @Override
     public Vector<T> tail() {
         if (isEmpty()) {
-            throw new UnsupportedOperationException("tail of empty vector");
-        }
-        if (length() == 1) {
-            return empty();
+            throw new UnsupportedOperationException("tail of empty Vector");
         } else {
-            final int newIndexShift = indexShift + 1;
-            return new Vector<>(newIndexShift, trie.remove(indexShift));
+            return drop(1);
         }
     }
 
@@ -1223,30 +1125,26 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     public Vector<T> take(int n) {
         if (n >= length()) {
             return this;
-        }
-        if (n <= 0) {
+        } else if (n <= 0) {
             return empty();
+        } else {
+            HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
+            for (int i = 0; i < n; i++) {
+                trie = trie.put(i, get(i));
+            }
+            return new Vector<>(trie);
         }
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        for (int i = 0; i < n; i++) {
-            trie = trie.put(i, get(i));
-        }
-        return new Vector<>(trie);
     }
 
     @Override
     public Vector<T> takeRight(int n) {
         if (n >= length()) {
             return this;
-        }
-        if (n <= 0) {
+        } else if (n <= 0) {
             return empty();
+        } else {
+            return drop(length() - n);
         }
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
-        for (int i = 0; i < n; i++) {
-            trie = trie.put(i, get(length() - n + i));
-        }
-        return new Vector<>(trie);
     }
 
     @Override
@@ -1258,15 +1156,13 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     @Override
     public Vector<T> takeWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        HashArrayMappedTrie<Integer, T> trie = HashArrayMappedTrie.empty();
         for (int i = 0; i < length(); i++) {
             final T value = get(i);
             if (!predicate.test(value)) {
-                break;
+                return take(i);
             }
-            trie = trie.put(i, get(i));
         }
-        return trie.size() == length() ? this : wrap(trie);
+        return this;
     }
 
     /**
@@ -1284,47 +1180,44 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public <U> Vector<U> unit(Iterable<? extends U> iterable) {
-        return Vector.ofAll(iterable);
+        return ofAll(iterable);
     }
 
     @Override
-    public <T1, T2> Tuple2<Vector<T1>, Vector<T2>> unzip(
-            Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
+    public <T1, T2> Tuple2<Vector<T1>, Vector<T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
-        HashArrayMappedTrie<Integer, T1> xs = HashArrayMappedTrie.empty();
-        HashArrayMappedTrie<Integer, T2> ys = HashArrayMappedTrie.empty();
-        for (T element : this) {
-            final Tuple2<? extends T1, ? extends T2> t = unzipper.apply(element);
-            xs = xs.put(xs.size(), t._1);
-            ys = ys.put(ys.size(), t._2);
+        Vector<T1> xs = empty();
+        Vector<T2> ys = empty();
+        for (int i = 0; i < length(); i++) {
+            final Tuple2<? extends T1, ? extends T2> t = unzipper.apply(get(i));
+            xs = xs.append(t._1);
+            ys = ys.append(t._2);
         }
-        return Tuple.of(new Vector<>(xs), new Vector<>(ys));
+        return Tuple.of(xs, ys);
     }
 
     @Override
     public <T1, T2, T3> Tuple3<Vector<T1>, Vector<T2>, Vector<T3>> unzip3(Function<? super T, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
-        HashArrayMappedTrie<Integer, T1> xs = HashArrayMappedTrie.empty();
-        HashArrayMappedTrie<Integer, T2> ys = HashArrayMappedTrie.empty();
-        HashArrayMappedTrie<Integer, T3> zs = HashArrayMappedTrie.empty();
-        for (T element : this) {
-            final Tuple3<? extends T1, ? extends T2, ? extends T3> t = unzipper.apply(element);
-            xs = xs.put(xs.size(), t._1);
-            ys = ys.put(ys.size(), t._2);
-            zs = zs.put(zs.size(), t._3);
+        Vector<T1> xs = empty();
+        Vector<T2> ys = empty();
+        Vector<T3> zs = empty();
+        for (int i = 0; i < length(); i++) {
+            final Tuple3<? extends T1, ? extends T2, ? extends T3> t = unzipper.apply(get(i));
+            xs = xs.append(t._1);
+            ys = ys.append(t._2);
+            zs = zs.append(t._3);
         }
-        return Tuple.of(new Vector<>(xs), new Vector<>(ys), new Vector<>(zs));
+        return Tuple.of(xs, ys, zs);
     }
 
     @Override
     public Vector<T> update(int index, T element) {
-        if (index < 0) {
+        if ((index < 0) || (index >= length())) {
             throw new IndexOutOfBoundsException("update(" + index + ")");
+        } else {
+            return new Vector<>(indexShift, trie.put(index + indexShift, element));
         }
-        if (index >= length()) {
-            throw new IndexOutOfBoundsException("update(" + index + ")");
-        }
-        return new Vector<>(indexShift, trie.put(index + indexShift, element));
     }
 
     @Override
@@ -1336,13 +1229,13 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     public <U, R> Vector<R> zipWith(Iterable<? extends U> that, BiFunction<? super T, ? super U, ? extends R> mapper) {
         Objects.requireNonNull(that, "that is null");
         Objects.requireNonNull(mapper, "mapper is null");
-        return Vector.ofAll(iterator().zipWith(that, mapper));
+        return ofAll(iterator().zipWith(that, mapper));
     }
 
     @Override
     public <U> Vector<Tuple2<T, U>> zipAll(Iterable<? extends U> that, T thisElem, U thatElem) {
         Objects.requireNonNull(that, "that is null");
-        return Vector.ofAll(iterator().zipAll(that, thisElem, thatElem));
+        return ofAll(iterator().zipAll(that, thisElem, thatElem));
     }
 
     @Override
@@ -1353,28 +1246,19 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     @Override
     public <U> Vector<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return Vector.ofAll(iterator().zipWithIndex(mapper));
+        return ofAll(iterator().zipWithIndex(mapper));
     }
 
-    private Object readResolve() {
-        return isEmpty() ? EMPTY : this;
-    }
+    private Object readResolve() { return isEmpty() ? EMPTY : this; }
 
     @Override
-    public boolean equals(Object o) {
-        if (o == this) {
-            return true;
-        } else if (o instanceof Vector) {
-            final Vector<?> that = (Vector<?>) o;
-            return (this.size() == that.size()) && Collections.areEqual(this, that);
-        } else {
-            return false;
-        }
+    public boolean equals(Object that) {
+        return (that == this) || ((that instanceof Vector) && areEqual(this, (Vector<?>) that));
     }
 
     @Override
     public int hashCode() {
-        return Collections.hash(this);
+        return hash(this);
     }
 
     @Override
@@ -1386,24 +1270,15 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     public String toString() {
         return mkString(stringPrefix() + "(", ", ", ")");
     }
-
-    private static <T> Vector<T> wrap(HashArrayMappedTrie<Integer, T> trie) {
-        return trie.isEmpty() ? empty() : new Vector<>(trie);
-    }
 }
 
 interface VectorModule {
-
     final class Combinations {
-
         static <T> Vector<Vector<T>> apply(Vector<T> elements, int k) {
-            if (k == 0) {
-                return Vector.of(Vector.empty());
-            } else {
-                return elements.zipWithIndex().flatMap(t -> apply(elements.drop(t._2 + 1), (k - 1))
-                        .map((Vector<T> c) -> c.prepend(t._1))
-                );
-            }
+            return (k == 0)
+                   ? Vector.of(Vector.empty())
+                   : elements.zipWithIndex().flatMap(
+                    t -> apply(elements.drop(t._2 + 1), (k - 1)).map((Vector<T> c) -> c.prepend(t._1)));
         }
     }
 }

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -842,7 +842,42 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
 
     @Override
     public Iterator<T> iterator() {
-        throw new UnsupportedOperationException();
+        return isEmpty() ? Iterator.empty() : new Iterator<T>() {
+            final int globalLength = Vector.this.length();
+            int globalIndex;
+
+            T[] leaf = leading;
+            int leafIndex;
+
+            @Override
+            public boolean hasNext() { return globalIndex < globalLength; }
+
+            @Override
+            public T next() {
+                if (leafIndex == leaf.length) { setCurrentArray(); }
+
+                final T next = leaf[leafIndex];
+                assert next == Vector.this.get(globalIndex);
+
+                leafIndex++;
+                globalIndex++;
+
+                return next;
+            }
+
+            @SuppressWarnings("ArrayEquality")
+            void setCurrentArray() {
+                if (globalIndex < trailingStartIndex()) { /* first middle-leaf can have an offset */
+                    leafIndex = (globalIndex > leadingLength()) ? 0
+                                                                : lastDigit(middle.offset());
+                    leaf = middle.getLeaf(globalIndex - leadingLength());
+                } else if (leaf != trailing) {
+                    leafIndex = 0;
+                    leaf = trailing;
+                }
+                assert leaf != null;
+            }
+        };
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -16,8 +16,6 @@ import java.util.function.*;
 import java.util.stream.Collector;
 
 import static java.lang.System.arraycopy;
-import static java.util.Arrays.copyOf;
-import static java.util.Arrays.copyOfRange;
 import static javaslang.collection.Arrays2.*;
 import static javaslang.collection.Collections.*;
 import static javaslang.collection.Vector.VectorTree.*;
@@ -48,28 +46,33 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
     static int digit(int num, int depthShift)      { return lastDigit(num >> depthShift); }
     static int lastDigit(int num)                  { return (num & (-1 >>> -BRANCHING_BASE)); }
 
-    private static final Vector<?> EMPTY = new Vector<>(emptyArray(), 0, emptyTree(), emptyArray(), 0);
+    private static final Vector<?> EMPTY = new Vector<>(Object.class, emptyArray(), 0, emptyTree(), emptyArray(), 0);
 
+    final Class<?> type;
     final VectorTree<T> middle;
-    final T[] leading, trailing;
+    final Object leading;
+    final Object trailing;
     final int leadingOffset, trailingLength;
+    final int length;
 
-    private Vector(T[] leading, int leadingOffset, VectorTree<T> middle, T[] trailing, int trailingLength) {
+    private Vector(Class<?> type, Object leading, int leadingOffset, VectorTree<T> middle, Object trailing, int trailingLength) {
+        this.type = type;
         this.leading = leading;
         this.middle = middle;
         this.trailing = trailing;
         this.leadingOffset = leadingOffset;
         this.trailingLength = trailingLength;
+        this.length = (getLength(leading) - leadingOffset) + middle.length() + trailingLength;
 
-        assert (leading.length <= branchingFactor()) && (trailing.length <= branchingFactor());
-        assert (leadingLength() == 0) || ((leadingOffset < leading.length) && (length() > 0));
-        assert (trailingLength == 0) || (leading.length > this.leadingOffset);
+        assert (getLength(leading) <= branchingFactor()) && (getLength(trailing) <= branchingFactor());
+        assert (leadingLength() == 0) || ((leadingOffset < getLength(leading)) && (length() > 0));
+        assert (trailingLength == 0) || (getLength(leading) > this.leadingOffset);
         assert (middle.length() == 0) || (trailingLength > 0);
     }
 
-    private static <T> Vector<T> normalized(T[] leading, int leadingOffset, VectorTree<T> middle, T[] trailing, int trailingLength) {
+    private static <T> Vector<T> normalized(Class<?> type, Object leading, int leadingOffset, VectorTree<T> middle, Object trailing, int trailingLength) {
         /* Normalize the 3 containers */
-        if (leading.length == leadingOffset) {
+        if (getLength(leading) == leadingOffset) {
             if (middle.length() > 0) {
                 leadingOffset = lastDigit(middle.offset());
                 leading = middle.getLeaf(0);
@@ -86,33 +89,35 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
         if (middle.length() > 0) {
             if (trailingLength == 0) {
                 trailing = middle.getLeaf(middle.length() - 1);
-                trailingLength = trailing.length;
+                trailingLength = getLength(trailing);
                 middle = middle.take(middle.length() - trailingLength);
             } else {
                 final int lastMiddleLeafLength = lastDigit(middle.offset() + middle.length());
                 if (lastMiddleLeafLength > 0) { // last leaf is not full
-                    final T[] middleLast = middle.getLeaf(middle.length() - 1);
-                    final int delta = branchingFactor() - middleLast.length;
+                    final Object middleLast = middle.getLeaf(middle.length() - 1);
+                    final int length = getLength(middleLast);
+                    final int delta = branchingFactor() - length;
                     assert (delta < branchingFactor()) && (delta <= trailingLength);
 
-                    final T[] newMiddle = copyOf(middleLast, branchingFactor());
-                    arraycopy(trailing, 0, newMiddle, middleLast.length, delta);
-                    middle = middle.take(middle.length() - middleLast.length).appendLeaf(newMiddle);
+                    final Object newMiddle = copyRange(middleLast, 0, branchingFactor());
+                    arraycopy(trailing, 0, newMiddle, length, delta);
+                    middle = middle.take(middle.length() - length).appendLeaf(newMiddle);
 
-                    trailing = copyOfRange(trailing, delta, trailingLength);
-                    trailingLength = trailing.length;
+                    trailing = copyRange(trailing, delta, trailingLength);
+                    trailingLength = getLength(trailing);
                 }
             }
         }
 
         middle = middle.collapseHeight();
 
-        return new Vector<>(leading, leadingOffset, middle, trailing, trailingLength);
+        return new Vector<>(type, leading, leadingOffset, middle, trailing, trailingLength);
     }
 
-    private T[] collapsedLeading()  { return collapse(leading, leadingOffset, leading.length); }
-    private T[] collapsedTrailing() { return collapse(trailing, 0, trailingLength); }
-    private int leadingLength()     { return leading.length - leadingOffset; }
+    private Object collapsedLeading()  { return collapse(leading, leadingOffset, getLength(leading)); }
+    private Object collapsedTrailing() { return collapse(trailing, 0, trailingLength); }
+    private int trailingStartIndex()   { return length - trailingLength; }
+    private int leadingLength()        { return trailingStartIndex() - middle.length(); }
 
     /**
      * Returns the empty Vector.
@@ -163,8 +168,9 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
      * @return A new Vector instance containing the given element
      */
     public static <T> Vector<T> of(T element) {
-        final T[] leading = (T[]) new Object[] {element};
-        return new Vector<T>(leading, 0, emptyTree(), emptyArray(), 0);
+        final Class<?> type = (element == null) ? Object.class : element.getClass();
+        final Object leading = asArray(type, element);
+        return new Vector<T>(type, leading, 0, emptyTree(), emptyArray(), 0);
     }
 
     /**
@@ -227,41 +233,58 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
             return (Vector<T>) elements;
         } else {
             final Seq<? extends T> seq = seq(elements);
-            return seq.isEmpty() ? empty()
-                                 : ofAll(seq, seq.size());
+            return ofAll(seq, seq.size());
         }
     }
 
     public static <T> Vector<T> ofAll(Collection<? extends T> elements) {
         Objects.requireNonNull(elements, "elements is null");
-        return elements.isEmpty() ? empty()
-                                  : ofAll(elements, elements.size());
+        return ofAll(elements, elements.size());
     }
 
     public static <T> Vector<T> ofAll(Iterable<? extends T> iterable, int size) {
-        Object[] array = (iterable instanceof ArrayList) ? ((ArrayList<?>) iterable).toArray()
-                                                         : asArray(iterable.iterator(), size);
-        if (array.length <= branchingFactor()) {
-            return new Vector<>((T[]) array, 0, emptyTree(), emptyArray(), 0);
+        if (!iterable.iterator().hasNext()) return empty();
+
+        final Object array = (iterable instanceof ArrayList) ? (T[]) ((ArrayList<T>) iterable).toArray()
+                                                             : asArray(iterable.iterator(), size);
+        return ofAll(Object.class, array, size);
+    }
+
+    static <T> Vector<T> ofAll(Class<?> type, Object array, int size) {
+        assert getLength(array) == size;
+        if (size <= branchingFactor()) {
+            return new Vector<>(type, array, 0, emptyTree(), emptyArray(), 0);
         }
 
-        final T[] leading = (T[]) copyOfRange(array, 0, Math.min(size, branchingFactor()));
-        final int remaining = size - leading.length;
+        final int leadingSize = Math.min(size, branchingFactor());
+        final Object leading = arrayCopy(type, leadingSize, array, 0, 0, leadingSize);
+
+        final int remaining = size - leadingSize;
         int trailingSize = lastDigit(remaining);
         if (trailingSize == 0) { trailingSize += branchingFactor(); }
-        final T[] trailing = (T[]) copyOfRange(array, array.length - trailingSize, array.length);
+
+        final int from = size - trailingSize;
+        final int trailingLength = size - from;
+
+        final Object trailing = arrayCopy(type, trailingLength, array, from, 0, trailingLength);
         final int middleSize = remaining - trailingSize;
         if (middleSize == 0) {
-            return new Vector<>(leading, 0, emptyTree(), trailing, trailing.length);
+            return new Vector<>(type, leading, 0, emptyTree(), trailing, trailingLength);
         }
+
+        array = arrayCopy(type, middleSize, array, leadingSize, 0, middleSize);
 
         int depthShift = 0;
-        for (array = copyOfRange(array, leading.length, leading.length + middleSize); array.length > branchingFactor(); depthShift += BRANCHING_BASE) {
-            array = Arrays2.grouped(array, array.length, branchingFactor());
+        while (true) {
+            final int length = getLength(array);
+            if (length <= branchingFactor()) break;
+
+            array = Arrays2.grouped(array, length, branchingFactor());
+            depthShift += BRANCHING_BASE;
         }
 
-        final VectorTree<T> middle = create(array, 0, middleSize, depthShift);
-        return new Vector<>(leading, 0, middle, trailing, trailing.length);
+        final VectorTree<T> middle = create(type, array, 0, middleSize, depthShift);
+        return new Vector<>(type, leading, 0, middle, trailing, trailingLength);
     }
 
     /**
@@ -284,7 +307,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
      */
     public static Vector<Boolean> ofAll(boolean[] array) {
         Objects.requireNonNull(array, "array is null");
-        return ofAll(Iterator.ofAll(array));
+        return ofAll(arrayType(array), array, array.length);
     }
 
     /**
@@ -295,7 +318,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
      */
     public static Vector<Byte> ofAll(byte[] array) {
         Objects.requireNonNull(array, "array is null");
-        return ofAll(Iterator.ofAll(array));
+        return ofAll(arrayType(array), array, array.length);
     }
 
     /**
@@ -306,7 +329,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
      */
     public static Vector<Character> ofAll(char[] array) {
         Objects.requireNonNull(array, "array is null");
-        return ofAll(Iterator.ofAll(array));
+        return ofAll(arrayType(array), array, array.length);
     }
 
     /**
@@ -317,7 +340,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
      */
     public static Vector<Double> ofAll(double[] array) {
         Objects.requireNonNull(array, "array is null");
-        return ofAll(Iterator.ofAll(array));
+        return ofAll(arrayType(array), array, array.length);
     }
 
     /**
@@ -328,7 +351,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
      */
     public static Vector<Float> ofAll(float[] array) {
         Objects.requireNonNull(array, "array is null");
-        return ofAll(Iterator.ofAll(array));
+        return ofAll(arrayType(array), array, array.length);
     }
 
     /**
@@ -339,7 +362,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
      */
     public static Vector<Integer> ofAll(int[] array) {
         Objects.requireNonNull(array, "array is null");
-        return ofAll(Iterator.ofAll(array));
+        return ofAll(arrayType(array), array, array.length);
     }
 
     /**
@@ -350,7 +373,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
      */
     public static Vector<Long> ofAll(long[] array) {
         Objects.requireNonNull(array, "array is null");
-        return ofAll(Iterator.ofAll(array));
+        return ofAll(arrayType(array), array, array.length);
     }
 
     /**
@@ -361,20 +384,23 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
      */
     public static Vector<Short> ofAll(short[] array) {
         Objects.requireNonNull(array, "array is null");
-        return ofAll(Iterator.ofAll(array));
+        return ofAll(arrayType(array), array, array.length);
     }
 
     public static Vector<Character> range(char from, char toExclusive) {
-        return ofAll(Iterator.range(from, toExclusive));
+        final char[] range = toPrimitiveArray(char.class, Iterator.range(from, toExclusive).toJavaArray());
+        return ofAll(range);
     }
 
     public static Vector<Character> rangeBy(char from, char toExclusive, int step) {
-        return ofAll(Iterator.rangeBy(from, toExclusive, step));
+        final char[] range = toPrimitiveArray(char.class, Iterator.rangeBy(from, toExclusive, step).toJavaArray());
+        return ofAll(range);
     }
 
     @GwtIncompatible
     public static Vector<Double> rangeBy(double from, double toExclusive, double step) {
-        return ofAll(Iterator.rangeBy(from, toExclusive, step));
+        final double[] range = toPrimitiveArray(double.class, Iterator.rangeBy(from, toExclusive, step).toJavaArray());
+        return ofAll(range);
     }
 
     /**
@@ -394,7 +420,8 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
      * @return a range of int values as specified or the empty range if {@code from >= toExclusive}
      */
     public static Vector<Integer> range(int from, int toExclusive) {
-        return ofAll(Iterator.range(from, toExclusive));
+        final int[] range = toPrimitiveArray(int.class, Iterator.range(from, toExclusive).toJavaArray());
+        return ofAll(range);
     }
 
     /**
@@ -420,7 +447,8 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
      * @throws IllegalArgumentException if {@code step} is zero
      */
     public static Vector<Integer> rangeBy(int from, int toExclusive, int step) {
-        return ofAll(Iterator.rangeBy(from, toExclusive, step));
+        final int[] range = toPrimitiveArray(int.class, Iterator.rangeBy(from, toExclusive, step).toJavaArray());
+        return ofAll(range);
     }
 
     /**
@@ -440,7 +468,8 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
      * @return a range of long values as specified or the empty range if {@code from >= toExclusive}
      */
     public static Vector<Long> range(long from, long toExclusive) {
-        return ofAll(Iterator.range(from, toExclusive));
+        final long[] range = toPrimitiveArray(long.class, Iterator.range(from, toExclusive).toJavaArray());
+        return ofAll(range);
     }
 
     /**
@@ -466,20 +495,24 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
      * @throws IllegalArgumentException if {@code step} is zero
      */
     public static Vector<Long> rangeBy(long from, long toExclusive, long step) {
-        return ofAll(Iterator.rangeBy(from, toExclusive, step));
+        final long[] range = toPrimitiveArray(long.class, Iterator.rangeBy(from, toExclusive, step).toJavaArray());
+        return ofAll(range);
     }
 
     public static Vector<Character> rangeClosed(char from, char toInclusive) {
-        return ofAll(Iterator.rangeClosed(from, toInclusive));
+        final char[] range = toPrimitiveArray(char.class, Iterator.rangeClosed(from, toInclusive).toJavaArray());
+        return ofAll(range);
     }
 
     public static Vector<Character> rangeClosedBy(char from, char toInclusive, int step) {
-        return ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
+        final char[] range = toPrimitiveArray(char.class, Iterator.rangeClosedBy(from, toInclusive, step).toJavaArray());
+        return ofAll(range);
     }
 
     @GwtIncompatible
     public static Vector<Double> rangeClosedBy(double from, double toInclusive, double step) {
-        return ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
+        final double[] range = toPrimitiveArray(double.class, Iterator.rangeClosedBy(from, toInclusive, step).toJavaArray());
+        return ofAll(range);
     }
 
     /**
@@ -499,7 +532,8 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
      * @return a range of int values as specified or the empty range if {@code from > toInclusive}
      */
     public static Vector<Integer> rangeClosed(int from, int toInclusive) {
-        return ofAll(Iterator.rangeClosed(from, toInclusive));
+        final int[] range = toPrimitiveArray(int.class, Iterator.rangeClosed(from, toInclusive).toJavaArray());
+        return ofAll(range);
     }
 
     /**
@@ -525,7 +559,8 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
      * @throws IllegalArgumentException if {@code step} is zero
      */
     public static Vector<Integer> rangeClosedBy(int from, int toInclusive, int step) {
-        return ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
+        final int[] range = toPrimitiveArray(int.class, Iterator.rangeClosedBy(from, toInclusive, step).toJavaArray());
+        return ofAll(range);
     }
 
     /**
@@ -545,7 +580,8 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
      * @return a range of long values as specified or the empty range if {@code from > toInclusive}
      */
     public static Vector<Long> rangeClosed(long from, long toInclusive) {
-        return ofAll(Iterator.rangeClosed(from, toInclusive));
+        final long[] range = toPrimitiveArray(long.class, Iterator.rangeClosed(from, toInclusive).toJavaArray());
+        return ofAll(range);
     }
 
     /**
@@ -571,7 +607,8 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
      * @throws IllegalArgumentException if {@code step} is zero
      */
     public static Vector<Long> rangeClosedBy(long from, long toInclusive, long step) {
-        return ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
+        final long[] range = toPrimitiveArray(long.class, Iterator.rangeClosedBy(from, toInclusive, step).toJavaArray());
+        return ofAll(range);
     }
 
     /**
@@ -662,15 +699,15 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
         } else {
             if ((trailingLength == 0) && (leadingLength() < branchingFactor())) {
                 assert middle.length() == 0;
-                final T[] newLeading = copyAppend(collapsedLeading(), element);
-                return new Vector<>(newLeading, 0, emptyTree(), emptyArray(), 0);
+                final Object newLeading = copyAppend(type, collapsedLeading(), element);
+                return new Vector<>(type, newLeading, 0, emptyTree(), emptyArray(), 0);
             } else if (trailingLength < branchingFactor()) {
-                final T[] newTrailing = copyAppend(collapsedTrailing(), element);
-                return new Vector<>(leading, leadingOffset, middle, newTrailing, newTrailing.length);
+                final Object newTrailing = copyAppend(type, collapsedTrailing(), element);
+                return new Vector<>(type, leading, leadingOffset, middle, newTrailing, trailingLength + 1);
             } else {
                 final VectorTree<T> newMiddle = middle.appendLeaf(collapsedTrailing());
-                final T[] newTrailing = (T[]) new Object[] {element};
-                return new Vector<>(leading, leadingOffset, newMiddle, newTrailing, newTrailing.length);
+                final Object newTrailing = asArray(type, element);
+                return new Vector<>(type, leading, leadingOffset, newMiddle, newTrailing, 1);
             }
         }
     }
@@ -733,14 +770,15 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
             return empty();
         } else {
             if (n < leadingLength()) {
-                final int newLeadingOffset = (leadingOffset + n);
-                return normalized(leading, newLeadingOffset, middle, trailing, trailingLength);
+                final int newLeadingOffset = leadingOffset + n;
+                return normalized(type, leading, newLeadingOffset, middle, trailing, trailingLength);
             } else if (n < trailingStartIndex()) {
                 final VectorTree<T> newMiddle = middle.drop(n - leadingLength());
-                return normalized(emptyArray(), 0, newMiddle, trailing, trailingLength);
+                return normalized(type, emptyArray(), 0, newMiddle, trailing, trailingLength);
             } else {
-                final T[] newTrailing = copyOfRange(trailing, n - trailingStartIndex(), trailingLength);
-                return normalized(emptyArray(), 0, emptyTree(), newTrailing, newTrailing.length);
+                final int from = n - trailingStartIndex();
+                final Object newTrailing = copyRange(trailing, from, trailingLength);
+                return normalized(type, emptyArray(), 0, emptyTree(), newTrailing, trailingLength - from);
             }
         }
     }
@@ -816,31 +854,39 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
 
     @Override
     public T get(int index) {
-        if ((index < 0) || (index >= length())) {
-            throw new IndexOutOfBoundsException("get(" + index + ")");
-        }
+        if ((index < 0) || (index >= length())) throw new IndexOutOfBoundsException("get(" + index + ")");
 
-        if (index < leadingLength()) {
-            return leading[leadingOffset + index];
-        } else if (index < trailingStartIndex()) {
-            index -= leadingLength();
-            final Object[] leaf = middle.getLeaf(index);
-            return (T) leaf[lastDigit(middle.offset() + index)];
+        return getAt(leafUnsafe(index), leafIndex(index));
+    }
+
+    Object leafUnsafe(int index) {
+        final int trailingStartIndex = trailingStartIndex(), leadingLength = trailingStartIndex - middle.length();
+        if (index < leadingLength) {
+            return leading;
+        } else if (index < trailingStartIndex) {
+            return middle.getLeaf(index - leadingLength);
         } else {
-            index -= trailingStartIndex();
-            assert index < trailingLength;
-            return trailing[index];
+            return collapsedTrailing();
         }
     }
 
-    private int trailingStartIndex() { return leadingLength() + middle.length(); }
+    int leafIndex(int index) {
+        final int trailingStartIndex = trailingStartIndex(), leadingLength = trailingStartIndex - middle.length();
+        if (index < leadingLength) {
+            return leadingOffset + index;
+        } else if (index < trailingStartIndex) {
+            return lastDigit(lastDigit(middle.offset()) + (index - leadingLength));
+        } else {
+            return index - trailingStartIndex;
+        }
+    }
 
     @Override
     public T head() {
         if (isEmpty()) {
             throw new NoSuchElementException("head of empty Vector");
         } else {
-            return leading[leadingOffset];
+            return getAt(leading, leadingOffset);
         }
     }
 
@@ -906,7 +952,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
 
     @Override
     public boolean isEmpty() {
-        return leadingLength() == 0;
+        return length == 0;
     }
 
     @Override
@@ -917,21 +963,21 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
     @Override
     public Iterator<T> iterator() {
         return isEmpty() ? Iterator.empty() : new Iterator<T>() {
-            final int globalLength = Vector.this.length();
             int globalIndex;
 
-            T[] leaf = leading;
+            Object leaf = leading;
+            int length = getLength(leaf);
             int leafIndex = leadingOffset;
 
             @Override
-            public boolean hasNext() { return globalIndex < globalLength; }
+            public boolean hasNext() { return globalIndex < Vector.this.length(); }
 
             @Override
             public T next() {
-                if (leafIndex == leaf.length) { setCurrentArray(); }
+                if (leafIndex == length) { setCurrentArray(); }
 
-                final T next = leaf[leafIndex];
-                assert next == Vector.this.get(globalIndex);
+                final T next = getAt(leaf, leafIndex);
+                assert Objects.equals(next, Vector.this.get(globalIndex));
 
                 leafIndex++;
                 globalIndex++;
@@ -950,6 +996,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
                     leaf = trailing;
                 }
                 assert leaf != null;
+                length = getLength(leaf);
             }
         };
     }
@@ -966,7 +1013,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
 
     @Override
     public int length() {
-        return leadingLength() + middle.length() + trailingLength;
+        return length;
     }
 
     @Override
@@ -977,8 +1024,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
             return empty();
         } else {
             final Iterator<? extends U> results = iterator().map(mapper);
-            return results.isEmpty() ? empty()
-                                     : ofAll(results);
+            return ofAll(results, length());
         }
     }
 
@@ -1054,19 +1100,17 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
             return of(element);
         } else {
             if (leadingLength() < branchingFactor()) {
-                final T[] newLeading = copyPrepend(collapsedLeading(), element);
-                return new Vector<>(newLeading, 0, middle, trailing, trailingLength);
+                final Object newLeading = copyPrepend(type, collapsedLeading(), element);
+                return new Vector<>(type, newLeading, 0, middle, trailing, trailingLength);
+            } else if (trailingLength == 0) {
+                assert middle.length() == 0;
+                final Object newLeading = asArray(type, element);
+                final Object newTrailing = collapsedLeading();
+                return new Vector<>(type, newLeading, 0, emptyTree(), newTrailing, getLength(newTrailing));
             } else {
-                final T[] newLeading = (T[]) new Object[] {element};
-                if (trailingLength == 0) {
-                    assert middle.length() == 0;
-                    final T[] newTrailing = collapsedLeading();
-                    final int newTrailingLength = newTrailing.length;
-                    return new Vector<>(newLeading, 0, emptyTree(), newTrailing, newTrailingLength);
-                } else {
-                    final VectorTree<T> newMiddle = middle.prependLeaf(collapsedLeading());
-                    return new Vector<>(newLeading, 0, newMiddle, trailing, trailingLength);
-                }
+                final Object newLeading = asArray(type, element);
+                final VectorTree<T> newMiddle = middle.prependLeaf(collapsedLeading());
+                return new Vector<>(type, newLeading, 0, newMiddle, trailing, trailingLength);
             }
         }
     }
@@ -1311,15 +1355,15 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
             return empty();
         } else {
             if (n < leadingLength()) {
-                final T[] newLeading = copyOfRange(leading, leadingOffset, leadingOffset + n);
-                return normalized(newLeading, 0, emptyTree(), emptyArray(), 0);
+                final Object newLeading = copyRange(leading, leadingOffset, leadingOffset + n);
+                return normalized(type, newLeading, 0, emptyTree(), emptyArray(), 0);
             } else if (n < trailingStartIndex()) {
                 final VectorTree<T> newMiddle = middle.take(n - leadingLength());
-                return normalized(leading, leadingOffset, newMiddle, emptyArray(), 0);
+                return normalized(type, leading, leadingOffset, newMiddle, emptyArray(), 0);
             } else {
                 final int newTrailingLength = (n - trailingStartIndex());
                 assert newTrailingLength < trailingLength;
-                return normalized(leading, leadingOffset, middle, trailing, newTrailingLength);
+                return normalized(type, leading, leadingOffset, middle, trailing, newTrailingLength);
             }
         }
     }
@@ -1405,14 +1449,14 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
             throw new IndexOutOfBoundsException("update(" + index + ")");
         } else {
             if (index < leadingLength()) {
-                final T[] newLeading = copyUpdate(collapsedLeading(), index, element);
-                return new Vector<>(newLeading, 0, middle, trailing, trailingLength);
+                final Object newLeading = copyUpdate(collapsedLeading(), index, element);
+                return new Vector<>(type, newLeading, 0, middle, trailing, trailingLength);
             } else if (index < trailingStartIndex()) {
                 final VectorTree<T> newMiddle = middle.update(index - leadingLength(), element);
-                return new Vector<>(leading, leadingOffset, newMiddle, trailing, trailingLength);
+                return new Vector<>(type, leading, leadingOffset, newMiddle, trailing, trailingLength);
             } else {
-                final T[] newTrailing = copyUpdate(collapsedTrailing(), index - trailingStartIndex(), element);
-                return new Vector<>(leading, leadingOffset, middle, newTrailing, newTrailing.length);
+                final Object newTrailing = copyUpdate(collapsedTrailing(), index - trailingStartIndex(), element);
+                return new Vector<>(type, leading, leadingOffset, middle, newTrailing, trailingLength);
             }
         }
     }
@@ -1471,23 +1515,21 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
     static final class VectorTree<T> implements Serializable {
         private static final long serialVersionUID = 1L;
 
-        private static final VectorTree<?> EMPTY = new VectorTree<>(emptyArray(), 0, 0, 0);
+        private static final VectorTree<?> EMPTY = new VectorTree<>(Object.class, emptyArray(), 0, 0, 0);
         static <T> VectorTree<T> emptyTree() { return (VectorTree<T>) EMPTY; }
 
-        private final Object[] array;
+        private final Class<?> type;
+        private final Object array;
         private final int offset, length;
         private final int depthShift;
 
-        static <T> VectorTree<T> create(Object[] array, int offset, int length, int depthShift) {
-            if (array.length == 0) {
-                assert (offset == 0) && (length == 0) && (depthShift == 0);
-                return (VectorTree<T>) EMPTY;
-            } else {
-                return new VectorTree<T>(array, offset, length, depthShift);
-            }
+        static <T> VectorTree<T> create(Class<?> type, Object array, int offset, int length, int depthShift) {
+            assert length > 0;
+            return new VectorTree<>(type, array, offset, length, depthShift);
         }
 
-        private VectorTree(Object[] array, int offset, int length, int depthShift) {
+        private VectorTree(Class<?> type, Object array, int offset, int length, int depthShift) {
+            this.type = type;
             this.array = array;
             this.offset = offset;
             this.length = length;
@@ -1501,18 +1543,19 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
             return branchCount * fullBranchSize;
         }
 
-        static <T> T[] collapse(T[] array, int fromInclusive, int toExclusive) {
-            final boolean shouldCollapse = (toExclusive - fromInclusive) < array.length;
-            return shouldCollapse ? copyOfRange(array, fromInclusive, toExclusive)
+        static <T> Object collapse(Object array, int fromInclusive, int toExclusive) {
+            final boolean shouldCollapse = (toExclusive - fromInclusive) < getLength(array);
+            return shouldCollapse ? copyRange(array, fromInclusive, toExclusive)
                                   : array;
         }
 
-        VectorTree<T> prependLeaf(T[] leading) {
-            assert leading.length == branchingFactor();
+        VectorTree<T> prependLeaf(Object leading) {
+            final int length = getLength(leading);
+            assert length == branchingFactor();
 
-            final int newSize = length() + leading.length;
+            final int newSize = length() + length;
             int offset = this.offset;
-            Object[] array = leading;
+            Object array = leading;
             int depthShift = this.depthShift;
             if (length() > 0) {
                 array = this.array;
@@ -1525,19 +1568,19 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
                     offset = treeSize(branchingFactor() - 1, depthShift);
                 }
 
-                offset -= leading.length;
+                offset -= length;
                 array = recursiveSet(array, offset, depthShift, leading, BRANCHING_BASE);
             }
 
-            return create(array, offset, newSize, depthShift);
+            return create(type, array, offset, newSize, depthShift);
         }
 
-        VectorTree<T> appendLeaf(T[] trailing) {
-            assert trailing.length == branchingFactor();
+        VectorTree<T> appendLeaf(Object trailing) {
+            assert getLength(trailing) == branchingFactor();
 
-            final int newSize = length() + trailing.length;
+            final int newSize = length() + getLength(trailing);
             int depthShift = this.depthShift;
-            Object[] array = trailing;
+            Object array = trailing;
             if (length() > 0) {
                 array = this.array;
                 if (newSize > treeSize(branchingFactor(), depthShift)) {
@@ -1548,24 +1591,22 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
                 array = recursiveSet(array, offset + length(), depthShift, trailing, BRANCHING_BASE);
             }
 
-            return create(array, offset, newSize, depthShift);
+            return create(type, array, offset, newSize, depthShift);
         }
 
         VectorTree<T> update(int index, T element) {
-            final Object[] root = recursiveSet(array, offset + index, depthShift, element, 0);
-            return create(root, offset, length(), depthShift);
+            final Object root = recursiveSet(array, offset + index, depthShift, element, 0);
+            return create(type, root, offset, length(), depthShift);
         }
 
         /** Since the depth of the tree is always small, a non-tailrecursive call is actually faster than pre-calculating the path (is probably unrolled) */
-        static <T> Object[] recursiveSet(Object arrayObject, int index, int depthShift, T element, int endShift) {
-            final Object[] array = (Object[]) arrayObject;
+        Object recursiveSet(Object array, int index, int depthShift, Object element, int endShift) {
             final int childIndex = digit(index, depthShift);
             if (depthShift <= endShift) {
                 return copyUpdate(array, childIndex, element);
             } else {
-                final int childShift = depthShift - BRANCHING_BASE;
-                Object[] childArray = getOrDefault(array, childIndex, emptyArray());
-                childArray = recursiveSet(childArray, index, childShift, element, endShift);
+                Object childArray = getOrDefault(array, childIndex, emptyArray());
+                childArray = recursiveSet(childArray, index, depthShift - BRANCHING_BASE, element, endShift);
                 return copyUpdate(array, childIndex, childArray);
             }
         }
@@ -1580,18 +1621,18 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
 
                 int shiftValue = depthShift;
                 int previousOffset = firstDigit(index, shiftValue);
-                final Object[] root = Arrays2.drop(array, previousOffset);
-                for (Object[] array = root; (array != null) && (shiftValue >= BRANCHING_BASE); ) {
+                final Object root = copyDrop(array, previousOffset);
+                for (Object array = root; (array != null) && (shiftValue >= BRANCHING_BASE); ) {
                     shiftValue -= BRANCHING_BASE;
                     final int offset = digit(index, shiftValue);
 
-                    final Object[] newNode = Arrays2.drop((T[]) array[previousOffset], offset);
-                    array[previousOffset] = newNode;
+                    final Object newNode = copyDrop(getAt(array, previousOffset), offset);
+                    setAt(array, previousOffset, newNode);
                     array = newNode;
 
                     previousOffset = offset;
                 }
-                return create(root, index, length() - n, depthShift);
+                return create(type, root, index, length() - n, depthShift);
             }
         }
 
@@ -1601,21 +1642,21 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
             } else if (n <= 0) {
                 return emptyTree();
             } else {
-                final Object[] array = recursiveTake(this.array, offset + n, depthShift);
-                return create(array, offset, n, depthShift);
+                final Object array = recursiveTake(this.array, offset + n, depthShift);
+                return create(type, array, offset, n, depthShift);
             }
         }
 
-        static <T> Object[] recursiveTake(Object arrayObject, int index, int depthShift) {
-            final Object[] array = (Object[]) arrayObject;
+        Object recursiveTake(Object arrayObject, int index, int depthShift) {
+            final Object array = arrayObject;
             final int childIndex = digit(index, depthShift);
 
-            final Object[] take = Arrays2.take(array, childIndex);
+            final Object take = copyTake(array, childIndex);
             if (depthShift <= 0) {
                 return take;
             } else {
                 final int childShift = depthShift - BRANCHING_BASE;
-                Object[] childArray = getOrDefault(array, childIndex, emptyArray());
+                Object childArray = getOrDefault(array, childIndex, emptyArray());
                 childArray = recursiveTake(childArray, index, childShift);
                 return copyUpdate(array, childIndex, childArray);
             }
@@ -1623,47 +1664,48 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T> {
 
         VectorTree<T> collapseHeight() {
             int offset = this.offset;
-            Object[] array = this.array;
+            Object array = this.array;
             int depthShift = this.depthShift;
             for (; depthShift > 0; depthShift -= BRANCHING_BASE) {
+                final int skippedElements = getLength(array) - 1;
                 final int currentOffset = digit(offset, depthShift);
-                if ((array.length - 1) != currentOffset) {
+                if (skippedElements != currentOffset) {
                     break;
                 }
 
-                final int skippedElements = array.length - 1;
-                array = (Object[]) array[skippedElements];
-
+                array = getAt(array, skippedElements);
                 offset -= treeSize(skippedElements, depthShift);
             }
 
             return (depthShift == this.depthShift) ? this
-                                                   : create(array, offset, length(), depthShift);
+                                                   : create(type, array, offset, length(), depthShift);
         }
 
         int offset() { return offset; }
 
-        T[] getLeaf(int index) {
-            index += offset;
-            assert index >= 0;
-
+        Object getLeaf(int index) {
             if (depthShift == 0) {
-                return (T[]) array;
-            } else if (depthShift == BRANCHING_BASE) {
-                return (T[]) array[firstDigit(index, depthShift)];
+                return array;
             } else {
-                Object[] root = (Object[]) array[firstDigit(index, depthShift)];
+                index += offset;
+                assert index >= 0;
 
-                int depthShift = this.depthShift - BRANCHING_BASE;
-                root = (Object[]) root[digit(index, depthShift)];
+                if (depthShift == BRANCHING_BASE) {
+                    return ((Object[]) array)[firstDigit(index, depthShift)];
+                } else {
+                    Object root = ((Object[]) array)[firstDigit(index, depthShift)];
 
-                while (depthShift > BRANCHING_BASE) {
-                    depthShift -= BRANCHING_BASE;
-                    root = (Object[]) root[digit(index, depthShift)];
+                    int depthShift = this.depthShift - BRANCHING_BASE;
+                    root = ((Object[]) root)[digit(index, depthShift)];
+
+                    while (depthShift > BRANCHING_BASE) {
+                        depthShift -= BRANCHING_BASE;
+                        root = ((Object[]) root)[digit(index, depthShift)];
+                    }
+
+                    assert root != null;
+                    return root;
                 }
-
-                assert root != null;
-                return (T[]) root;
             }
         }
 

--- a/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
@@ -54,6 +54,22 @@ public class VectorPropertyTest {
     }
 
     @Test
+    public void shouldPrepend() {
+        Seq<Integer> expected = Array.empty();
+        Vector<Integer> actual = Vector.empty();
+
+        for (int drop = 0; drop <= (Vector.branchingFactor() + 1); drop += 2) {
+            for (Integer value : Iterator.range(0, getMaxSizeForDepth(3) + 1)) {
+                expected = expected.drop(drop);
+                actual = assertAreEqual(actual, drop, Vector::drop, expected);
+
+                expected = expected.prepend(value);
+                actual = assertAreEqual(actual, value, Vector::prepend, expected);
+            }
+        }
+    }
+
+    @Test
     public void shouldAppend() {
         Seq<Integer> expected = Array.empty();
         Vector<Integer> actual = Vector.empty();

--- a/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
@@ -54,6 +54,22 @@ public class VectorPropertyTest {
     }
 
     @Test
+    public void shouldAppend() {
+        Seq<Integer> expected = Array.empty();
+        Vector<Integer> actual = Vector.empty();
+
+        for (int drop = 0; drop <= (Vector.branchingFactor() + 1); drop += 2) {
+            for (Integer value : Iterator.range(0, getMaxSizeForDepth(2) + 1)) {
+                expected = expected.drop(drop);
+                actual = assertAreEqual(actual, drop, Vector::drop, expected);
+
+                expected = expected.append(value);
+                actual = assertAreEqual(actual, value, Vector::append, expected);
+            }
+        }
+    }
+
+    @Test
     public void shouldUpdate() {
         final Function<Integer, Integer> mapper = i -> i + 1;
 

--- a/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.function.Function;
 
 import java.util.List;
 
@@ -49,6 +50,25 @@ public class VectorPropertyTest {
             }
 
             System.out.println("Depth " + depth + " ok!");
+        }
+    }
+
+    @Test
+    public void shouldUpdate() {
+        final Function<Integer, Integer> mapper = i -> i + 1;
+
+        for (byte depth = 0; depth <= 2; depth++) {
+            final int length = getMaxSizeForDepth(depth) + 1;
+
+            Seq<Integer> expected = Array.range(0, length);
+            Vector<Integer> actual = Vector.ofAll(expected);
+
+            for (int i = 0; i < actual.length(); i++) {
+                final Integer newValue = mapper.apply(actual.get(i));
+                actual = actual.update(i, newValue);
+            }
+
+            assertAreEqual(actual, 0, (a, p) -> a, expected.map(mapper));
         }
     }
 

--- a/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static javaslang.Function2.constant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class VectorPropertyTest {
@@ -29,6 +30,20 @@ public class VectorPropertyTest {
             for (Integer value : expected) {
                 final Integer actualValue = actual.get(i++);
                 assertThat(actualValue).isEqualTo(value);
+            }
+
+            System.out.println("Depth " + depth + " ok!");
+        }
+    }
+
+    @Test
+    public void shouldIterate() {
+        for (byte depth = 1; depth <= 6; depth++) {
+            for (int i = 0; i < getMaxSizeForDepth(depth); i++) {
+                final Seq<Integer> expected = Array.range(0, i);
+                final Vector<Integer> actual = Vector.ofAll(expected);
+
+                assertAreEqual(actual, null, constant(actual), expected);
             }
 
             System.out.println("Depth " + depth + " ok!");

--- a/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
@@ -11,6 +11,8 @@ import org.junit.Test;
 
 import java.util.List;
 
+import java.util.List;
+
 import static javaslang.Function2.constant;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -47,6 +49,24 @@ public class VectorPropertyTest {
             }
 
             System.out.println("Depth " + depth + " ok!");
+        }
+    }
+
+    @Test
+    public void shouldDropRight() {
+        final int length = getMaxSizeForDepth(5) + 1;
+
+        final Seq<Integer> expected = Array.range(0, length);
+        final Vector<Integer> actual = Vector.ofAll(expected);
+
+        Vector<Integer> actualSingleDrop = actual;
+        for (int i = 0; i <= length; i++) {
+            final Seq<Integer> expectedDrop = expected.dropRight(i);
+
+            assertAreEqual(actual, i, Vector::dropRight, expectedDrop);
+            assertAreEqual(actualSingleDrop, null, (a, p) -> a, expectedDrop);
+
+            actualSingleDrop = actualSingleDrop.dropRight(1);
         }
     }
 

--- a/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
@@ -6,13 +6,15 @@
 package javaslang.collection;
 
 import javaslang.Function2;
+import javaslang.Tuple;
+import javaslang.Tuple2;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.function.Function;
-
-import java.util.List;
 
 import static javaslang.Function2.constant;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,19 +25,34 @@ public class VectorPropertyTest {
 
     @Test
     public void shouldCreateAndGet() {
-        for (byte depth = 0; depth <= 6; depth++) {
-            final int length = getMaxSizeForDepth(depth);
-
-            final Seq<Integer> expected = Array.range(0, length);
+        for (int i = 0; i < 2000; i++) {
+            final Seq<Integer> expected = Array.range(0, i);
             final Vector<Integer> actual = Vector.ofAll(expected);
+            assertAreEqual(expected, actual);
 
-            int i = 0;
-            for (Integer value : expected) {
-                final Integer actualValue = actual.get(i++);
-                assertThat(actualValue).isEqualTo(value);
-            }
+            final Vector<Byte> actualByte = Vector.ofAll(Arrays2.<byte[]> toPrimitiveArray(byte.class, expected.map(Integer::byteValue).toJavaArray()));
+            assert actualByte.leading instanceof byte[];
+            assertAreEqual(expected, actual);
 
-            System.out.println("Depth " + depth + " ok!");
+            final Vector<Boolean> actualBoolean = Vector.ofAll(Arrays2.<boolean[]> toPrimitiveArray(boolean.class, expected.map(v -> (v % 2) == 0).toJavaArray()));
+            assert actualBoolean.leading instanceof boolean[];
+            assertAreEqual(expected, actual);
+
+            final Vector<Character> actualChar = Vector.ofAll(Arrays2.<char[]> toPrimitiveArray(char.class, expected.map(v -> (char) v.intValue()).toJavaArray()));
+            assert actualChar.leading instanceof char[];
+            assertAreEqual(expected, actual);
+
+            final Vector<Double> actualDouble = Vector.ofAll(Arrays2.<double[]> toPrimitiveArray(double.class, expected.map(Integer::doubleValue).toJavaArray()));
+            assert actualDouble.leading instanceof double[];
+            assertAreEqual(expected, actual);
+
+            final Vector<Integer> actualInt = Vector.ofAll(Arrays2.<int[]> toPrimitiveArray(int.class, expected.toJavaArray()));
+            assert actualInt.leading instanceof int[];
+            assertAreEqual(expected, actual);
+
+            final Vector<Long> actualLong = Vector.ofAll(Arrays2.<long[]> toPrimitiveArray(long.class, expected.map(Integer::longValue).toJavaArray()));
+            assert actualLong.leading instanceof long[];
+            assertAreEqual(expected, actual);
         }
     }
 
@@ -50,6 +67,22 @@ public class VectorPropertyTest {
             }
 
             System.out.println("Depth " + depth + " ok!");
+        }
+
+        Seq<Integer> expected = Array.range(0, 1000);
+        Vector<Integer> actual = Vector.ofAll(Arrays2.<int[]> toPrimitiveArray(int.class, expected.toJavaArray()));
+        for (int drop = 0; drop <= (Vector.branchingFactor() + 1); drop++) {
+            final Iterator<Integer> expectedIterator = expected.iterator();
+            for (int i = 0; i < actual.length(); ) {
+                final int[] leaf = (int[]) actual.leafUnsafe(i);
+                for (int j = actual.leafIndex(i); j < leaf.length; j++) {
+                    assertThat(leaf[j]).isEqualTo(expectedIterator.next());
+                    i++;
+                }
+            }
+
+            expected = expected.tail().init();
+            actual = actual.tail().init();
         }
     }
 
@@ -144,6 +177,112 @@ public class VectorPropertyTest {
 
             actualSingleDrop = actualSingleDrop.dropRight(1);
         }
+    }
+
+    @Test
+    public void shouldSlice() {
+        for (int length = 1, end = getMaxSizeForDepth(2) + 1; length <= end; length++) {
+            Seq<Integer> expected = Array.range(0, length);
+            Vector<Integer> actual = Vector.ofAll(expected);
+
+            for (int i = 0; i <= expected.length(); i++) {
+                expected = expected.slice(1, expected.size() - 1);
+                actual = assertAreEqual(actual, i, (a, p) -> a.slice(1, a.size() - 1), expected);
+            }
+        }
+    }
+
+    @Test
+    public void shouldBehaveLikeArray() {
+        Random random = new Random();
+        final int seed = random.nextInt();
+        System.out.println("using seed " + seed);
+        random = new Random(seed);
+
+        for (int i = 0; i < 10; i++) {
+            Seq<Integer> expected = Array.empty();
+            Vector<Integer> actual = Vector.empty();
+            for (int j = 0; j < 50_000; j++) {
+                Seq<Tuple2<Seq<Integer>, Vector<Integer>>> history = Array.empty();
+
+                if (random.nextInt(100) < 20) {
+                    final ArrayList<Integer> values = new ArrayList<>();
+                    for (int k = 0; k < random.nextInt(j + 1); k++) {
+                        values.add(random.nextInt());
+                    }
+                    expected = Array.ofAll(values);
+                    final boolean isPrimitive = random.nextInt(100) < 50;
+                    actual = assertAreEqual(values, null, (v, p) -> isPrimitive ? Vector.ofAll(Arrays2.<int[]> toPrimitiveArray(int.class, v.toArray())) : Vector.ofAll(v), expected);
+                    history = history.append(Tuple.of(expected, actual));
+                }
+
+                if (random.nextInt(100) < 50) {
+                    final Integer value = randomOrNull(actual, random);
+                    expected = expected.append(value);
+                    actual = assertAreEqual(actual, value, Vector::append, expected);
+                    history = history.append(Tuple.of(expected, actual));
+                }
+
+                if (random.nextInt(100) < 50) {
+                    final Integer value = randomOrNull(actual, random);
+                    expected = expected.prepend(value);
+                    actual = assertAreEqual(actual, value, Vector::prepend, expected);
+                    history = history.append(Tuple.of(expected, actual));
+                }
+
+                if (random.nextInt(100) < 30) {
+                    final int n = random.nextInt(expected.size() + 1);
+                    expected = expected.drop(n);
+                    actual = assertAreEqual(actual, n, Vector::drop, expected);
+                    history = history.append(Tuple.of(expected, actual));
+                }
+
+                if (random.nextInt(100) < 30) {
+                    final int n = random.nextInt(expected.size() + 1);
+                    expected = expected.take(n);
+                    actual = assertAreEqual(actual, n, Vector::take, expected);
+                    history = history.append(Tuple.of(expected, actual));
+                }
+
+                if (!expected.isEmpty()) {
+                    assertThat(actual.head()).isEqualTo(expected.head());
+                    assertThat(actual.tail().toJavaList()).isEqualTo(expected.tail().toJavaList());
+                    history = history.append(Tuple.of(expected, actual));
+                }
+
+                if (!expected.isEmpty()) {
+                    final int index = random.nextInt(expected.size());
+                    assertThat(actual.get(index)).isEqualTo(expected.get(index));
+                    history = history.append(Tuple.of(expected, actual));
+                }
+
+                if (random.nextInt(100) < 50) {
+                    if (!expected.isEmpty()) {
+                        final int index = random.nextInt(expected.size());
+                        final Integer value = randomOrNull(actual, random);
+                        expected = expected.update(index, value);
+                        actual = assertAreEqual(actual, null, (a, p) -> a.update(index, value), expected);
+                        history = history.append(Tuple.of(expected, actual));
+                    }
+                }
+
+                for (int k = 0; k < 10; k++) {
+                    if (!expected.isEmpty()) {
+                        final int from = random.nextInt(expected.size());
+                        final int to = random.nextInt(expected.size());
+                        expected = expected.slice(from, to);
+                        actual = assertAreEqual(actual, null, (a, p) -> a.slice(from, to), expected);
+                        history = history.append(Tuple.of(expected, actual));
+                    }
+                }
+
+                history.forEach(t -> assertAreEqual(t._1, t._2)); // test that the modifications are persistent
+            }
+        }
+    }
+    private Integer randomOrNull(Vector<Integer> actual, Random random) {
+        return (!actual.type.isPrimitive() && (random.nextInt(100) < 5)) ? null
+                                                                         : random.nextInt();
     }
 
     private static <T1, T2> Vector<Integer> assertAreEqual(T1 previousActual, T2 param, Function2<T1, T2, Vector<Integer>> actualProvider, Seq<Integer> expected) {

--- a/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
@@ -1,0 +1,54 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2016 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+import javaslang.Function2;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VectorPropertyTest {
+    @Before
+    public void setUp() { Vector.BRANCHING_BASE = 2; }
+
+    @Test
+    public void shouldCreateAndGet() {
+        for (byte depth = 0; depth <= 6; depth++) {
+            final int length = getMaxSizeForDepth(depth);
+
+            final Seq<Integer> expected = Array.range(0, length);
+            final Vector<Integer> actual = Vector.ofAll(expected);
+
+            int i = 0;
+            for (Integer value : expected) {
+                final Integer actualValue = actual.get(i++);
+                assertThat(actualValue).isEqualTo(value);
+            }
+
+            System.out.println("Depth " + depth + " ok!");
+        }
+    }
+
+    private static <T1, T2> Vector<Integer> assertAreEqual(T1 previousActual, T2 param, Function2<T1, T2, Vector<Integer>> actualProvider, Seq<Integer> expected) {
+        final Vector<Integer> actual = actualProvider.apply(previousActual, param);
+        assertAreEqual(expected, actual);
+        return actual; // makes debugging a lot easier, as the frame can be dropped and rerun on AssertError
+    }
+
+    private static void assertAreEqual(Seq<Integer> expected, Seq<Integer> actual) {
+        final List<Integer> actualList = actual.toJavaList();
+        final List<Integer> expectedList = expected.toJavaList();
+        assertThat(actualList).isEqualTo(expectedList); // a lot faster than `hasSameElementsAs`
+    }
+
+    private static int getMaxSizeForDepth(int depth) {
+        final int max = Vector.branchingFactor() + (int) Math.pow(Vector.branchingFactor(), depth) + Vector.branchingFactor();
+        return Math.min(max, 10_000);
+    }
+}

--- a/javaslang/src/test/java/javaslang/collection/VectorTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorTest.java
@@ -5,10 +5,10 @@
  */
 package javaslang.collection;
 
-import javaslang.Value;
-import javaslang.control.Option;
 import javaslang.Serializables;
 import javaslang.Tuple2;
+import javaslang.Value;
+import javaslang.control.Option;
 import org.junit.Test;
 
 import java.io.InvalidObjectException;
@@ -16,7 +16,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.*;
+import java.util.stream.Collector;
 import java.util.stream.Stream;
 
 public class VectorTest extends AbstractIndexedSeqTest {
@@ -196,7 +196,7 @@ public class VectorTest extends AbstractIndexedSeqTest {
 
     @Test
     public void shouldTransform() {
-        String transformed = of(42).transform(v -> String.valueOf(v.get()));
+        final String transformed = of(42).transform(v -> String.valueOf(v.get()));
         assertThat(transformed).isEqualTo("42");
     }
 
@@ -210,10 +210,10 @@ public class VectorTest extends AbstractIndexedSeqTest {
     @Test
     public void shouldUnfoldRightSimpleVector() {
         assertThat(
-            Vector.unfoldRight(10, x -> x == 0
-                               ? Option.none()
-                               : Option.of(new Tuple2<>(x, x-1))))
-            .isEqualTo(of(10, 9, 8, 7, 6, 5, 4, 3, 2, 1));
+                Vector.unfoldRight(10, x -> x == 0
+                                            ? Option.none()
+                                            : Option.of(new Tuple2<>(x, x - 1))))
+                .isEqualTo(of(10, 9, 8, 7, 6, 5, 4, 3, 2, 1));
     }
 
     @Test
@@ -224,10 +224,10 @@ public class VectorTest extends AbstractIndexedSeqTest {
     @Test
     public void shouldUnfoldLeftSimpleVector() {
         assertThat(
-            Vector.unfoldLeft(10, x -> x == 0
-                              ? Option.none()
-                              : Option.of(new Tuple2<>(x-1, x))))
-            .isEqualTo(of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+                Vector.unfoldLeft(10, x -> x == 0
+                                           ? Option.none()
+                                           : Option.of(new Tuple2<>(x - 1, x))))
+                .isEqualTo(of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
     }
 
     @Test
@@ -238,10 +238,10 @@ public class VectorTest extends AbstractIndexedSeqTest {
     @Test
     public void shouldUnfoldSimpleVector() {
         assertThat(
-            Vector.unfold(10, x -> x == 0
-                          ? Option.none()
-                          : Option.of(new Tuple2<>(x-1, x))))
-            .isEqualTo(of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+                Vector.unfold(10, x -> x == 0
+                                       ? Option.none()
+                                       : Option.of(new Tuple2<>(x - 1, x))))
+                .isEqualTo(of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
     }
 
     // -- toString
@@ -261,40 +261,6 @@ public class VectorTest extends AbstractIndexedSeqTest {
     @Test(expected = InvalidObjectException.class)
     public void shouldNotSerializeEnclosingClass() throws Throwable {
         Serializables.callReadObject(List.of(1));
-    }
-
-    @Test(expected = InvalidObjectException.class)
-    public void shouldNotDeserializeListWithSizeLessThanOne() throws Throwable {
-        try {
-            /*
-             * This implementation is stable regarding jvm impl changes of object serialization. The index of the number
-             * of List elements is gathered dynamically.
-             */
-            final byte[] listWithOneElement = Serializables.serialize(List.of(0));
-            final byte[] listWithTwoElements = Serializables.serialize(List.of(0, 0));
-            int index = -1;
-            for (int i = 0; i < listWithOneElement.length && index == -1; i++) {
-                final byte b1 = listWithOneElement[i];
-                final byte b2 = listWithTwoElements[i];
-                if (b1 != b2) {
-                    if (b1 != 1 || b2 != 2) {
-                        throw new IllegalStateException("Difference does not indicate number of elements.");
-                    } else {
-                        index = i;
-                    }
-                }
-            }
-            if (index == -1) {
-                throw new IllegalStateException("Hack incomplete - index not found");
-            }
-            /*
-             * Hack the serialized data and fake zero elements.
-			 */
-            listWithOneElement[index] = 0;
-            Serializables.deserialize(listWithOneElement);
-        } catch (IllegalStateException x) {
-            throw (x.getCause() != null) ? x.getCause() : x;
-        }
     }
 
     // -- toVector

--- a/javaslang/src/test/java/javaslang/collection/VectorTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorTest.java
@@ -244,6 +244,28 @@ public class VectorTest extends AbstractIndexedSeqTest {
                 .isEqualTo(of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
     }
 
+    // -- dropRightWhile
+
+    @Test
+    public void shouldDropRightWhileNoneOnNil() {
+        assertThat(empty().dropRightWhile(ignored -> true)).isEqualTo(empty());
+    }
+
+    @Test
+    public void shouldDropRightWhileNoneIfPredicateIsFalse() {
+        assertThat(of(1, 2, 3).dropRightWhile(ignored -> false)).isEqualTo(of(1, 2, 3));
+    }
+
+    @Test
+    public void shouldDropRightWhileAllIfPredicateIsTrue() {
+        assertThat(of(1, 2, 3).dropRightWhile(ignored -> true)).isEqualTo(empty());
+    }
+
+    @Test
+    public void shouldDropRightWhileCorrect() {
+        assertThat(ofAll("abc  ".toCharArray()).dropRightWhile(Character::isWhitespace)).isEqualTo(ofAll("abc".toCharArray()));
+    }
+
     // -- toString
 
     @Test


### PR DESCRIPTION
EDIT: this PR was separated in multiple smaller ones:
* https://github.com/javaslang/javaslang/pull/1503
* https://github.com/javaslang/javaslang/pull/1504
* https://github.com/javaslang/javaslang/pull/1522

---

Vector is the default Seq implementation that provides effectively constant time access to any element.
Many other operations (e.g. `tail`, `drop`, `slice`) are also effectively constant.

It's implemented using a `bit-mapped vector trie`, i.e. a tree where each node has `32` children.
For integers this means that the tree's depth will be `≤ 6`.

For symmetrically fast beginning and end operations (e.g. `drop` vs `dropRight`) two small arrays are used as depthless staging areas.
The leading and trailing arrays have dynamic lengths (their max size equals the branching factor),
but the middle tree's leafs only contain full blocks - though the first one may be padded by an offset.
The leading is only empty if everything is empty; if the trailing is empty, so is the middle.

For smaller memory footprint, primitive inputs are not boxed, resulting in a `4x` smaller size than `ArrayList`, with `~2x` faster iteration and `~5x` faster creation.
Some operations may box the primitive values, but it's possible to retrieve the values without boxing also (by returning the corresponding array).

Already boxed primitives are not unboxed (i.e. are stored as wrappers).

---

It's not based on [Clojure](https://github.com/paplorinc/clojure/blob/master/src/jvm/clojure/lang/PersistentVector.java) or [Scala](https://github.com/paplorinc/scala/blob/2.12.x/src/library/scala/collection/immutable/Vector.scala), but it has the same underlying idea: logarithmic access using a very wide and shallow tree, with a high branching factor.

This implementation is optimized algorithmically - though small wins are probably still lurking around :).

Compared to the old implementation, it's usually a lot faster and uses a *lot* less memory:
Memory - almost `70x` less memory overhead for large enough datasets (with `13x` less total memory for primitives):
```
for 32768 elements
 `javaslang.collection.OldVector` uses `1.9 MB` (`1.3 MB` overhead, `41.4` bytes overhead per element)
 `javaslang.collection.Vector` uses `659 KB` (`20.7 KB` overhead, `0.6` bytes overhead per element)

for 1024 elements
 `javaslang.collection.OldVector` uses `58.8 KB` (`40.1 KB` overhead, `40.1` bytes overhead per element)
 `javaslang.collection.Vector` uses `19.3 KB` (`672 bytes` overhead, `0.7` bytes overhead per element)

for 32 elements
 `javaslang.collection.OldVector` uses `1.6 KB` (`1.1 KB` overhead, `35.2` bytes overhead per element)
 `javaslang.collection.Vector` uses `544 bytes` (`40 bytes` overhead, `1.2` bytes overhead per element)
```

Speed - the new impl is `~4-5x` faster on average:
```groovy
Operation Ratio                                    32     1024      32768
Create   slang_persistent/old_slang_persistent 74.21×   44.92×     60.12× 
Head     slang_persistent/old_slang_persistent  3.82×    4.28×      5.52× 
Tail     slang_persistent/old_slang_persistent  4.09×    3.91×      6.55× 
Get      slang_persistent/old_slang_persistent  3.53×    5.94×      4.40× 
Update   slang_persistent/old_slang_persistent  1.40×    1.60×      2.33× 
Prepend  slang_persistent/old_slang_persistent  2.51×    3.96×      5.53× 
Append   slang_persistent/old_slang_persistent  1.55×    2.20×      3.08× 
GroupBy  slang_persistent/old_slang_persistent  1.23×    2.76×      3.94× 
Slice    slang_persistent/old_slang_persistent 44.33× 2014.66× 124956.66× 
Iterate  slang_persistent/old_slang_persistent  9.26×    7.78×      8.56× 
```

Compared to `Java`'s mutable `ArrayList`, and `Scala`'s, `Clojure`'s, `Functional Java`'s and `Pcollections`'s persistent ones, these are the results (e.g. `2x` means that our implementation is `2` times faster - can be executed twice while the other only once - for the given number of elements):

```groovy
Operation  Ratio                                               32     1024      32768 
Create     slang_persistent/java_mutable                    1.13×    0.20×      0.24×
Create     slang_persistent/fjava_persistent              315.71×   89.95×     75.30×
Create     slang_persistent/pcollections_persistent       160.86×   99.40×    152.24×
Create     slang_persistent/clojure_persistent              1.26×    5.88×      5.29×
Create     slang_persistent/scala_persistent               19.82×    4.01×      2.79×
                                                                             
Head       slang_persistent/java_mutable                    0.85×    0.81×      0.85×
Head       slang_persistent/fjava_persistent                1.00×    0.95×      1.00×
Head       slang_persistent/pcollections_persistent         2.68×    5.76×      9.26×
Head       slang_persistent/clojure_persistent              0.92×    1.32×      1.91×
Head       slang_persistent/scala_persistent                1.02×    0.96×      1.02×
                                                                             
Tail       slang_persistent/java_mutable                    0.53×    0.36×      0.29×
Tail       slang_persistent/fjava_persistent               42.17×   29.95×     35.59×
Tail       slang_persistent/pcollections_persistent         4.98×    5.71×      9.24×
Tail       slang_persistent/scala_persistent                2.52×    3.15×      4.48×
                                                                             
Get        slang_persistent/java_mutable                    0.86×    0.30×      0.23×
Get        slang_persistent/fjava_persistent               60.01×   71.98×     50.88×
Get        slang_persistent/pcollections_persistent         8.57×   10.06×     11.66×
Get        slang_persistent/clojure_persistent              0.99×    0.96×      0.91×
Get        slang_persistent/scala_persistent                1.26×    0.76×      0.62×
                                                                             
Update     slang_persistent/java_mutable                    0.11×    0.05×      0.02×
Update     slang_persistent/fjava_persistent              135.14×  227.17×    226.08×
Update     slang_persistent/pcollections_persistent         2.51×    3.63×      5.27×
Update     slang_persistent/clojure_persistent              0.92×    1.08×      1.10×
Update     slang_persistent/scala_persistent                1.07×    0.92×      1.18×
                                                                             
Prepend    slang_persistent/java_mutable                    1.61×    3.67×     83.34×
Prepend    slang_persistent/fjava_persistent                7.22×    8.73×      7.64×
Prepend    slang_persistent/pcollections_persistent         4.89×   13.11×     20.31×
Prepend    slang_persistent/clojure_persistent             29.43×  674.17×  22795.68×
Prepend    slang_persistent/scala_persistent                1.13×    1.18×      1.10×
                                                                             
Append     slang_persistent/java_mutable                    0.27×    0.20×      0.13×
Append     slang_persistent/fjava_persistent                5.17×    5.07×      5.06×
Append     slang_persistent/pcollections_persistent         2.72×    6.08×     10.26×
Append     slang_persistent/clojure_persistent              1.00×    0.78×      0.85×
Append     slang_persistent/scala_persistent                0.82×    0.74×      0.74×
                                                                             
Slice      slang_persistent/java_mutable                    0.24×    0.30×      0.32×
Slice      slang_persistent/clojure_persistent              0.21×    0.26×      0.29×
Slice      slang_persistent/scala_persistent                0.97×    3.45×      5.95×
                                                                             
Iterate    slang_persistent/java_mutable                    0.87×    0.30×      0.37×
Iterate    slang_persistent/fjava_persistent              388.66×  281.62×    275.59×
Iterate    slang_persistent/pcollections_persistent        16.37×    9.52×      7.21×
Iterate    slang_persistent/clojure_persistent              0.89×    0.73×      1.00×
Iterate    slang_persistent/scala_persistent                1.97×    1.06×      0.89×
```                                                                          
                                                                             
with significant wins in create and iterate for primitives:
```java
Operation  Ratio                                               32     1024    32768 
Create     slang_persistent_int/java_mutable                3.88×    0.48×    0.43×
Create     slang_persistent_int/fjava_persistent         1079.05×  214.89×  136.56×
Create     slang_persistent_int/pcollections_persistent   549.81×  237.47×  276.11×
Create     slang_persistent_int/clojure_persistent          4.31×   14.06×    9.60×
Create     slang_persistent_int/scala_persistent           67.74×    9.58×    5.06×

Iterate    slang_persistent_int/java_mutable                2.42×    1.72×    2.09×
Iterate    slang_persistent_int/fjava_persistent         1078.59× 1600.60× 1542.54×
Iterate    slang_persistent_int/pcollections_persistent    45.43×   54.11×   40.35×
Iterate    slang_persistent_int/clojure_persistent          2.48×    4.14×    5.62×
Iterate    slang_persistent_int/scala_persistent            5.46×    6.01×    4.98×
```

and memory usages:
```groovy
for 32768 elements
 `java.util.ArrayList` uses `638.4 KB` (`0 bytes` overhead, `0.0` bytes overhead per element)
 `scala.collection.immutable.Vector` uses `659 KB` (`20.7 KB` overhead, `0.6` bytes overhead per element)
 `clojure.lang.PersistentVector` uses `683.8 KB` (`45.4 KB` overhead, `1.4` bytes overhead per element)
 `org.pcollections.TreePVector` uses `1.7 MB` (`1.1 MB` overhead, `36.0` bytes overhead per element)
 `fj.data.Seq` uses `3.3 MB` (`2.6 MB` overhead, `84.1` bytes overhead per element)
 `javaslang.collection.Vector` uses `659 KB` (`20.7 KB` overhead, `0.6` bytes overhead per element)
 `javaslang.collection.Vector` uses `148.7 KB` (`-501400 bytes` overhead, `-15.3` bytes overhead per element) (with primitives)

for 1024 elements
 `java.util.ArrayList` uses `18.6 KB` (`0 bytes` overhead, `0.0` bytes overhead per element)
 `scala.collection.immutable.Vector` uses `19.3 KB` (`672 bytes` overhead, `0.7` bytes overhead per element)
 `clojure.lang.PersistentVector` uses `20 KB` (`1.4 KB` overhead, `1.4` bytes overhead per element)
 `org.pcollections.TreePVector` uses `54.7 KB` (`36.1 KB` overhead, `36.1` bytes overhead per element)
 `fj.data.Seq` uses `102.3 KB` (`83.7 KB` overhead, `83.7` bytes overhead per element)
 `javaslang.collection.Vector` uses `19.3 KB` (`672 bytes` overhead, `0.7` bytes overhead per element)
 `javaslang.collection.Vector` uses `4.7 KB` (`-14248 bytes` overhead, `-13.9` bytes overhead per element) (with primitives)

for 32 elements
 `java.util.ArrayList` uses `504 bytes` (`0 bytes` overhead, `0.0` bytes overhead per element)
 `scala.collection.immutable.Vector` uses `536 bytes` (`32 bytes` overhead, `1.0` bytes overhead per element)
 `clojure.lang.PersistentVector` uses `704 bytes` (`200 bytes` overhead, `6.2` bytes overhead per element)
 `org.pcollections.TreePVector` uses `1.7 KB` (`1.2 KB` overhead, `37.8` bytes overhead per element)
 `fj.data.Seq` uses `3 KB` (`2.5 KB` overhead, `80.0` bytes overhead per element)
 `javaslang.collection.Vector` uses `544 bytes` (`40 bytes` overhead, `1.2` bytes overhead per element)
 `javaslang.collection.Vector` uses `232 bytes` (`-272 bytes` overhead, `-8.5` bytes overhead per element) (with primitives)
```

The implementation is quite complex, please review it from your IDE instead (preferably commit-by-commit) :).

Primitive storage also enabled the creation of very big `Vectors`, i.e.
```java
Create      slang_persistent_int     1048576     330.374  ops/s                     
Create      slang_persistent_int    33554432       8.309 ops/s    
```

Every comment is very welcome! :)

@danieldietrich, @zsolt-donca, @szili88, @ovidiudeac, @djspiewak, please review.