### PR TITLE
POC: test non-boxed, primitive collection storage with reflection

### DIFF
--- a/javaslang-benchmark/src/test/java/javaslang/BenchmarkPerformanceReporter.java
+++ b/javaslang-benchmark/src/test/java/javaslang/BenchmarkPerformanceReporter.java
@@ -227,7 +227,7 @@ public class BenchmarkPerformanceReporter {
                 return "";
             }
             final double ratio = baseResult.getScore() / alternativeScore;
-            return ratio == 1.0 ? "" : PERFORMANCE_FORMAT.format(ratio) + "x";
+            return ratio == 1.0 ? "" : PERFORMANCE_FORMAT.format(ratio) + "×";
         }
     }
 
@@ -365,7 +365,7 @@ public class BenchmarkPerformanceReporter {
                 final Option<TestExecution> baseExecution = baseImplExecutions.find(e -> e.getParamKey().equals(paramKey));
                 final String paramRatio = alternativeExecution.isEmpty() || baseExecution.isEmpty() || baseExecution.get().getScore() == 0.0
                                           ? ""
-                                          : PERFORMANCE_FORMAT.format(alternativeExecution.get().getScore() / baseExecution.get().getScore()) + "x";
+                                          : PERFORMANCE_FORMAT.format(alternativeExecution.get().getScore() / baseExecution.get().getScore()) + "×";
                 ratioStings = ratioStings.append(padRight(paramRatio, paramKeySize));
             }
             return ratioStings.mkString(" ");

