### PR TITLE
Benchmark version updates

### DIFF
--- a/javaslang-benchmark/pom.xml
+++ b/javaslang-benchmark/pom.xml
@@ -30,13 +30,13 @@
         <dependency>
             <groupId>org.scalaz</groupId>
             <artifactId>scalaz-core_2.11</artifactId>
-            <version>7.3.0-M3</version>
+            <version>7.3.0-M4</version>
             <!--contains scala-library 2.11.8-->
         </dependency>
         <dependency>
             <groupId>org.clojure</groupId>
             <artifactId>clojure</artifactId>
-            <version>1.9.0-alpha8</version>
+            <version>1.9.0-alpha10</version>
         </dependency>
         <dependency>
             <groupId>org.pcollections</groupId>
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.functionaljava</groupId>
             <artifactId>functionaljava</artifactId>
-            <version>4.5</version>
+            <version>4.6</version>
         </dependency>
         <dependency>
             <groupId>com.carrotsearch</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@ Note: The maven build currently needs to be started from the javaslang root dir
         <assertj.core.version>3.3.0</assertj.core.version>
         <eclipse.lifecycle.mapping.version>1.0.0</eclipse.lifecycle.mapping.version>
         <java.version>1.8</java.version>
-        <jmh.version>1.12</jmh.version>
+        <jmh.version>1.13</jmh.version>
         <junit.version>4.12</junit.version>
         <maven.build-helper.version>1.9.1</maven.build-helper.version>
         <maven.bundle.version>3.0.1</maven.bundle.version>


### PR DESCRIPTION
Also added `Functional Java`'s new `PriorityQueue` to the bencharking suite.
The verdict: it uses `~2x` more additional memory than our implementation and is usually `~15`-`30x` slower (it's even worse than `Scalaz`):

memory:
```java
for 1000 elements
	`scalaz.Heap$$anon$4` uses `146.7 KB` (`128.8 KB` overhead, `131.9` bytes overhead per element)
	`fj.data.PriorityQueue` uses `123 KB` (`81.6 KB` overhead, `83.6` bytes overhead per element)
	`javaslang.collection.PriorityQueue` uses `60.9 KB` (`43 KB` overhead, `44.0` bytes overhead per element)

for 100 elements
	`scalaz.Heap$$anon$4` uses `14.2 KB` (`12.8 KB` overhead, `131.0` bytes overhead per element)
	`fj.data.PriorityQueue` uses `11.7 KB` (`8 KB` overhead, `81.7` bytes overhead per element)
	`javaslang.collection.PriorityQueue` uses `5.7 KB` (`4.3 KB` overhead, `44.4` bytes overhead per element)

for 10 elements
	`scalaz.Heap$$anon$4` uses `1.5 KB` (`1.3 KB` overhead, `136.0` bytes overhead per element)
	`fj.data.PriorityQueue` uses `1.2 KB` (`832 bytes` overhead, `83.2` bytes overhead per element)
	`javaslang.collection.PriorityQueue` uses `664 bytes` (`480 bytes` overhead, `48.0` bytes overhead per element)
```
speed:
```java
Ratios slang / <alternative_impl>
Operation Ratio                                       10     100    1000 
Enqueue   slang_persistent/java_mutable            0.41x   0.36x   0.59x
Enqueue   slang_persistent/java_blocking_mutable   1.14x   0.96x   1.00x
Enqueue   slang_persistent/scala_mutable           0.58x   0.75x   1.16x
Enqueue   slang_persistent/scalaz_persistent       7.66x   7.03x   5.12x
Enqueue   slang_persistent/fjava_persistent        5.79x   7.06x   8.04x

Dequeue   slang_persistent/java_blocking_mutable   0.74x   0.34x   0.33x
Dequeue   slang_persistent/java_mutable            0.12x   0.12x   0.24x
Dequeue   slang_persistent/scala_mutable           0.19x   0.17x   0.34x
Dequeue   slang_persistent/scalaz_persistent       9.30x  11.61x  11.00x
Dequeue   slang_persistent/fjava_persistent       19.83x  40.76x  53.16x

Sort      slang_persistent/java_blocking_mutable   0.65x   0.30x   0.21x
Sort      slang_persistent/java_mutable            0.16x   0.11x   0.14x
Sort      slang_persistent/java_treeset_mutable    1.18x   0.72x   0.77x
Sort      slang_persistent/scala_mutable           0.24x   0.19x   0.19x
Sort      slang_persistent/scalaz_persistent      12.13x  10.34x   8.17x
Sort      slang_persistent/fjava_persistent       16.43x  28.79x  33.91x
```