### PR TITLE
Curried checked functions now returns the chain of Function1 followed by single CheckedFunction1 call - exactly what partial application would do.

### DIFF
--- a/javaslang/generator/Generator.scala
+++ b/javaslang/generator/Generator.scala
@@ -603,17 +603,10 @@ def generateMainClasses(): Unit = {
           case _ => ""
         }
 
-        def curriedType(max: Int, function: String): String = {
-          if (max == 0) {
-            s"$className<R>"
-          } else {
-            def returnType(curr: Int, max: Int): String = {
-              val isParam = curr < max
-              val next = if (isParam) returnType(curr + 1, max) else "R"
-              s"${function}1<T$curr, $next>"
-            }
-            returnType(1, max)
-          }
+        def curriedType(max: Int, function: String, idx: Int = 1): String = max match {
+          case 0 => s"$className<R>"
+          case 1 => s"${function}1<T$idx, R>"
+          case _ => s"Function1<T$idx, ${curriedType(max - 1, function, idx + 1)}>"
         }
 
         def arguments(count: Int): String = count match {
@@ -1296,17 +1289,10 @@ def generateTestClasses(): Unit = {
         val assertThat = im.getStatic("org.assertj.core.api.Assertions.assertThat")
         val recFuncF1 = if (i == 0) "11;" else s"i1 <= 0 ? i1 : $className.recurrent2.apply(${(1 to i).gen(j => s"i$j" + (j == 1).gen(s" - 1"))(", ")}) + 1;"
 
-        def curriedType(max: Int, function: String): String = {
-          if (max == 0) {
-            s"${function}0<Object>"
-          } else {
-            def returnType(curr: Int, max: Int): String = {
-              val isParam = curr < max
-              val next = if (isParam) returnType(curr + 1, max) else "Object"
-              s"${function}1<Object, $next>"
-            }
-            returnType(1, max)
-          }
+        def curriedType(max: Int, function: String): String = max match {
+          case 0 => s"${function}0<Object>"
+          case 1 => s"${function}1<Object, Object>"
+          case _ => s"Function1<Object, ${curriedType(max - 1, function)}>"
         }
         
         xs"""

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction2.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction2.java
@@ -111,7 +111,7 @@ public interface CheckedFunction2<T1, T2, R> extends λ<R> {
     }
 
     @Override
-    default CheckedFunction1<T1, CheckedFunction1<T2, R>> curried() {
+    default Function1<T1, CheckedFunction1<T2, R>> curried() {
         return t1 -> t2 -> apply(t1, t2);
     }
 

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction3.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction3.java
@@ -126,7 +126,7 @@ public interface CheckedFunction3<T1, T2, T3, R> extends λ<R> {
     }
 
     @Override
-    default CheckedFunction1<T1, CheckedFunction1<T2, CheckedFunction1<T3, R>>> curried() {
+    default Function1<T1, Function1<T2, CheckedFunction1<T3, R>>> curried() {
         return t1 -> t2 -> t3 -> apply(t1, t2, t3);
     }
 

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction4.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction4.java
@@ -142,7 +142,7 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends λ<R> {
     }
 
     @Override
-    default CheckedFunction1<T1, CheckedFunction1<T2, CheckedFunction1<T3, CheckedFunction1<T4, R>>>> curried() {
+    default Function1<T1, Function1<T2, Function1<T3, CheckedFunction1<T4, R>>>> curried() {
         return t1 -> t2 -> t3 -> t4 -> apply(t1, t2, t3, t4);
     }
 

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction5.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction5.java
@@ -159,7 +159,7 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends λ<R> {
     }
 
     @Override
-    default CheckedFunction1<T1, CheckedFunction1<T2, CheckedFunction1<T3, CheckedFunction1<T4, CheckedFunction1<T5, R>>>>> curried() {
+    default Function1<T1, Function1<T2, Function1<T3, Function1<T4, CheckedFunction1<T5, R>>>>> curried() {
         return t1 -> t2 -> t3 -> t4 -> t5 -> apply(t1, t2, t3, t4, t5);
     }
 

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction6.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction6.java
@@ -177,7 +177,7 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
     }
 
     @Override
-    default CheckedFunction1<T1, CheckedFunction1<T2, CheckedFunction1<T3, CheckedFunction1<T4, CheckedFunction1<T5, CheckedFunction1<T6, R>>>>>> curried() {
+    default Function1<T1, Function1<T2, Function1<T3, Function1<T4, Function1<T5, CheckedFunction1<T6, R>>>>>> curried() {
         return t1 -> t2 -> t3 -> t4 -> t5 -> t6 -> apply(t1, t2, t3, t4, t5, t6);
     }
 

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction7.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction7.java
@@ -196,7 +196,7 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
     }
 
     @Override
-    default CheckedFunction1<T1, CheckedFunction1<T2, CheckedFunction1<T3, CheckedFunction1<T4, CheckedFunction1<T5, CheckedFunction1<T6, CheckedFunction1<T7, R>>>>>>> curried() {
+    default Function1<T1, Function1<T2, Function1<T3, Function1<T4, Function1<T5, Function1<T6, CheckedFunction1<T7, R>>>>>>> curried() {
         return t1 -> t2 -> t3 -> t4 -> t5 -> t6 -> t7 -> apply(t1, t2, t3, t4, t5, t6, t7);
     }
 

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction8.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction8.java
@@ -216,7 +216,7 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<
     }
 
     @Override
-    default CheckedFunction1<T1, CheckedFunction1<T2, CheckedFunction1<T3, CheckedFunction1<T4, CheckedFunction1<T5, CheckedFunction1<T6, CheckedFunction1<T7, CheckedFunction1<T8, R>>>>>>>> curried() {
+    default Function1<T1, Function1<T2, Function1<T3, Function1<T4, Function1<T5, Function1<T6, Function1<T7, CheckedFunction1<T8, R>>>>>>>> curried() {
         return t1 -> t2 -> t3 -> t4 -> t5 -> t6 -> t7 -> t8 -> apply(t1, t2, t3, t4, t5, t6, t7, t8);
     }
 

--- a/javaslang/src-gen/test/java/javaslang/CheckedFunction2Test.java
+++ b/javaslang/src-gen/test/java/javaslang/CheckedFunction2Test.java
@@ -47,7 +47,7 @@ public class CheckedFunction2Test {
     @Test
     public void shouldCurry() {
         final CheckedFunction2<Object, Object, Object> f = (o1, o2) -> null;
-        final CheckedFunction1<Object, CheckedFunction1<Object, Object>> curried = f.curried();
+        final Function1<Object, CheckedFunction1<Object, Object>> curried = f.curried();
         assertThat(curried).isNotNull();
     }
 

--- a/javaslang/src-gen/test/java/javaslang/CheckedFunction3Test.java
+++ b/javaslang/src-gen/test/java/javaslang/CheckedFunction3Test.java
@@ -48,7 +48,7 @@ public class CheckedFunction3Test {
     @Test
     public void shouldCurry() {
         final CheckedFunction3<Object, Object, Object, Object> f = (o1, o2, o3) -> null;
-        final CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, Object>>> curried = f.curried();
+        final Function1<Object, Function1<Object, CheckedFunction1<Object, Object>>> curried = f.curried();
         assertThat(curried).isNotNull();
     }
 

--- a/javaslang/src-gen/test/java/javaslang/CheckedFunction4Test.java
+++ b/javaslang/src-gen/test/java/javaslang/CheckedFunction4Test.java
@@ -49,7 +49,7 @@ public class CheckedFunction4Test {
     @Test
     public void shouldCurry() {
         final CheckedFunction4<Object, Object, Object, Object, Object> f = (o1, o2, o3, o4) -> null;
-        final CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, Object>>>> curried = f.curried();
+        final Function1<Object, Function1<Object, Function1<Object, CheckedFunction1<Object, Object>>>> curried = f.curried();
         assertThat(curried).isNotNull();
     }
 

--- a/javaslang/src-gen/test/java/javaslang/CheckedFunction5Test.java
+++ b/javaslang/src-gen/test/java/javaslang/CheckedFunction5Test.java
@@ -50,7 +50,7 @@ public class CheckedFunction5Test {
     @Test
     public void shouldCurry() {
         final CheckedFunction5<Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5) -> null;
-        final CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, Object>>>>> curried = f.curried();
+        final Function1<Object, Function1<Object, Function1<Object, Function1<Object, CheckedFunction1<Object, Object>>>>> curried = f.curried();
         assertThat(curried).isNotNull();
     }
 

--- a/javaslang/src-gen/test/java/javaslang/CheckedFunction6Test.java
+++ b/javaslang/src-gen/test/java/javaslang/CheckedFunction6Test.java
@@ -51,7 +51,7 @@ public class CheckedFunction6Test {
     @Test
     public void shouldCurry() {
         final CheckedFunction6<Object, Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5, o6) -> null;
-        final CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, Object>>>>>> curried = f.curried();
+        final Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, CheckedFunction1<Object, Object>>>>>> curried = f.curried();
         assertThat(curried).isNotNull();
     }
 

--- a/javaslang/src-gen/test/java/javaslang/CheckedFunction7Test.java
+++ b/javaslang/src-gen/test/java/javaslang/CheckedFunction7Test.java
@@ -52,7 +52,7 @@ public class CheckedFunction7Test {
     @Test
     public void shouldCurry() {
         final CheckedFunction7<Object, Object, Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5, o6, o7) -> null;
-        final CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, Object>>>>>>> curried = f.curried();
+        final Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, CheckedFunction1<Object, Object>>>>>>> curried = f.curried();
         assertThat(curried).isNotNull();
     }
 

--- a/javaslang/src-gen/test/java/javaslang/CheckedFunction8Test.java
+++ b/javaslang/src-gen/test/java/javaslang/CheckedFunction8Test.java
@@ -53,7 +53,7 @@ public class CheckedFunction8Test {
     @Test
     public void shouldCurry() {
         final CheckedFunction8<Object, Object, Object, Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5, o6, o7, o8) -> null;
-        final CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, CheckedFunction1<Object, Object>>>>>>>> curried = f.curried();
+        final Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, CheckedFunction1<Object, Object>>>>>>>> curried = f.curried();
         assertThat(curried).isNotNull();
     }
 


### PR DESCRIPTION
Since the behaviour of partial application methods changed in 3.0.0 I assume that curried mathod call should match the new behaviour.
It is expected that curried function will only execute its body when all parameters are present therefore Function1 is a safe substitute for all except last interfaces in curried chain.