--- a/javaslang-benchmark/src/test/java/javaslang/JmhRunner.java
+++ b/javaslang-benchmark/src/test/java/javaslang/JmhRunner.java
@@ -4,9 +4,14 @@ import javaslang.collection.*;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.runner.Runner;
-import org.openjdk.jmh.runner.options.*;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+import org.openjdk.jmh.runner.options.VerboseMode;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 public class JmhRunner {
@@ -15,7 +20,7 @@ public class JmhRunner {
      * Note: it takes about 3 hours.
      */
     public static void main(String[] args) {
-        JmhRunner.runSlowNoAsserts(Array.of(
+        final Array<Class<?>> CLASSES = Array.of(
                 ArrayBenchmark.class,
                 BitSetBenchmark.class,
                 CharSeqBenchmark.class,
@@ -23,68 +28,83 @@ public class JmhRunner {
                 ListBenchmark.class,
                 PriorityQueueBenchmark.class,
                 VectorBenchmark.class
-        ));
+        );
+        runDebugWithAsserts(CLASSES);
+        runSlowNoAsserts(CLASSES);
     }
 
     /** enables debugging and assertions for benchmarks and production code - the speed results will be totally unreliable */
     public static void runDebugWithAsserts(Array<Class<?>> groups) {
         final Array<String> classNames = groups.map(Class::getCanonicalName);
-        run(classNames, 0, 1, 1, 0, VerboseMode.SILENT, Assertions.Enable);
+        run(classNames, 0, 1, 1, ForkJvm.DISABLE, VerboseMode.SILENT, Assertions.ENABLE, PrintInlining.DISABLE);
 
         MemoryUsage.printAndReset();
     }
 
     @SuppressWarnings("unused")
     public static void runQuickNoAsserts(Array<Class<?>> groups) {
-        runAndReport(groups, 10, 10, 10, 1, VerboseMode.NORMAL, Assertions.Disable);
+        runAndReport(groups, 5, 5, 10, ForkJvm.ENABLE, VerboseMode.NORMAL, Assertions.DISABLE, PrintInlining.DISABLE);
     }
 
     @SuppressWarnings("unused")
     public static void runNormalNoAsserts(Array<Class<?>> groups) {
-        runAndReport(groups, 15, 10, 100, 1, VerboseMode.NORMAL, Assertions.Disable);
+        runAndReport(groups, 10, 10, 200, ForkJvm.ENABLE, VerboseMode.NORMAL, Assertions.DISABLE, PrintInlining.DISABLE);
     }
 
     @SuppressWarnings("unused")
     public static void runSlowNoAsserts(Array<Class<?>> groups) {
-        runAndReport(groups, 15, 15, 300, 1, VerboseMode.EXTRA, Assertions.Disable);
+        runAndReport(groups, 25, 15, 500, ForkJvm.ENABLE, VerboseMode.EXTRA, Assertions.DISABLE, PrintInlining.DISABLE);
     }
 
-    public static void runAndReport(Array<Class<?>> groups, int warmupIterations, int measurementIterations, int millis, int forks, VerboseMode silent, Assertions assertions) {
+    public static void runAndReport(Array<Class<?>> groups, int warmupIterations, int measurementIterations, int millis, ForkJvm forkJvm, VerboseMode silent, Assertions assertions, PrintInlining printInlining) {
         final Array<String> classNames = groups.map(Class::getCanonicalName);
-        final Array<RunResult> results = run(classNames, warmupIterations, measurementIterations, millis, forks, silent, assertions);
+        final Array<RunResult> results = run(classNames, warmupIterations, measurementIterations, millis, forkJvm, silent, assertions, printInlining);
         BenchmarkPerformanceReporter.of(classNames, results).print();
-
-        MemoryUsage.printAndReset();
     }
 
-    private static Array<RunResult> run(Array<String> classNames, int warmupIterations, int measurementIterations, int millis, int forks, VerboseMode verboseMode, Assertions assertions) {
-        final ChainedOptionsBuilder builder = new OptionsBuilder()
-                .shouldDoGC(true)
-                .verbosity(verboseMode)
-                .shouldFailOnError(true)
-                .mode(Mode.Throughput)
-                .timeUnit(TimeUnit.SECONDS)
-                .warmupTime(TimeValue.milliseconds(millis))
-                .warmupIterations(warmupIterations)
-                .measurementTime(TimeValue.milliseconds(millis))
-                .measurementIterations(measurementIterations)
-                .forks(forks)
-                // We are using 2Gb and setting NewGen to 100% to avoid GC during testing.
-                // Any GC during testing will destroy the iteration (i.e. introduce unreliable noise in the measurement), which should get ignored as an outlier
-                .jvmArgsAppend("-XX:+UseG1GC", "-Xss100m", "-Xms2g", "-Xmx2g", "-XX:MaxGCPauseMillis=1000", "-XX:+UnlockExperimentalVMOptions", "-XX:G1NewSizePercent=100", "-XX:G1MaxNewSizePercent=100", assertions.vmArg);
-
-        classNames.forEach(builder::include);
-
+    private static Array<RunResult> run(Array<String> classNames, int warmupIterations, int measurementIterations, int millis, ForkJvm forkJvm, VerboseMode verboseMode, Assertions assertions, PrintInlining printInlining) {
         try {
+            final ChainedOptionsBuilder builder = new OptionsBuilder()
+                    .shouldDoGC(true)
+                    .verbosity(verboseMode)
+                    .shouldFailOnError(true)
+                    .mode(Mode.Throughput)
+                    .timeUnit(TimeUnit.SECONDS)
+                    .warmupTime(TimeValue.milliseconds(millis))
+                    .warmupIterations(warmupIterations)
+                    .measurementTime(TimeValue.milliseconds(millis))
+                    .measurementIterations(measurementIterations)
+                    .forks(forkJvm.forkCount)
+                  /* We are using 4Gb and setting NewGen to 100% to avoid GC during testing.
+                     Any GC during testing will destroy the iteration (i.e. introduce unreliable noise in the measurement), which should get ignored as an outlier */
+                    .jvmArgsAppend("-XX:+UseG1GC", "-Xss100m", "-Xms4g", "-Xmx4g", "-XX:MaxGCPauseMillis=1000", "-XX:+UnlockExperimentalVMOptions", "-XX:G1NewSizePercent=100", "-XX:G1MaxNewSizePercent=100", assertions.vmArg);
+            classNames.forEach(builder::include);
+
+            if (printInlining == PrintInlining.ENABLE) {
+                builder.jvmArgsAppend("-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining"); /* might help in deciding when the JVM is properly warmed up - or where to optimize the code */
+            }
+
             return Array.ofAll(new Runner(builder.build()).run());
-        } catch (Exception e) {
-            throw new RuntimeException(e.getMessage(), e);
+        } catch (RunnerException e) {
+            throw new RuntimeException(e);
         }
     }
 
-    public enum Assertions {
-        Enable("-enableassertions"),
-        Disable("-disableassertions");
+    /* Options */
+    private enum ForkJvm {
+        ENABLE(1),
+        DISABLE(0);
+
+        final int forkCount;
+
+        ForkJvm(int forkCount) {
+            this.forkCount = forkCount;
+        }
+    }
+
+    private enum Assertions {
+        ENABLE("-enableassertions"),
+        DISABLE("-disableassertions");
 
         final String vmArg;
 
@@ -93,13 +113,22 @@ public class JmhRunner {
         }
     }
 
+    private enum PrintInlining {
+        ENABLE,
+        DISABLE;
+    }
+
+    /* Helper methods */
+
     public static Integer[] getRandomValues(int size, int seed) {
         return getRandomValues(size, seed, false);
     }
 
     public static Integer[] getRandomValues(int size, int seed, boolean nonNegative) {
-        final Random random = new Random(seed);
+        return getRandomValues(size, nonNegative, new Random(seed));
+    }
 
+    public static Integer[] getRandomValues(int size, boolean nonNegative, Random random) {
         final Integer[] results = new Integer[size];
         for (int i = 0; i < size; i++) {
             final int value = random.nextInt(size) - (nonNegative ? 0 : (size / 2));

--- a/javaslang-benchmark/src/test/java/javaslang/MemoryUsage.java
+++ b/javaslang-benchmark/src/test/java/javaslang/MemoryUsage.java
@@ -1,6 +1,7 @@
 package javaslang;
 
-import javaslang.collection.*;
+import javaslang.collection.List;
+import javaslang.collection.TreeMultimap;
 
 import java.text.DecimalFormat;
 import java.util.Comparator;
@@ -9,7 +10,7 @@ import static com.carrotsearch.sizeof.RamUsageEstimator.*;
 
 public class MemoryUsage {
     private static final DecimalFormat RATIO_FORMAT = new DecimalFormat("#0.0");
-    private static TreeMultimap<Integer, String> memoryUsages = TreeMultimap.withSeq().empty(Comparator.reverseOrder());
+    private static TreeMultimap<Integer, String> memoryUsages = TreeMultimap.withSeq().empty(Comparator.reverseOrder()); // if forked, this will be reset every time
 
     /** Calculate the occupied memory of different internals */
     static void printAndReset() {

--- a/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java
@@ -3,28 +3,21 @@ package javaslang.collection;
 import javaslang.JmhRunner;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
-import org.openjdk.jmh.infra.Blackhole;
-import scala.compat.java8.JFunction;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Objects;
+import java.util.Random;
 
 import static java.util.Arrays.asList;
-import static javaslang.JmhRunner.*;
+import static javaslang.JmhRunner.create;
+import static javaslang.JmhRunner.getRandomValues;
 import static javaslang.collection.Collections.areEqual;
-import static scala.collection.JavaConversions.*;
 
+@SuppressWarnings({"ALL", "unchecked"})
 public class VectorBenchmark {
     static final Array<Class<?>> CLASSES = Array.of(
             Create.class,
             Head.class,
-            Tail.class,
             Get.class,
-            Update.class,
-            Prepend.class,
-            Append.class,
-            GroupBy.class,
-            Slice.class,
             Iterate.class
     );
 
@@ -34,77 +27,39 @@ public class VectorBenchmark {
     }
 
     public static void main(String... args) {
+        JmhRunner.runDebugWithAsserts(CLASSES);
         JmhRunner.runNormalNoAsserts(CLASSES);
     }
 
     @State(Scope.Benchmark)
     public static class Base {
-        @Param({ "32", "1024", "32768"/*, "1048576"*/ }) // i.e. depth 1,2,3(,4) for a branching factor of 32
+        @Param({/*"32",*/ "1024"/*, "32768"*/ /*, "1048576", "33554432", "1073741824" */}) /* i.e. depth 1,2,3(,4,5,6) for a branching factor of 32 */
         public int CONTAINER_SIZE;
 
         int EXPECTED_AGGREGATE;
         Integer[] ELEMENTS;
+        int[] INT_ELEMENTS;
+        int[] RANDOMIZED_INDICES;
 
         /* Only use this for non-mutating operations */
         java.util.ArrayList<Integer> javaMutable;
-
-        fj.data.Seq<Integer> fjavaPersistent = fj.data.Seq.empty();
-        org.pcollections.PVector<Integer> pcollectionsPersistent = org.pcollections.TreePVector.empty();
-        scala.collection.immutable.Vector<Integer> scalaPersistent;
-        clojure.lang.PersistentVector clojurePersistent;
         javaslang.collection.Vector<Integer> slangPersistent;
 
         @Setup
-        @SuppressWarnings("unchecked")
         public void setup() {
-            ELEMENTS = getRandomValues(CONTAINER_SIZE, 0);
+            final Random random = new Random(0);
+            ELEMENTS = getRandomValues(CONTAINER_SIZE, false, random);
+            RANDOMIZED_INDICES = Arrays2.shuffle(Array.range(0, CONTAINER_SIZE).toJavaStream().mapToInt(Integer::intValue).toArray(), random);
+
             EXPECTED_AGGREGATE = Array.of(ELEMENTS).reduce(JmhRunner::aggregate);
 
             javaMutable = create(java.util.ArrayList::new, asList(ELEMENTS), v -> areEqual(v, asList(ELEMENTS)));
-            scalaPersistent = create(v -> (scala.collection.immutable.Vector<Integer>) scala.collection.immutable.Vector$.MODULE$.apply(asScalaBuffer(v)), javaMutable, v -> areEqual(asJavaCollection(v), javaMutable));
-            clojurePersistent = create(clojure.lang.PersistentVector::create, javaMutable, v -> areEqual(v, javaMutable));
-            pcollectionsPersistent = create(org.pcollections.TreePVector::from, javaMutable, v -> areEqual(v, javaMutable));
-            fjavaPersistent = create(fj.data.Seq::fromJavaList, javaMutable, v -> areEqual(v, javaMutable));
             slangPersistent = create(javaslang.collection.Vector::ofAll, javaMutable, v -> areEqual(v, javaMutable));
         }
     }
 
+    /** Bulk creation from array based, boxed source */
     public static class Create extends Base {
-        @Benchmark
-        public Object java_mutable() {
-            final ArrayList<Integer> values = new ArrayList<>(javaMutable);
-            assert areEqual(values, javaMutable);
-            return values;
-        }
-
-        @Benchmark
-        public Object scala_persistent() {
-            final scala.collection.immutable.Vector<?> values = scala.collection.immutable.Vector$.MODULE$.apply(scalaPersistent);
-            assert Objects.equals(values, scalaPersistent);
-            return values;
-        }
-
-        @Benchmark
-        public Object clojure_persistent() {
-            final clojure.lang.PersistentVector values = clojure.lang.PersistentVector.create(javaMutable);
-            assert areEqual(values, javaMutable);
-            return values;
-        }
-
-        @Benchmark
-        public Object fjava_persistent() {
-            final fj.data.Seq<Integer> values = fj.data.Seq.fromJavaList(javaMutable);
-            assert areEqual(values, javaMutable);
-            return values;
-        }
-
-        @Benchmark
-        public Object pcollections_persistent() {
-            final org.pcollections.PVector<Integer> values = org.pcollections.TreePVector.from(javaMutable);
-            assert areEqual(values, javaMutable);
-            return values;
-        }
-
         @Benchmark
         public Object slang_persistent() {
             final javaslang.collection.Vector<Integer> values = javaslang.collection.Vector.ofAll(javaMutable);
@@ -115,41 +70,6 @@ public class VectorBenchmark {
 
     public static class Head extends Base {
         @Benchmark
-        public Object java_mutable() {
-            final Object head = javaMutable.get(0);
-            assert Objects.equals(head, ELEMENTS[0]);
-            return head;
-        }
-
-        @Benchmark
-        public Object scala_persistent() {
-            final Object head = scalaPersistent.head();
-            assert Objects.equals(head, javaMutable.get(0));
-            return head;
-        }
-
-        @Benchmark
-        public Object clojure_persistent() {
-            final Object head = clojurePersistent.nth(0);
-            assert Objects.equals(head, javaMutable.get(0));
-            return head;
-        }
-
-        @Benchmark
-        public Object fjava_persistent() {
-            final Object head = fjavaPersistent.head();
-            assert Objects.equals(head, javaMutable.get(0));
-            return head;
-        }
-
-        @Benchmark
-        public Object pcollections_persistent() {
-            final Object head = pcollectionsPersistent.get(0);
-            assert Objects.equals(head, javaMutable.get(0));
-            return head;
-        }
-
-        @Benchmark
         public Object slang_persistent() {
             final Object head = slangPersistent.head();
             assert Objects.equals(head, javaMutable.get(0));
@@ -157,140 +77,12 @@ public class VectorBenchmark {
         }
     }
 
-    @SuppressWarnings("Convert2MethodRef")
-    public static class Tail extends Base {
-        @State(Scope.Thread)
-        public static class Initialized {
-            final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
-
-            @Setup(Level.Invocation)
-            public void initializeMutable(Base state) {
-                java.util.Collections.addAll(javaMutable, state.ELEMENTS);
-                assert areEqual(javaMutable, asList(state.ELEMENTS));
-            }
-
-            @TearDown(Level.Invocation)
-            public void tearDown() {
-                javaMutable.clear();
-            }
-        }
-
-        @Benchmark
-        public Object java_mutable(Initialized state) {
-            final java.util.ArrayList<Integer> values = state.javaMutable;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                values.remove(0);
-            }
-            assert values.isEmpty();
-            return values;
-        }
-
-        @Benchmark
-        public Object scala_persistent() {
-            scala.collection.immutable.Vector<Integer> values = scalaPersistent;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                values = values.tail();
-            }
-            assert values.isEmpty();
-            return values;
-        }
-
-        @Benchmark
-        public Object clojure_persistent() {
-            clojure.lang.PersistentVector values = clojurePersistent;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                values = values.pop();
-            }
-            assert values.isEmpty();
-            return values;
-        }
-
-        @Benchmark
-        public Object fjava_persistent() {
-            fj.data.Seq<Integer> values = fjavaPersistent;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                values = values.tail();
-            }
-            assert values.isEmpty();
-            return values;
-        }
-
-        @Benchmark
-        public Object pcollections_persistent() {
-            org.pcollections.PVector<Integer> values = pcollectionsPersistent;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                values = values.minus(0);
-            }
-            assert values.isEmpty();
-            return values;
-        }
-
-        @Benchmark
-        public Object slang_persistent() {
-            javaslang.collection.Vector<Integer> values = slangPersistent;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                values = values.tail();
-            }
-            assert values.isEmpty();
-            return values;
-        }
-    }
-
+    /** Aggregated, randomized access to every element */
     public static class Get extends Base {
-        @Benchmark
-        public int java_mutable() {
-            int aggregate = 0;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                aggregate ^= javaMutable.get(i);
-            }
-            assert aggregate == EXPECTED_AGGREGATE;
-            return aggregate;
-        }
-
-        @Benchmark
-        public int scala_persistent() {
-            int aggregate = 0;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                aggregate ^= scalaPersistent.apply(i);
-            }
-            assert aggregate == EXPECTED_AGGREGATE;
-            return aggregate;
-        }
-
-        @Benchmark
-        public int clojure_persistent() {
-            int aggregate = 0;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                aggregate ^= (int) clojurePersistent.get(i);
-            }
-            assert aggregate == EXPECTED_AGGREGATE;
-            return aggregate;
-        }
-
-        @Benchmark
-        public int fjava_persistent() {
-            int aggregate = 0;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                aggregate ^= fjavaPersistent.index(i);
-            }
-            assert aggregate == EXPECTED_AGGREGATE;
-            return aggregate;
-        }
-
-        @Benchmark
-        public int pcollections_persistent() {
-            int aggregate = 0;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                aggregate ^= pcollectionsPersistent.get(i);
-            }
-            assert aggregate == EXPECTED_AGGREGATE;
-            return aggregate;
-        }
-
         @Benchmark
         public int slang_persistent() {
             int aggregate = 0;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
+            for (int i : RANDOMIZED_INDICES) {
                 aggregate ^= slangPersistent.get(i);
             }
             assert aggregate == EXPECTED_AGGREGATE;
@@ -298,315 +90,8 @@ public class VectorBenchmark {
         }
     }
 
-    public static class Update extends Base {
-        @State(Scope.Thread)
-        public static class Initialized {
-            final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
-
-            @Setup(Level.Invocation)
-            public void initializeMutable(Base state) {
-                java.util.Collections.addAll(javaMutable, state.ELEMENTS);
-                assert areEqual(javaMutable, asList(state.ELEMENTS));
-            }
-
-            @TearDown(Level.Invocation)
-            public void tearDown() {
-                javaMutable.clear();
-            }
-        }
-
-        @Benchmark
-        public Object java_mutable(Initialized state) {
-            final java.util.ArrayList<Integer> values = state.javaMutable;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                values.set(i, 0);
-            }
-            assert Array.ofAll(values).forAll(e -> e == 0);
-            return values;
-        }
-
-        @Benchmark
-        public Object scala_persistent() {
-            scala.collection.immutable.Vector<Integer> values = scalaPersistent;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                values = values.updateAt(i, 0);
-            }
-            assert Array.ofAll(asJavaCollection(values)).forAll(e -> e == 0);
-            return values;
-        }
-
-        @Benchmark
-        public Object clojure_persistent() {
-            clojure.lang.PersistentVector values = clojurePersistent;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                values = values.assocN(i, 0);
-            }
-            assert Array.of(values.toArray()).forAll(e -> Objects.equals(e, 0));
-            return values;
-        }
-
-        @Benchmark
-        public Object fjava_persistent() {
-            fj.data.Seq<Integer> values = fjavaPersistent;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                values = values.update(i, 0);
-            }
-            assert Array.ofAll(values).forAll(e -> e == 0);
-            return values;
-        }
-
-        @Benchmark
-        public Object pcollections_persistent() {
-            org.pcollections.PVector<Integer> values = pcollectionsPersistent;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                values = values.with(i, 0);
-            }
-            assert Array.ofAll(values).forAll(e -> e == 0);
-            return values;
-        }
-
-        @Benchmark
-        public Object slang_persistent() {
-            javaslang.collection.Vector<Integer> values = slangPersistent;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                values = values.update(i, 0);
-            }
-            assert values.forAll(e -> e == 0);
-            return values;
-        }
-    }
-
-    @SuppressWarnings("ManualArrayToCollectionCopy")
-    public static class Prepend extends Base {
-        @Benchmark
-        public Object java_mutable() {
-            final java.util.ArrayList<Integer> values = new java.util.ArrayList<>(CONTAINER_SIZE);
-            for (Integer element : ELEMENTS) {
-                values.add(0, element);
-            }
-            assert areEqual(Array.ofAll(values).reverse(), javaMutable);
-            return values;
-        }
-
-        @Benchmark
-        public Object scala_persistent() {
-            scala.collection.immutable.Vector<Integer> values = scala.collection.immutable.Vector$.MODULE$.empty();
-            for (Integer element : ELEMENTS) {
-                values = values.appendFront(element);
-            }
-            assert areEqual(Array.ofAll(asJavaCollection(values)).reverse(), javaMutable);
-            return values;
-        }
-
-        @Benchmark
-        public Object fjava_persistent() {
-            fj.data.Seq<Integer> values = fj.data.Seq.empty();
-            for (Integer element : ELEMENTS) {
-                values = values.cons(element);
-            }
-            assert areEqual(Array.ofAll(values).reverse(), javaMutable);
-            return values;
-        }
-
-        @Benchmark
-        public Object pcollections_persistent() {
-            org.pcollections.PVector<Integer> values = org.pcollections.TreePVector.empty();
-            for (Integer element : ELEMENTS) {
-                values = values.plus(0, element);
-            }
-            assert areEqual(Array.ofAll(values).reverse(), javaMutable);
-            return values;
-        }
-
-        @Benchmark
-        public Object slang_persistent() {
-            javaslang.collection.Vector<Integer> values = javaslang.collection.Vector.empty();
-            for (Integer element : ELEMENTS) {
-                values = values.prepend(element);
-            }
-            assert areEqual(values.reverse(), javaMutable);
-            return values;
-        }
-    }
-
-    @SuppressWarnings("ManualArrayToCollectionCopy")
-    public static class Append extends Base {
-        @Benchmark
-        public Object java_mutable() {
-            final java.util.ArrayList<Integer> values = new java.util.ArrayList<>(CONTAINER_SIZE);
-            for (Integer element : ELEMENTS) {
-                values.add(element);
-            }
-            assert areEqual(values, javaMutable);
-            return values;
-        }
-
-        @Benchmark
-        public Object scala_persistent() {
-            scala.collection.immutable.Vector<Integer> values = scala.collection.immutable.Vector$.MODULE$.empty();
-            for (Integer element : ELEMENTS) {
-                values = values.appendBack(element);
-            }
-            assert areEqual(asJavaCollection(values), javaMutable);
-            return values;
-        }
-
-        @Benchmark
-        public Object clojure_persistent() {
-            clojure.lang.PersistentVector values = clojure.lang.PersistentVector.EMPTY;
-            for (Integer element : ELEMENTS) {
-                values = values.cons(element);
-            }
-            assert areEqual(values, javaMutable);
-            return values;
-        }
-
-        @Benchmark
-        public Object fjava_persistent() {
-            fj.data.Seq<Integer> values = fj.data.Seq.empty();
-            for (Integer element : ELEMENTS) {
-                values = values.snoc(element);
-            }
-            assert areEqual(values, javaMutable);
-            return values;
-        }
-
-        @Benchmark
-        public Object pcollections_persistent() {
-            org.pcollections.PVector<Integer> values = org.pcollections.TreePVector.empty();
-            for (Integer element : ELEMENTS) {
-                values = values.plus(element);
-            }
-            assert areEqual(values, javaMutable);
-            return values;
-        }
-
-        @Benchmark
-        public Object slang_persistent() {
-            javaslang.collection.Vector<Integer> values = javaslang.collection.Vector.empty();
-            for (Integer element : ELEMENTS) {
-                values = values.append(element);
-            }
-            assert areEqual(values, javaMutable);
-            return values;
-        }
-    }
-
-    public static class GroupBy extends Base {
-        @Benchmark
-        public Object java_mutable() {
-            return javaMutable.stream().collect(Collectors.groupingBy(Integer::bitCount));
-        }
-
-        @Benchmark
-        public Object scala_persistent() {
-            return scalaPersistent.groupBy(JFunction.func(Integer::bitCount));
-        }
-
-        @Benchmark
-        public Object slang_persistent() {
-            return slangPersistent.groupBy(Integer::bitCount);
-        }
-    }
-
-    public static class Slice extends Base {
-        @Benchmark
-        public void java_mutable(Blackhole bh) {
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                for (int j = i; j < Math.min(CONTAINER_SIZE, 100); j++) {
-                    bh.consume(javaMutable.subList(i, j));
-                }
-            }
-        }
-
-        @Benchmark
-        public void scala_persistent(Blackhole bh) {
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                for (int j = i; j < Math.min(CONTAINER_SIZE, 100); j++) {
-                    bh.consume(scalaPersistent.slice(i, j));
-                }
-            }
-        }
-
-        @Benchmark
-        public void slang_persistent(Blackhole bh) {
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                for (int j = i; j < Math.min(CONTAINER_SIZE, 100); j++) {
-                    bh.consume(slangPersistent.slice(i, j));
-                }
-            }
-        }
-    }
-
-    @SuppressWarnings("ForLoopReplaceableByForEach")
+    /* Sequential access for all elements */
     public static class Iterate extends Base {
-        @State(Scope.Thread)
-        public static class Initialized {
-            final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
-
-            @Setup(Level.Invocation)
-            public void initializeMutable(Base state) {
-                java.util.Collections.addAll(javaMutable, state.ELEMENTS);
-                assert areEqual(javaMutable, asList(state.ELEMENTS));
-            }
-
-            @TearDown(Level.Invocation)
-            public void tearDown() {
-                javaMutable.clear();
-            }
-        }
-
-        @Benchmark
-        public int java_mutable(Initialized state) {
-            int aggregate = 0;
-            for (final java.util.Iterator<Integer> iterator = state.javaMutable.iterator(); iterator.hasNext(); ) {
-                aggregate ^= iterator.next();
-            }
-            assert aggregate == EXPECTED_AGGREGATE;
-            return aggregate;
-        }
-
-        @Benchmark
-        public int scala_persistent() {
-            int aggregate = 0;
-            for (final scala.collection.Iterator<Integer> iterator = scalaPersistent.iterator(); iterator.hasNext(); ) {
-                aggregate ^= iterator.next();
-            }
-            assert aggregate == EXPECTED_AGGREGATE;
-            return aggregate;
-        }
-
-        @Benchmark
-        @SuppressWarnings("unchecked")
-        public int clojure_persistent() {
-            int aggregate = 0;
-            for (final java.util.Iterator<Integer> iterator = clojurePersistent.iterator(); iterator.hasNext(); ) {
-                aggregate ^= iterator.next();
-            }
-            assert aggregate == EXPECTED_AGGREGATE;
-            return aggregate;
-        }
-
-        @Benchmark
-        public int fjava_persistent() {
-            int aggregate = 0;
-            for (final java.util.Iterator<Integer> iterator = fjavaPersistent.iterator(); iterator.hasNext(); ) {
-                aggregate ^= iterator.next();
-            }
-            assert aggregate == EXPECTED_AGGREGATE;
-            return aggregate;
-        }
-
-        @Benchmark
-        public int pcollections_persistent() {
-            int aggregate = 0;
-            for (final java.util.Iterator<Integer> iterator = pcollectionsPersistent.iterator(); iterator.hasNext(); ) {
-                aggregate ^= iterator.next();
-            }
-            assert aggregate == EXPECTED_AGGREGATE;
-            return aggregate;
-        }
-
         @Benchmark
         public int slang_persistent() {
             int aggregate = 0;

--- a/javaslang/src/main/java/javaslang/collection/Arrays2.java
+++ b/javaslang/src/main/java/javaslang/collection/Arrays2.java
@@ -21,17 +21,17 @@ final class Arrays2 { // TODO reuse these in `Array` also
 
     /** Repeatedly group an array into equal sized sub-trees */
     static Object grouped(Object array, int length, int groupSize) {
-        Class<?> type = toPrimitive(get(array, 0).getClass());
+        Class<?> type = toPrimitive(array.getClass().getComponentType());
 
         final int firstSize = Math.min(groupSize, length);
         Object results = newInstance(type, firstSize);
         System.arraycopy(array, 0, results, 0, firstSize);
 
-        if (firstSize < getLength(array)) {
+        if (firstSize < length) {
             final Object[] parentArray = new Object[1 + ((length - 1) / groupSize)];
             parentArray[0] = results;
 
-            for (int start = firstSize, i = 1; start < getLength(array); i++) {
+            for (int start = firstSize, i = 1; start < length; i++) {
                 int nextSize = Math.min(groupSize, length - (i * groupSize));
                 Object next = newInstance(type, nextSize);
                 System.arraycopy(array, start, next, 0, nextSize);
@@ -45,56 +45,82 @@ final class Arrays2 { // TODO reuse these in `Array` also
         return results;
     }
 
+    static <T> Object drop(Class<?> type, Object array, int index) {
+        final int length = getLength(type, array);
+        Object copy = newInstance(type, length);
+        System.arraycopy(array, index, copy, index, length - index);
+        return copy;
+    }
+
     /** Store the content of an iterable in an array */
     static <T> Object asArray(java.util.Iterator<T> it, int length) {
         assert length > 0;
 
         Object first = it.next();
-        final Class<?> type = toPrimitive(first.getClass());
-        Object array = newInstance(type, length);
-        set(array, 0, first);
+        Object[] array = new Object[length];
+        array[0] = first;
 
         for (int i = 1; i < length; i++) {
-            set(array, i, it.next());
+            array[i] = it.next();
         }
         return array;
     }
 
     static Object asArray(Class<?> type, Object element) {
         Object newTrailing = newInstance(type, 1);
-        set(newTrailing, 0, element);
+        set(type, newTrailing, 0, element);
         return newTrailing;
     }
 
     static Object newInstance(Class<?> type, int size) {
-        if (int.class.equals(type)) {
-            return new int[size];
+        if (type.isPrimitive()) {
+            if (int.class.equals(type)) return new int[size];
+            else if (char.class.equals(type)) return new char[size];
+            else if (byte.class.equals(type)) return new byte[size];
+            else if (long.class.equals(type)) return new long[size];
+            else if (double.class.equals(type)) return new double[size];
+            else return java.lang.reflect.Array.newInstance(type, size);
         } else {
             return new Object[size];
         }
     }
-    static int getLength(Object array) {
-        if (array instanceof int[]) {
-            final int[] intArray = (int[]) array;
-            return intArray.length;
+
+    static int getLength(Class<?> type, Object array) {
+        if (type.isPrimitive()) {
+            if (array instanceof int[]) return ((int[]) array).length;
+            else if (array instanceof char[]) return ((char[]) array).length;
+            else if (array instanceof byte[]) return ((byte[]) array).length;
+            else if (array instanceof long[]) return ((long[]) array).length;
+            else if (array instanceof double[]) return ((double[]) array).length;
+            else return java.lang.reflect.Array.getLength(array);
         } else {
             final Object[] objectArray = (Object[]) array;
             return objectArray.length;
         }
     }
-    static Object get(Object array, int index) {
-        if (array instanceof int[]) {
-            final int[] intArray = (int[]) array;
-            return intArray[index];
+
+    static <T> T get(Class<?> type, Object array, int index) {
+        if (type.isPrimitive()) {
+            if (array instanceof int[]) return (T) (Object) ((int[]) array)[index];
+            else if (array instanceof char[]) return (T) (Object) ((char[]) array)[index];
+            else if (array instanceof byte[]) return (T) (Object) ((byte[]) array)[index];
+            else if (array instanceof long[]) return (T) (Object) ((long[]) array)[index];
+            else if (array instanceof double[]) return (T) (Object) ((double[]) array)[index];
+            else return (T) java.lang.reflect.Array.get(array, index);
         } else {
             final Object[] objectArray = (Object[]) array;
-            return objectArray[index];
+            return (T) objectArray[index];
         }
     }
-    static void set(Object array, int index, Object value) {
-        if (array instanceof int[]) {
-            final int[] intArray = (int[]) array;
-            intArray[index] = (Integer) value;
+
+    static void set(Class<?> type, Object array, int index, Object value) {
+        if (type.isPrimitive()) {
+            if (array instanceof int[]) ((int[]) array)[index] = (int) value;
+            else if (array instanceof char[]) ((char[]) array)[index] = (char) value;
+            else if (array instanceof byte[]) ((byte[]) array)[index] = (byte) value;
+            else if (array instanceof long[]) ((long[]) array)[index] = (long) value;
+            else if (array instanceof double[]) ((double[]) array)[index] = (double) value;
+            else java.lang.reflect.Array.set(array, index, value);
         } else {
             final Object[] objectArray = (Object[]) array;
             objectArray[index] = value;
@@ -104,7 +130,7 @@ final class Arrays2 { // TODO reuse these in `Array` also
     static Object toPrimitiveArray(Class<?> type, Object[] array) {
         Object results = newInstance(type, array.length);
         for (int i = 0; i < array.length; i++) {
-            set(results, i, array[i]);
+            set(type, results, i, array[i]);
         }
         return results;
     }

--- a/javaslang/src/main/java/javaslang/collection/Arrays2.java
+++ b/javaslang/src/main/java/javaslang/collection/Arrays2.java
@@ -1,0 +1,68 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2016 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+import java.util.Random;
+
+/**
+ * Internal class, containing helpers.
+ *
+ * @author Pap Lőrinc
+ * @since 3.0.0
+ */
+@SuppressWarnings({"unchecked", "SuspiciousArrayCast"})
+final class Arrays2 { // TODO reuse these in `Array` also
+    private static final Object[] EMPTY = {};
+
+    static <T> T[] emptyArray()                  { return (T[]) EMPTY; }
+    static boolean isNullOrEmpty(Object[] array) { return (array == null) || (array.length == 0); }
+
+    /** Repeatedly group an array into equal sized sub-trees */
+    static Object[] grouped(Object[] array, int length, int size) {
+        Object[] results = new Object[Math.min(size, length)];
+        System.arraycopy(array, 0, results, 0, results.length);
+
+        if (results.length < array.length) {
+            final Object[] parentArray = new Object[1 + ((length - 1) / size)];
+            parentArray[0] = results;
+
+            for (int start = results.length, i = 1; start < array.length; i++) {
+                final int nextLength = Math.min(size, length - (i * size));
+                Object[] next = new Object[nextLength];
+                System.arraycopy(array, start, next, 0, nextLength);
+                parentArray[i] = next;
+                start += nextLength;
+            }
+
+            results = parentArray;
+        }
+
+        return results;
+    }
+
+    /** Store the content of an iterable in an array */
+    static <T> T[] asArray(java.util.Iterator<T> it, int length) {
+        final T[] array = (T[]) new Object[length];
+        for (int i = 0; i < length; i++) {
+            array[i] = it.next();
+        }
+        return array;
+    }
+
+    /** Randomly mutate array positions */
+    static <T> int[] shuffle(int[] array, Random random) {
+        for (int i = array.length; i > 1; i--) {
+            swap(array, i - 1, random.nextInt(i));
+        }
+        return array;
+    }
+
+    static <T> void swap(int[] array, int i, int j) {
+        final int temp = array[i];
+        array[i] = array[j];
+        array[j] = temp;
+    }
+}

--- a/javaslang/src/main/java/javaslang/collection/Arrays2.java
+++ b/javaslang/src/main/java/javaslang/collection/Arrays2.java
@@ -67,16 +67,46 @@ final class Arrays2 { // TODO reuse these in `Array` also
     }
 
     static Object newInstance(Class<?> type, int size) {
-        return java.lang.reflect.Array.newInstance(type, size);
+        if (int.class.equals(type)) {
+            return new int[size];
+        } else {
+            return new Object[size];
+        }
     }
     static int getLength(Object array) {
-        return java.lang.reflect.Array.getLength(array);
+        if (array instanceof int[]) {
+            final int[] intArray = (int[]) array;
+            return intArray.length;
+        } else {
+            final Object[] objectArray = (Object[]) array;
+            return objectArray.length;
+        }
     }
     static Object get(Object array, int index) {
-        return java.lang.reflect.Array.get(array, index);
+        if (array instanceof int[]) {
+            final int[] intArray = (int[]) array;
+            return intArray[index];
+        } else {
+            final Object[] objectArray = (Object[]) array;
+            return objectArray[index];
+        }
     }
     static void set(Object array, int index, Object value) {
-        java.lang.reflect.Array.set(array, index, value);
+        if (array instanceof int[]) {
+            final int[] intArray = (int[]) array;
+            intArray[index] = (Integer) value;
+        } else {
+            final Object[] objectArray = (Object[]) array;
+            objectArray[index] = value;
+        }
+    }
+
+    static Object toPrimitiveArray(Class<?> type, Object[] array) {
+        Object results = newInstance(type, array.length);
+        for (int i = 0; i < array.length; i++) {
+            set(results, i, array[i]);
+        }
+        return results;
     }
 
     /* convert to primitive */

--- a/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
@@ -5,6 +5,7 @@
  */
 package javaslang.collection;
 
+import javaslang.Function2;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -23,10 +24,50 @@ public class VectorPropertyTest {
             final Vector<Integer> actual = Vector.ofAll(expected);
             assertAreEqual(expected, actual);
 
+            final Vector<Byte> actualByte = Vector.ofAll((byte[]) Arrays2.toPrimitiveArray(byte.class, expected.map(Integer::byteValue).toJavaArray()));
+            assert actualByte.leading instanceof byte[];
+            assertAreEqual(expected, actual);
+
+            final Vector<Boolean> actualBoolean = Vector.ofAll((boolean[]) Arrays2.toPrimitiveArray(boolean.class, expected.map(v -> (v % 2) == 0).toJavaArray()));
+            assert actualBoolean.leading instanceof boolean[];
+            assertAreEqual(expected, actual);
+
+            final Vector<Character> actualChar = Vector.ofAll((char[]) Arrays2.toPrimitiveArray(char.class, expected.map(v -> (char) v.intValue()).toJavaArray()));
+            assert actualChar.leading instanceof char[];
+            assertAreEqual(expected, actual);
+
+            final Vector<Double> actualDouble = Vector.ofAll((double[]) Arrays2.toPrimitiveArray(double.class, expected.map(Integer::doubleValue).toJavaArray()));
+            assert actualDouble.leading instanceof double[];
+            assertAreEqual(expected, actual);
+
             final Vector<Integer> actualInt = Vector.ofAll((int[]) Arrays2.toPrimitiveArray(int.class, expected.toJavaArray()));
             assert actualInt.leading instanceof int[];
             assertAreEqual(expected, actual);
+
+            final Vector<Long> actualLong = Vector.ofAll((long[]) Arrays2.toPrimitiveArray(long.class, expected.map(Integer::longValue).toJavaArray()));
+            assert actualLong.leading instanceof long[];
+            assertAreEqual(expected, actual);
         }
+    }
+
+    @Test
+    public void shouldIterate() {
+        final Seq<Integer> expected = Array.range(0, 10000);
+        final Vector<Integer> actual = Vector.ofAll((int[]) Arrays2.toPrimitiveArray(int.class, expected.toJavaArray()));
+
+        Iterator<Integer> expectedIterator = expected.iterator();
+        for (int i = 0; i < actual.length(); ) {
+            for (int value : (int[]) actual.getLeafUnsafe(i)) {
+                assertThat(value).isEqualTo(expectedIterator.next());
+                i++;
+            }
+        }
+    }
+
+    private static <T1, T2> Vector<Integer> assertAreEqual(T1 previousActual, T2 param, Function2<T1, T2, Vector<Integer>> actualProvider, Seq<Integer> expected) {
+        final Vector<Integer> actual = actualProvider.apply(previousActual, param);
+        assertAreEqual(expected, actual);
+        return actual; // makes debugging a lot easier, as the frame can be dropped and rerun on AssertError
     }
 
     private static void assertAreEqual(Seq<Integer> expected, Seq<Integer> actual) {

--- a/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
@@ -5,7 +5,6 @@
  */
 package javaslang.collection;
 
-import javaslang.Function2;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -19,26 +18,15 @@ public class VectorPropertyTest {
 
     @Test
     public void shouldCreateAndGet() {
-        for (byte depth = 0; depth <= 6; depth++) {
-            final int length = getMaxSizeForDepth(depth);
-
-            final Seq<Integer> expected = Array.range(0, length);
+        for (int i = 0; i < 2000; i++) {
+            final Seq<Integer> expected = Array.range(0, i);
             final Vector<Integer> actual = Vector.ofAll(expected);
+            assertAreEqual(expected, actual);
 
-            int i = 0;
-            for (Integer value : expected) {
-                final Integer actualValue = actual.get(i++);
-                assertThat(actualValue).isEqualTo(value);
-            }
-
-            System.out.println("Depth " + depth + " ok!");
+            final Vector<Integer> actualInt = Vector.ofAll((int[]) Arrays2.toPrimitiveArray(int.class, expected.toJavaArray()));
+            assert actualInt.leading instanceof int[];
+            assertAreEqual(expected, actual);
         }
-    }
-
-    private static <T1, T2> Vector<Integer> assertAreEqual(T1 previousActual, T2 param, Function2<T1, T2, Vector<Integer>> actualProvider, Seq<Integer> expected) {
-        final Vector<Integer> actual = actualProvider.apply(previousActual, param);
-        assertAreEqual(expected, actual);
-        return actual; // makes debugging a lot easier, as the frame can be dropped and rerun on AssertError
     }
 
     private static void assertAreEqual(Seq<Integer> expected, Seq<Integer> actual) {

--- a/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
@@ -1,0 +1,54 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2016 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+import javaslang.Function2;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VectorPropertyTest {
+    @Before
+    public void setUp() { Vector.BRANCHING_BASE = 2; }
+
+    @Test
+    public void shouldCreateAndGet() {
+        for (byte depth = 0; depth <= 6; depth++) {
+            final int length = getMaxSizeForDepth(depth);
+
+            final Seq<Integer> expected = Array.range(0, length);
+            final Vector<Integer> actual = Vector.ofAll(expected);
+
+            int i = 0;
+            for (Integer value : expected) {
+                final Integer actualValue = actual.get(i++);
+                assertThat(actualValue).isEqualTo(value);
+            }
+
+            System.out.println("Depth " + depth + " ok!");
+        }
+    }
+
+    private static <T1, T2> Vector<Integer> assertAreEqual(T1 previousActual, T2 param, Function2<T1, T2, Vector<Integer>> actualProvider, Seq<Integer> expected) {
+        final Vector<Integer> actual = actualProvider.apply(previousActual, param);
+        assertAreEqual(expected, actual);
+        return actual; // makes debugging a lot easier, as the frame can be dropped and rerun on AssertError
+    }
+
+    private static void assertAreEqual(Seq<Integer> expected, Seq<Integer> actual) {
+        final List<Integer> actualList = actual.toJavaList();
+        final List<Integer> expectedList = expected.toJavaList();
+        assertThat(actualList).isEqualTo(expectedList); // a lot faster than `hasSameElementsAs`
+    }
+
+    private static int getMaxSizeForDepth(int depth) {
+        final int max = Vector.branchingFactor() + (int) Math.pow(Vector.branchingFactor(), depth) + Vector.branchingFactor();
+        return Math.min(max, 10_000);
+    }
+}

--- a/javaslang/src/test/java/javaslang/collection/VectorTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorTest.java
@@ -5,10 +5,10 @@
  */
 package javaslang.collection;
 
-import javaslang.Value;
-import javaslang.control.Option;
 import javaslang.Serializables;
 import javaslang.Tuple2;
+import javaslang.Value;
+import javaslang.control.Option;
 import org.junit.Test;
 
 import java.io.InvalidObjectException;
@@ -16,7 +16,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.*;
+import java.util.stream.Collector;
 import java.util.stream.Stream;
 
 public class VectorTest extends AbstractIndexedSeqTest {
@@ -196,7 +196,7 @@ public class VectorTest extends AbstractIndexedSeqTest {
 
     @Test
     public void shouldTransform() {
-        String transformed = of(42).transform(v -> String.valueOf(v.get()));
+        final String transformed = of(42).transform(v -> String.valueOf(v.get()));
         assertThat(transformed).isEqualTo("42");
     }
 
@@ -210,10 +210,10 @@ public class VectorTest extends AbstractIndexedSeqTest {
     @Test
     public void shouldUnfoldRightSimpleVector() {
         assertThat(
-            Vector.unfoldRight(10, x -> x == 0
-                               ? Option.none()
-                               : Option.of(new Tuple2<>(x, x-1))))
-            .isEqualTo(of(10, 9, 8, 7, 6, 5, 4, 3, 2, 1));
+                Vector.unfoldRight(10, x -> x == 0
+                                            ? Option.none()
+                                            : Option.of(new Tuple2<>(x, x - 1))))
+                .isEqualTo(of(10, 9, 8, 7, 6, 5, 4, 3, 2, 1));
     }
 
     @Test
@@ -224,10 +224,10 @@ public class VectorTest extends AbstractIndexedSeqTest {
     @Test
     public void shouldUnfoldLeftSimpleVector() {
         assertThat(
-            Vector.unfoldLeft(10, x -> x == 0
-                              ? Option.none()
-                              : Option.of(new Tuple2<>(x-1, x))))
-            .isEqualTo(of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+                Vector.unfoldLeft(10, x -> x == 0
+                                           ? Option.none()
+                                           : Option.of(new Tuple2<>(x - 1, x))))
+                .isEqualTo(of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
     }
 
     @Test
@@ -238,10 +238,10 @@ public class VectorTest extends AbstractIndexedSeqTest {
     @Test
     public void shouldUnfoldSimpleVector() {
         assertThat(
-            Vector.unfold(10, x -> x == 0
-                          ? Option.none()
-                          : Option.of(new Tuple2<>(x-1, x))))
-            .isEqualTo(of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+                Vector.unfold(10, x -> x == 0
+                                       ? Option.none()
+                                       : Option.of(new Tuple2<>(x - 1, x))))
+                .isEqualTo(of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
     }
 
     // -- toString
@@ -261,40 +261,6 @@ public class VectorTest extends AbstractIndexedSeqTest {
     @Test(expected = InvalidObjectException.class)
     public void shouldNotSerializeEnclosingClass() throws Throwable {
         Serializables.callReadObject(List.of(1));
-    }
-
-    @Test(expected = InvalidObjectException.class)
-    public void shouldNotDeserializeListWithSizeLessThanOne() throws Throwable {
-        try {
-            /*
-             * This implementation is stable regarding jvm impl changes of object serialization. The index of the number
-             * of List elements is gathered dynamically.
-             */
-            final byte[] listWithOneElement = Serializables.serialize(List.of(0));
-            final byte[] listWithTwoElements = Serializables.serialize(List.of(0, 0));
-            int index = -1;
-            for (int i = 0; i < listWithOneElement.length && index == -1; i++) {
-                final byte b1 = listWithOneElement[i];
-                final byte b2 = listWithTwoElements[i];
-                if (b1 != b2) {
-                    if (b1 != 1 || b2 != 2) {
-                        throw new IllegalStateException("Difference does not indicate number of elements.");
-                    } else {
-                        index = i;
-                    }
-                }
-            }
-            if (index == -1) {
-                throw new IllegalStateException("Hack incomplete - index not found");
-            }
-            /*
-             * Hack the serialized data and fake zero elements.
-			 */
-            listWithOneElement[index] = 0;
-            Serializables.deserialize(listWithOneElement);
-        } catch (IllegalStateException x) {
-            throw (x.getCause() != null) ? x.getCause() : x;
-        }
     }
 
     // -- toVector


### PR DESCRIPTION
I created a POC (not to be merged), [demonstrating non-boxed primitive storage](https://github.com/javaslang/javaslang/pull/1484/commits/4a626461cef06fa37a89326eaec494d36929469b#diff-5f4a536088f7f19a51ebbef20cf7b3efR54) for [`Vector`](https://github.com/javaslang/javaslang/pull/1449).

That is, if a `Vector` is created with a primitive wrapper type (e.g. `Vector<Integer>`), the internal array will be of the corresponding primitive type (e.g. `int[]`) instead of the boxed type (e.g. `Integer[]`).
All operations on the `Vector`'s internal array are implemented [using reflection or via specialized checks](https://github.com/javaslang/javaslang/pull/1484/commits/d24faab1daa7fe12ae32ad5b291f6d3366ebf676#diff-c6c1876105d111251f38e0916d4d99a4R69).

The memory usage for unboxed primitive storage is very promising, i.e. uses up to `~4x` less memory than `ArrayList` or `boxed` `Vector`:
```java
for 1024 elements
`java.util.ArrayList` uses `18.6 KB` (`0 bytes` overhead, `0.0` bytes overhead per element)
`javaslang.collection.BoxedVector` uses `19.3 KB` (`664 bytes` overhead, `0.6` bytes overhead per element)
`javaslang.collection.Vector` uses `4.7 KB` (`-14240 bytes` overhead, `-13.9` bytes overhead per element)
```

Boxed, no reflection (original implementation):
```java
Operation   Impl                Params            Score  ±  Error  Unit
Create      slang_persistent      1024      550,181.653  ±  6.17% ops/s
Head        slang_persistent      1024  273,522,239.620  ± 15.05% ops/s
Get         slang_persistent      1024      253,750.035  ±  1.97% ops/s
```
[Boxed, with reflection](https://github.com/javaslang/javaslang/pull/1484/commits/4a626461cef06fa37a89326eaec494d36929469b#diff-c6c1876105d111251f38e0916d4d99a4R69) - without primitive conversion:
```java
Operation   Impl                Params            Score  ± Error   Unit
Create      slang_persistent      1024      235,575.521  ± 2.90%  ops/s
Head        slang_persistent      1024   21,594,009.129  ± 0.77%  ops/s
Get         slang_persistent      1024       11,254.908  ± 1.70%  ops/s
```
[Primitive, with reflection](https://github.com/javaslang/javaslang/pull/1484/commits/4a626461cef06fa37a89326eaec494d36929469b#diff-c6c1876105d111251f38e0916d4d99a4R69) -  note: uses `~4x` less memory:
```java
Operation   Impl                Params            Score  ± Error   Unit
Create      slang_persistent      1024       23,179.890  ± 1.36%  ops/s
Head        slang_persistent      1024   14,401,390.967  ± 2.22%  ops/s
Get         slang_persistent      1024        8,707.254  ± 1.84%  ops/s
```
i.e. `~10-50` times slower.

However, [simple specialization](https://github.com/javaslang/javaslang/pull/1484/commits/d24faab1daa7fe12ae32ad5b291f6d3366ebf676#diff-c6c1876105d111251f38e0916d4d99a4R69) (e.g. if `Vector` were an interface with e.g. `IntVector`/`CharVector` children) reveals (note: uses `~4x` less memory):
```java
Operation Impl                  Params            Score  ± Error   Unit
Create    slang_persistent        1024      279,322.949  ± 3.44%  ops/s
Create    slang_persistent_int    1024      655,092.717  ± 1.46%  ops/s

Head      slang_persistent        1024  168,508,482.722  ± 0.83%  ops/s
Head      slang_persistent_int    1024  269,753,246.425  ± 0.91%  ops/s

Get       slang_persistent        1024       78,920.869  ± 0.87%  ops/s
Get       slang_persistent_int    1024      252,564.494  ± 2.06%  ops/s
```
which is only `~60%` of the original speed with boxed end result (i.e. a `get` that returns an `Integer`).
If we provide specialized methods (which could be accessed via casting to `IntVector`), it would have the same speed as the original (using a lot less memory).

---

**EDIT**:
specialized for most primitives and the numbers are pretty good! (https://github.com/javaslang/javaslang/pull/1484/commits/26cbb1355a58466d3a2dfd109a88783559e637ee#diff-c6c1876105d111251f38e0916d4d99a4R75)
Also, I found a way of avoiding boxing at the end (making te whole solution viable), take a look :)
```java
Operation  Impl                 Params            Score  ± Error   Unit
Create     slang_persistent       1024      353,200.887  ± 7.15%  ops/s
Create     slang_persistent_int   1024      711,118.523  ± 1.79%  ops/s

Head       slang_persistent       1024  144,142,491.461  ± 1.36%  ops/s
Head       slang_persistent_int   1024  207,905,574.556  ± 0.95%  ops/s

Get        slang_persistent       1024      106,121.968  ± 1.50%  ops/s
Get        slang_persistent_int   1024      214,445.932  ± 1.49%  ops/s

Iterate    slang_persistent       1024      116,656.843  ± 1.49%  ops/s
Iterate    slang_persistent_int   1024    2,163,161.600  ± 1.42%  ops/s
```