### PR TITLE
Add aliases in API

### DIFF
--- a/javaslang/generator/Generator.scala
+++ b/javaslang/generator/Generator.scala
@@ -57,6 +57,7 @@ def generateMainClasses(): Unit = {
       val ExecutorServiceType = im.getType("java.util.concurrent.ExecutorService")
       val TryType = im.getType("javaslang.control.Try")
       val ValidationType = im.getType("javaslang.control.Validation")
+      val CharSeqType = im.getType("javaslang.collection.CharSeq")
 
       def genAliases(im: ImportManager, packageName: String, className: String): String = {
         xs"""
@@ -333,6 +334,37 @@ def generateMainClasses(): Unit = {
            */
           public static <E, T> $ValidationType<E, T> Invalid(E error) {
               return $ValidationType.invalid(error);
+          }
+
+          /$javadoc
+           * Alias for {@link $CharSeqType#of(char)}
+           *
+           * @param character A character.
+           * @return A new {@link $CharSeqType} instance containing the given element
+           */
+          public static $CharSeqType CharSeq(char character) {
+              return $CharSeqType.of(character);
+          }
+
+          /$javadoc
+           * Alias for {@link $CharSeqType#of(char...)}
+           *
+           * @param characters Zero or more characters.
+           * @return A new {@link $CharSeqType} instance containing the given characters in the same order.
+           * @throws NullPointerException if {@code elements} is null
+           */
+          public static $CharSeqType CharSeq(char... characters) {
+              return $CharSeqType.of(characters);
+          }
+
+          /$javadoc
+           * Alias for {@link $CharSeqType#of(CharSequence)}
+           *
+           * @param sequence {@code CharSequence} instance.
+           * @return A new {@link $CharSeqType} instance
+           */
+          public static $CharSeqType CharSeq(CharSequence sequence) {
+              return $CharSeqType.of(sequence);
           }
 
         """
@@ -1829,6 +1861,12 @@ def generateTestClasses(): Unit = {
           ${genSimpleAliasTest("Valid", "1")}
 
           ${genSimpleAliasTest("Invalid", "new Error()")}
+
+          ${genMediumAliasTest("Char", "(Iterable<Character>) CharSeq", "'1'")}
+
+          ${genMediumAliasTest("CharArray", "(Iterable<Character>) CharSeq", "'1', '2', '3'")}
+
+          ${genMediumAliasTest("CharSeq", "(Iterable<Character>) CharSeq", "\"123\"")}
 
         """
       }

--- a/javaslang/generator/Generator.scala
+++ b/javaslang/generator/Generator.scala
@@ -230,6 +230,17 @@ def generateMainClasses(): Unit = {
               return $FutureType.failed(executorService, exception);
           }
 
+          /$javadoc
+           * Alias for {@link Lazy#of($SupplierType)}
+           *
+           * @param <T>      type of the lazy value
+           * @param supplier A supplier
+           * @return A new instance of {@link Lazy}
+           */
+          public static <T> Lazy<T> Lazy($SupplierType<? extends T> supplier) {
+              return Lazy.of(supplier);
+          }
+
         """
       }
 
@@ -1636,6 +1647,19 @@ def generateTestClasses(): Unit = {
         """
       }
 
+      def genExtAliasTest(name: String, func: String, value: String, check: String): String = {
+        xs"""
+          @$test
+          public void should${name}() {
+              assertThat($func($value)).$check;
+          }
+        """
+      }
+
+      def genMediumAliasTest(name: String, func: String, value: String): String = genExtAliasTest(s"${name}ReturnNotNull", func, value, "isNotNull()")
+
+      def genSimpleAliasTest(name: String, value: String): String = genMediumAliasTest(name, name, value)
+
       def genAliasesTests(im: ImportManager, packageName: String, className: String): String = {
         xs"""
           ${(0 to N).gen(i => {
@@ -1680,6 +1704,8 @@ def generateTestClasses(): Unit = {
           ${genFutureTests("Value", "1", success = true)}
 
           ${genFutureTests("Error", "new Error()", success = false)}
+
+          ${genSimpleAliasTest("Lazy", "() -> 1")}
 
         """
       }

--- a/javaslang/generator/Generator.scala
+++ b/javaslang/generator/Generator.scala
@@ -69,6 +69,10 @@ def generateMainClasses(): Unit = {
       val TreeSetType = im.getType("javaslang.collection.TreeSet")
       val PriorityQueueType = im.getType("javaslang.collection.PriorityQueue")
       val JavaComparatorType = im.getType("java.util.Comparator")
+      val LinkedHashMapType = im.getType("javaslang.collection.LinkedHashMap")
+      val HashMapType = im.getType("javaslang.collection.HashMap")
+      val TreeMapType = im.getType("javaslang.collection.TreeMap")
+      val JavaMapType = im.getType("java.util.Map")
 
       def genTraversableAliases(traversableType: String, name: String): String = {
         xs"""
@@ -249,6 +253,72 @@ def generateMainClasses(): Unit = {
            */
           public static <T> $traversableType<T> $name($JavaComparatorType<? super T> comparator, $JavaStreamType<? extends T> elements) {
               return $traversableType.ofAll(comparator, elements);
+          }
+        """
+      }
+
+      def genMapAliases(mapType: String, name: String): String = {
+        xs"""
+          /$javadoc
+           * Alias for {@link $mapType#empty()}
+           *
+           * @param <K> The key type.
+           * @param <V> The value type.
+           * @return A singleton instance of empty {@link $mapType}
+           */
+          public static <K, V> $mapType<K, V> $name() {
+              return $mapType.empty();
+          }
+
+          /$javadoc
+           * Alias for {@link $mapType#of(Object, Object)}
+           *
+           * @param <K>   The key type.
+           * @param <V>   The value type.
+           * @param key   A singleton map key.
+           * @param value A singleton map value.
+           * @return A new {@link $mapType} instance containing the given entry
+           */
+          public static <K, V> $mapType<K, V> $name(K key, V value) {
+              return $mapType.of(key, value);
+          }
+
+          /$javadoc
+           * Alias for {@link $mapType#ofEntries(Tuple2...)}
+           *
+           * @param <K>     The key type.
+           * @param <V>     The value type.
+           * @param entries Map entries.
+           * @return A new {@link $mapType} instance containing the given entries
+           */
+          @SuppressWarnings("varargs")
+          @SafeVarargs
+          public static <K, V> $mapType<K, V> $name(Tuple2<? extends K, ? extends V>... entries) {
+              return $mapType.ofEntries(entries);
+          }
+
+          /$javadoc
+           * Alias for {@link $mapType#ofAll($JavaMapType)}
+           *
+           * @param <K> The key type.
+           * @param <V> The value type.
+           * @param map A map entry.
+           * @return A new {@link $mapType} instance containing the given map
+           */
+          public static <K, V> $mapType<K, V> $name($JavaMapType<? extends K, ? extends V> map) {
+              return $mapType.ofAll(map);
+          }
+
+          /$javadoc
+           * Alias for {@link $mapType#of(Object...)}
+           *
+           * @param <K>   The key type.
+           * @param <V>   The value type.
+           * @param pairs A list of key-value pairs.
+           * @return A new {@link $mapType} instance containing the given entries
+           */
+          public static <K, V> $mapType<K, V> $name(Object... pairs) {
+              return $mapType.of(pairs);
           }
         """
       }
@@ -582,6 +652,113 @@ def generateMainClasses(): Unit = {
           ${genSortedTraversableAliases(TreeSetType, "SortedSet", "extends Comparable<? super T>")}
 
           ${genSortedTraversableAliases(PriorityQueueType, "PriorityQueue", "extends Comparable<T>")}
+
+          ${genMapAliases(LinkedHashMapType, "LinkedMap")}
+
+          ${genMapAliases(HashMapType, "Map")}
+
+          /$javadoc
+           * Alias for {@link $TreeMapType#empty()}
+           *
+           * @param <K> The key type.
+           * @param <V> The value type.
+           * @return A new empty {@link $TreeMapType} instance
+           */
+          public static <K extends Comparable<? super K>, V> $TreeMapType<K, V> SortedMap() {
+              return $TreeMapType.empty();
+          }
+
+          /$javadoc
+           * Alias for {@link $TreeMapType#empty($JavaComparatorType)}
+           *
+           * @param <K>           The key type.
+           * @param <V>           The value type.
+           * @param keyComparator The comparator used to sort the entries by their key
+           * @return A new empty {@link $TreeMapType} instance
+           */
+          public static <K, V> $TreeMapType<K, V> SortedMap($JavaComparatorType<? super K> keyComparator) {
+              return $TreeMapType.empty(keyComparator);
+          }
+
+          /$javadoc
+           * Alias for {@link $TreeMapType#of(Comparable, Object)}
+           *
+           * @param <K>   The key type.
+           * @param <V>   The value type.
+           * @param key   A singleton map key.
+           * @param value A singleton map value.
+           * @return A new {@link $TreeMapType} instance containing the given entry
+           */
+          public static <K extends Comparable<? super K>, V> $TreeMapType<K, V> SortedMap(K key, V value) {
+              return $TreeMapType.of(key, value);
+          }
+
+          /$javadoc
+           * Alias for {@link $TreeMapType#of(Comparator, Object, Object)}
+           *
+           * @param <K>           The key type.
+           * @param <V>           The value type.
+           * @param keyComparator The comparator used to sort the entries by their key
+           * @param key           A singleton map key.
+           * @param value         A singleton map value.
+           * @return A new {@link $TreeMapType} instance containing the given entry
+           */
+          public static <K, V> $TreeMapType<K, V> SortedMap(Comparator<? super K> keyComparator, K key, V value) {
+              return $TreeMapType.of(keyComparator, key, value);
+          }
+
+          /$javadoc
+           * Alias for {@link $TreeMapType#ofEntries(Tuple2...)}
+           *
+           * @param <K>     The key type.
+           * @param <V>     The value type.
+           * @param entries Map entries.
+           * @return A new {@link $TreeMapType} instance containing the given entries
+           */
+          @SuppressWarnings("varargs")
+          @SafeVarargs
+          public static <K extends Comparable<? super K>, V> $TreeMapType<K, V> SortedMap(Tuple2<? extends K, ? extends V>... entries) {
+              return $TreeMapType.ofEntries(entries);
+          }
+
+          /$javadoc
+           * Alias for {@link $TreeMapType#ofEntries($JavaComparatorType, Tuple2...)}
+           *
+           * @param <K>           The key type.
+           * @param <V>           The value type.
+           * @param keyComparator The comparator used to sort the entries by their key
+           * @param entries       Map entries.
+           * @return A new {@link $TreeMapType} instance containing the given entry
+           */
+          @SuppressWarnings("varargs")
+          @SafeVarargs
+          public static <K, V> $TreeMapType<K, V> SortedMap($JavaComparatorType<? super K> keyComparator, Tuple2<? extends K, ? extends V>... entries) {
+              return $TreeMapType.ofEntries(keyComparator, entries);
+          }
+
+          /$javadoc
+           * Alias for {@link $TreeMapType#ofAll($JavaMapType)}
+           *
+           * @param <K> The key type.
+           * @param <V> The value type.
+           * @param map A map entry.
+           * @return A new {@link $TreeMapType} instance containing the given map
+           */
+          public static <K extends Comparable<? super K>, V> $TreeMapType<K, V> SortedMap($JavaMapType<? extends K, ? extends V> map) {
+              return $TreeMapType.ofAll(map);
+          }
+
+          /$javadoc
+           * Alias for {@link $TreeMapType#of(Object...)}
+           *
+           * @param <K>   The key type.
+           * @param <V>   The value type.
+           * @param pairs A list of key-value pairs.
+           * @return A new {@link $TreeMapType} instance containing the given entries
+           */
+          public static <K extends Comparable<? super K>, V> $TreeMapType<K, V> SortedMap(Object... pairs) {
+              return $TreeMapType.of(pairs);
+          }
         """
       }
 
@@ -1965,6 +2142,7 @@ def generateTestClasses(): Unit = {
       val TryType = im.getType("javaslang.control.Try")
       val JavaStreamType = im.getType("java.util.stream.Stream")
       val JavaComparatorType = im.getType("java.util.Comparator")
+      val JavaCollectionsType = im.getType("java.util.Collections")
 
       val d = "$";
 
@@ -2040,6 +2218,21 @@ def generateTestClasses(): Unit = {
           ${genMediumAliasTest(s"${func}WithStream", func, s"$JavaStreamType.of('1', '2', '3')")}
 
           ${genMediumAliasTest(s"${func}WithStreamAndComparator", func, s"Character::compareTo, $JavaStreamType.of('1', '2', '3')")}
+
+        """
+      }
+
+      def genMapTests(func: String): String = {
+        xs"""
+          ${genMediumAliasTest(s"Empty${func}", func, "")}
+
+          ${genMediumAliasTest(s"${func}FromSingle", func, "1, '1'")}
+
+          ${genMediumAliasTest(s"${func}FromTuples", func, "Tuple(1, '1'), Tuple(2, '2'), Tuple(3, '3')")}
+
+          ${genMediumAliasTest(s"${func}FromMap", func, s"$JavaCollectionsType.singletonMap(1, '1')")}
+
+          ${genMediumAliasTest(s"${func}FromPairs", func, "1, '1', 2, '2', 3, '3'")}
 
         """
       }
@@ -2137,6 +2330,15 @@ def generateTestClasses(): Unit = {
 
           ${genSortedTraversableTests("SortedSet")}
           ${genSortedTraversableTests("PriorityQueue")}
+
+          ${genMapTests("LinkedMap")}
+          ${genMapTests("Map")}
+          ${genMapTests("SortedMap")}
+          ${genMediumAliasTest("EmptySortedMapFromComparator", "SortedMap", "Integer::compareTo")}
+
+          ${genMediumAliasTest("SortedMapFromSingleAndComparator", "SortedMap", s"($JavaComparatorType<Integer>)Integer::compareTo, 1, '1'")}
+
+          ${genMediumAliasTest("SortedMapFromTuplesAndComparator", "SortedMap", s"($JavaComparatorType<Integer>)Integer::compareTo, Tuple(1, '1'), Tuple(2, '2'), Tuple(3, '3')")}
         """
       }
 

--- a/javaslang/generator/Generator.scala
+++ b/javaslang/generator/Generator.scala
@@ -92,6 +92,36 @@ def generateMainClasses(): Unit = {
             """
           })("\n\n")}
 
+          /$javadoc
+           * Alias for {@link Tuple#empty()}
+           *
+           * @return the empty tuple.
+           */
+          public static Tuple0 Tuple() {
+              return Tuple.empty();
+          }
+
+          ${(1 to N).gen(i => {
+            val generics = (1 to i).gen(j => s"T$j")(", ")
+            val links = (1 to i).gen(j => s"Object")(", ")
+            val params = (1 to i).gen(j => s"T$j t$j")(", ")
+            val args = (1 to i).gen(j => s"t$j")(", ")
+            xs"""
+              /$javadoc
+               * Alias for {@link Tuple#of($links)}
+               *
+               * Creates a tuple of ${i.numerus("element")}.
+               *
+               ${(1 to i).gen(j => s"* @param <T$j> type of the ${j.ordinal} element")("\n")}
+               ${(1 to i).gen(j => s"* @param t$j   the ${j.ordinal} element")("\n")}
+               * @return a tuple of ${i.numerus("element")}.
+               */
+              public static <$generics> Tuple$i<$generics> Tuple($params) {
+                  return Tuple.of($args);
+              }
+            """
+          })("\n\n")}
+
         """
       }
 
@@ -1487,6 +1517,17 @@ def generateTestClasses(): Unit = {
               @$test
               public void shouldCheckedFunction${i}ReturnNotNull() {
                   assertThat(CheckedFunction$i(($params) -> null)).isNotNull();
+              }
+
+            """
+          })("\n\n")}
+
+          ${(0 to N).gen(i => {
+            val params = (1 to i).gen(j => s"$j")(", ")
+            xs"""
+              @$test
+              public void shouldTuple${i}ReturnNotNull() {
+                  assertThat(Tuple($params)).isNotNull();
               }
 
             """

--- a/javaslang/generator/Generator.scala
+++ b/javaslang/generator/Generator.scala
@@ -241,6 +241,38 @@ def generateMainClasses(): Unit = {
               return Lazy.of(supplier);
           }
 
+          /$javadoc
+           * Alias for {@link $OptionType#of(Object)}
+           *
+           * @param <T>   type of the value
+           * @param value A value
+           * @return {@link $OptionType.Some} if value is not {@code null}, {@link $OptionType.None} otherwise
+           */
+          public static <T> $OptionType<T> Option(T value) {
+              return $OptionType.of(value);
+          }
+
+          /$javadoc
+           * Alias for {@link $OptionType#some(Object)}
+           *
+           * @param <T>   type of the value
+           * @param value A value
+           * @return {@link $OptionType.Some}
+           */
+          public static <T> $OptionType<T> Some(T value) {
+              return $OptionType.some(value);
+          }
+
+          /$javadoc
+           * Alias for {@link $OptionType#none()}
+           *
+           * @param <T> component type
+           * @return the singleton instance of {@link $OptionType.None}
+           */
+          public static <T> $OptionType<T> None() {
+              return $OptionType.none();
+          }
+
         """
       }
 
@@ -1706,6 +1738,12 @@ def generateTestClasses(): Unit = {
           ${genFutureTests("Error", "new Error()", success = false)}
 
           ${genSimpleAliasTest("Lazy", "() -> 1")}
+
+          ${genSimpleAliasTest("Option", "1")}
+
+          ${genSimpleAliasTest("Some", "1")}
+
+          ${genSimpleAliasTest("None", "")}
 
         """
       }

--- a/javaslang/generator/Generator.scala
+++ b/javaslang/generator/Generator.scala
@@ -58,6 +58,77 @@ def generateMainClasses(): Unit = {
       val TryType = im.getType("javaslang.control.Try")
       val ValidationType = im.getType("javaslang.control.Validation")
       val CharSeqType = im.getType("javaslang.collection.CharSeq")
+      val ArrayType = im.getType("javaslang.collection.Array")
+      val VectorType = im.getType("javaslang.collection.Vector")
+      val ListType = im.getType("javaslang.collection.List")
+      val StreamType = im.getType("javaslang.collection.Stream")
+      val QueueType = im.getType("javaslang.collection.Queue")
+      val LinkedHashSetType = im.getType("javaslang.collection.LinkedHashSet")
+      val HashSetType = im.getType("javaslang.collection.HashSet")
+      val JavaStreamType = im.getType("java.util.stream.Stream")
+
+      def genTraversableAliases(traversableType: String, name: String): String = {
+        xs"""
+          /$javadoc
+           * Alias for {@link $traversableType#empty()}
+           *
+           * @param <T> Component type of element.
+           * @return A singleton instance of empty {@link $traversableType}
+           */
+          public static <T> $traversableType<T> $name() {
+              return $traversableType.empty();
+          }
+
+          /$javadoc
+           * Alias for {@link $traversableType#of(Object)}
+           *
+           * @param <T>     Component type of element.
+           * @param element An element.
+           * @return A new {@link $traversableType} instance containing the given element
+           */
+          public static <T> $traversableType<T> $name(T element) {
+              return $traversableType.of(element);
+          }
+
+          /$javadoc
+           * Alias for {@link $traversableType#of(Object...)}
+           *
+           * @param <T>      Component type of elements.
+           * @param elements Zero or more elements.
+           * @return A new {@link $traversableType} instance containing the given elements
+           * @throws NullPointerException if {@code elements} is null
+           */
+          @SuppressWarnings("varargs")
+          @SafeVarargs
+          public static <T> $traversableType<T> $name(T... elements) {
+              return $traversableType.of(elements);
+          }
+
+          /$javadoc
+           * Alias for {@link $traversableType#ofAll(Iterable)}
+           *
+           * @param <T>      Component type of elements.
+           * @param elements Zero or more elements.
+           * @return A new {@link $traversableType} instance containing the given elements
+           * @throws NullPointerException if {@code elements} is null
+           */
+          public static <T> $traversableType<T> $name(Iterable<? extends T> elements) {
+              return $traversableType.ofAll(elements);
+          }
+
+          /$javadoc
+           * Alias for {@link $traversableType#ofAll($JavaStreamType)}
+           *
+           * @param <T>      Component type of elements.
+           * @param elements Zero or more elements.
+           * @return A new {@link $traversableType} instance containing the given elements
+           * @throws NullPointerException if {@code elements} is null
+           */
+          public static <T> $traversableType<T> $name($JavaStreamType<? extends T> elements) {
+              return $traversableType.ofAll(elements);
+          }
+        """
+      }
 
       def genAliases(im: ImportManager, packageName: String, className: String): String = {
         xs"""
@@ -367,6 +438,23 @@ def generateMainClasses(): Unit = {
               return $CharSeqType.of(sequence);
           }
 
+          ${genTraversableAliases(ArrayType, "Array")}
+
+          ${genTraversableAliases(VectorType, "Vector")}
+
+          ${genTraversableAliases(ListType, "List")}
+
+          ${genTraversableAliases(StreamType, "Stream")}
+
+          ${genTraversableAliases(QueueType, "Queue")}
+
+          ${genTraversableAliases(LinkedHashSetType, "LinkedSet")}
+
+          ${genTraversableAliases(HashSetType, "Set")}
+
+          ${genTraversableAliases(ListType, "Seq")}
+
+          ${genTraversableAliases(VectorType, "IndexedSeq")}
         """
       }
 
@@ -1748,6 +1836,7 @@ def generateTestClasses(): Unit = {
       val ExecutorServiceType = im.getType("java.util.concurrent.Executors")
       val ExecutorService = s"${ExecutorServiceType}.newSingleThreadExecutor()"
       val TryType = im.getType("javaslang.control.Try")
+      val JavaStreamType = im.getType("java.util.stream.Stream")
 
       val d = "$";
 
@@ -1786,6 +1875,21 @@ def generateTestClasses(): Unit = {
       def genMediumAliasTest(name: String, func: String, value: String): String = genExtAliasTest(s"${name}ReturnNotNull", func, value, "isNotNull()")
 
       def genSimpleAliasTest(name: String, value: String): String = genMediumAliasTest(name, name, value)
+
+      def genTraversableTests(func: String): String = {
+        xs"""
+          ${genMediumAliasTest(s"Empty${func}", func, "")}
+
+          ${genMediumAliasTest(s"${func}WithSingle", func, "'1'")}
+
+          ${genMediumAliasTest(s"${func}WithVarArg", func, "'1', '2', '3'")}
+
+          ${genMediumAliasTest(s"${func}WithIterable", func, "CharSeq('1', '2', '3')")}
+
+          ${genMediumAliasTest(s"${func}WithStream", func, s"$JavaStreamType.of('1', '2', '3')")}
+
+        """
+      }
 
       def genTryTests(func: String, value: String, success: Boolean): String = {
         val check = if (success) "isSuccess" else "isFailure"
@@ -1868,6 +1972,15 @@ def generateTestClasses(): Unit = {
 
           ${genMediumAliasTest("CharSeq", "(Iterable<Character>) CharSeq", "\"123\"")}
 
+          ${genTraversableTests("Array")}
+          ${genTraversableTests("Vector")}
+          ${genTraversableTests("List")}
+          ${genTraversableTests("Stream")}
+          ${genTraversableTests("Queue")}
+          ${genTraversableTests("LinkedSet")}
+          ${genTraversableTests("Set")}
+          ${genTraversableTests("Seq")}
+          ${genTraversableTests("IndexedSeq")}
         """
       }
 

--- a/javaslang/generator/Generator.scala
+++ b/javaslang/generator/Generator.scala
@@ -66,6 +66,9 @@ def generateMainClasses(): Unit = {
       val LinkedHashSetType = im.getType("javaslang.collection.LinkedHashSet")
       val HashSetType = im.getType("javaslang.collection.HashSet")
       val JavaStreamType = im.getType("java.util.stream.Stream")
+      val TreeSetType = im.getType("javaslang.collection.TreeSet")
+      val PriorityQueueType = im.getType("javaslang.collection.PriorityQueue")
+      val JavaComparatorType = im.getType("java.util.Comparator")
 
       def genTraversableAliases(traversableType: String, name: String): String = {
         xs"""
@@ -126,6 +129,126 @@ def generateMainClasses(): Unit = {
            */
           public static <T> $traversableType<T> $name($JavaStreamType<? extends T> elements) {
               return $traversableType.ofAll(elements);
+          }
+        """
+      }
+
+      def genSortedTraversableAliases(traversableType: String, name: String, comparableExt: String): String = {
+        xs"""
+          /$javadoc
+           * Alias for {@link $traversableType#empty()}
+           *
+           * @param <T> Component type of element.
+           * @return A new {@link $traversableType} empty instance
+           */
+          public static <T $comparableExt> $traversableType<T> $name() {
+              return $traversableType.empty();
+          }
+
+          /$javadoc
+           * Alias for {@link $traversableType#empty($JavaComparatorType)}
+           *
+           * @param <T> Component type of element.
+           * @return A new {@link $traversableType} empty instance
+           */
+          public static <T $comparableExt> $traversableType<T> $name($JavaComparatorType<? super T> comparator) {
+              return $traversableType.empty(comparator);
+          }
+
+          /$javadoc
+           * Alias for {@link $traversableType#of(Comparable)}
+           *
+           * @param <T>     Component type of element.
+           * @param element An element.
+           * @return A new {@link $traversableType} instance containing the given element
+           */
+          public static <T $comparableExt> $traversableType<T> $name(T element) {
+              return $traversableType.of(element);
+          }
+
+          /$javadoc
+           * Alias for {@link $traversableType#of($JavaComparatorType, Object)}
+           *
+           * @param <T>     Component type of element.
+           * @param comparator The comparator used to sort the elements
+           * @param element An element.
+           * @return A new {@link $traversableType} instance containing the given element
+           */
+          public static <T> $traversableType<T> $name($JavaComparatorType<? super T> comparator, T element) {
+              return $traversableType.of(comparator, element);
+          }
+
+          /$javadoc
+           * Alias for {@link $traversableType#of(Comparable...)}
+           *
+           * @param <T>      Component type of element.
+           * @param elements Zero or more elements.
+           * @return A new {@link $traversableType} instance containing the given elements
+           */
+          @SuppressWarnings("varargs")
+          @SafeVarargs
+          public static <T $comparableExt> $traversableType<T> $name(T... elements) {
+              return $traversableType.of(elements);
+          }
+
+          /$javadoc
+           * Alias for {@link $traversableType#of($JavaComparatorType, Object...)}
+           *
+           * @param <T>      Component type of element.
+           * @param comparator The comparator used to sort the elements
+           * @param elements Zero or more elements.
+           * @return A new {@link $traversableType} instance containing the given elements
+           */
+          @SuppressWarnings("varargs")
+          @SafeVarargs
+          public static <T> $traversableType<T> $name($JavaComparatorType<? super T> comparator, T... elements) {
+              return $traversableType.of(comparator, elements);
+          }
+
+          /$javadoc
+           * Alias for {@link $traversableType#ofAll(Iterable)}
+           *
+           * @param <T>      Component type of element.
+           * @param elements Zero or more elements.
+           * @return A new {@link $traversableType} instance containing the given elements
+           */
+          public static <T $comparableExt> $traversableType<T> $name(Iterable<? extends T> elements) {
+              return $traversableType.ofAll(elements);
+          }
+
+          /$javadoc
+           * Alias for {@link $traversableType#ofAll($JavaComparatorType, Iterable)}
+           *
+           * @param <T>      Component type of element.
+           * @param comparator The comparator used to sort the elements
+           * @param elements Zero or more elements.
+           * @return A new {@link $traversableType} instance containing the given elements
+           */
+          public static <T> $traversableType<T> $name($JavaComparatorType<? super T> comparator, Iterable<? extends T> elements) {
+              return $traversableType.ofAll(comparator, elements);
+          }
+
+          /$javadoc
+           * Alias for {@link $traversableType#ofAll($JavaStreamType)}
+           *
+           * @param <T>      Component type of element.
+           * @param elements Zero or more elements.
+           * @return A new {@link $traversableType} instance containing the given elements
+           */
+          public static <T $comparableExt> $traversableType<T> $name($JavaStreamType<? extends T> elements) {
+              return $traversableType.ofAll(elements);
+          }
+
+          /$javadoc
+           * Alias for {@link $traversableType#ofAll($JavaComparatorType, $JavaStreamType)}
+           *
+           * @param <T>      Component type of element.
+           * @param comparator The comparator used to sort the elements
+           * @param elements Zero or more elements.
+           * @return A new {@link $traversableType} instance containing the given elements
+           */
+          public static <T> $traversableType<T> $name($JavaComparatorType<? super T> comparator, $JavaStreamType<? extends T> elements) {
+              return $traversableType.ofAll(comparator, elements);
           }
         """
       }
@@ -455,6 +578,10 @@ def generateMainClasses(): Unit = {
           ${genTraversableAliases(ListType, "Seq")}
 
           ${genTraversableAliases(VectorType, "IndexedSeq")}
+
+          ${genSortedTraversableAliases(TreeSetType, "SortedSet", "extends Comparable<? super T>")}
+
+          ${genSortedTraversableAliases(PriorityQueueType, "PriorityQueue", "extends Comparable<T>")}
         """
       }
 
@@ -1837,6 +1964,7 @@ def generateTestClasses(): Unit = {
       val ExecutorService = s"${ExecutorServiceType}.newSingleThreadExecutor()"
       val TryType = im.getType("javaslang.control.Try")
       val JavaStreamType = im.getType("java.util.stream.Stream")
+      val JavaComparatorType = im.getType("java.util.Comparator")
 
       val d = "$";
 
@@ -1887,6 +2015,31 @@ def generateTestClasses(): Unit = {
           ${genMediumAliasTest(s"${func}WithIterable", func, "CharSeq('1', '2', '3')")}
 
           ${genMediumAliasTest(s"${func}WithStream", func, s"$JavaStreamType.of('1', '2', '3')")}
+
+        """
+      }
+
+      def genSortedTraversableTests(func: String): String = {
+        xs"""
+          ${genMediumAliasTest(s"Empty${func}", func, "")}
+
+          ${genMediumAliasTest(s"Empty${func}WithComparator", func, s"($JavaComparatorType<Character>) Character::compareTo")}
+
+          ${genMediumAliasTest(s"${func}WithSingle", func, "'1'")}
+
+          ${genMediumAliasTest(s"${func}WithSingleAndComparator", func, "Character::compareTo, '1'")}
+
+          ${genMediumAliasTest(s"${func}WithVarArg", func, "'1', '2', '3'")}
+
+          ${genMediumAliasTest(s"${func}WithVarArgAndComparator", func, s"($JavaComparatorType<Character>) Character::compareTo, '1', '2', '3'")}
+
+          ${genMediumAliasTest(s"${func}WithIterable", func, "CharSeq('1', '2', '3')")}
+
+          ${genMediumAliasTest(s"${func}WithIterableAndComparator", func, "Character::compareTo, CharSeq('1', '2', '3')")}
+
+          ${genMediumAliasTest(s"${func}WithStream", func, s"$JavaStreamType.of('1', '2', '3')")}
+
+          ${genMediumAliasTest(s"${func}WithStreamAndComparator", func, s"Character::compareTo, $JavaStreamType.of('1', '2', '3')")}
 
         """
       }
@@ -1981,6 +2134,9 @@ def generateTestClasses(): Unit = {
           ${genTraversableTests("Set")}
           ${genTraversableTests("Seq")}
           ${genTraversableTests("IndexedSeq")}
+
+          ${genSortedTraversableTests("SortedSet")}
+          ${genSortedTraversableTests("PriorityQueue")}
         """
       }
 

--- a/javaslang/generator/Generator.scala
+++ b/javaslang/generator/Generator.scala
@@ -51,6 +51,7 @@ def generateMainClasses(): Unit = {
       val PredicateType = im.getType("java.util.function.Predicate")
       val SupplierType = im.getType("java.util.function.Supplier")
       val IteratorType = im.getType("javaslang.collection.Iterator")
+      val EitherType = im.getType("javaslang.control.Either")
 
       def genAliases(im: ImportManager, packageName: String, className: String): String = {
         xs"""
@@ -121,6 +122,30 @@ def generateMainClasses(): Unit = {
               }
             """
           })("\n\n")}
+
+          /$javadoc
+           * Alias for {@link $EitherType#right(Object)}
+           *
+           * @param <L>   Type of left value.
+           * @param <R>   Type of right value.
+           * @param right The value.
+           * @return A new {@link $EitherType.Right} instance.
+           */
+          public static <L, R> $EitherType<L, R> Right(R right) {
+              return $EitherType.right(right);
+          }
+
+          /$javadoc
+           * Alias for {@link $EitherType#left(Object)}
+           *
+           * @param <L>  Type of left value.
+           * @param <R>  Type of right value.
+           * @param left The value.
+           * @return A new {@link $EitherType.Left} instance.
+           */
+          public static <L, R> $EitherType<L, R> Left(L left) {
+              return $EitherType.left(left);
+          }
 
         """
       }
@@ -1528,6 +1553,16 @@ def generateTestClasses(): Unit = {
               @$test
               public void shouldTuple${i}ReturnNotNull() {
                   assertThat(Tuple($params)).isNotNull();
+              }
+
+            """
+          })("\n\n")}
+
+          ${Seq("Right", "Left").gen(name => {
+            xs"""
+              @$test
+              public void should${name}ReturnNotNull() {
+                  assertThat($name(null)).isNotNull();
               }
 
             """

--- a/javaslang/generator/Generator.scala
+++ b/javaslang/generator/Generator.scala
@@ -56,6 +56,7 @@ def generateMainClasses(): Unit = {
       val CheckedSupplierType = im.getType("javaslang.control.Try.CheckedSupplier")
       val ExecutorServiceType = im.getType("java.util.concurrent.ExecutorService")
       val TryType = im.getType("javaslang.control.Try")
+      val ValidationType = im.getType("javaslang.control.Validation")
 
       def genAliases(im: ImportManager, packageName: String, className: String): String = {
         xs"""
@@ -306,6 +307,32 @@ def generateMainClasses(): Unit = {
            */
           public static <T> $TryType<T> Failure(Throwable exception) {
               return $TryType.failure(exception);
+          }
+
+          /$javadoc
+           * Alias for {@link $ValidationType#valid(Object)}
+           *
+           * @param <E>   type of the error
+           * @param <T>   type of the given {@code value}
+           * @param value A value
+           * @return {@link $ValidationType.Valid}
+           * @throws NullPointerException if value is null
+           */
+          public static <E, T> $ValidationType<E, T> Valid(T value) {
+              return $ValidationType.valid(value);
+          }
+
+          /$javadoc
+           * Alias for {@link $ValidationType#invalid(Object)}
+           *
+           * @param <E>   type of the given {@code error}
+           * @param <T>   type of the value
+           * @param error An error
+           * @return {@link $ValidationType.Invalid}
+           * @throws NullPointerException if error is null
+           */
+          public static <E, T> $ValidationType<E, T> Invalid(E error) {
+              return $ValidationType.invalid(error);
           }
 
         """
@@ -1798,6 +1825,10 @@ def generateTestClasses(): Unit = {
           ${genTryTests("Success", "1", success = true)}
 
           ${genTryTests("Failure", "new Error()", success = false)}
+
+          ${genSimpleAliasTest("Valid", "1")}
+
+          ${genSimpleAliasTest("Invalid", "new Error()")}
 
         """
       }

--- a/javaslang/src-gen/main/java/javaslang/API.java
+++ b/javaslang/src-gen/main/java/javaslang/API.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javaslang.collection.Iterator;
+import javaslang.control.Either;
 import javaslang.control.Option;
 
 /**
@@ -524,6 +525,30 @@ public final class API {
      */
     public static <T1, T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> Tuple(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) {
         return Tuple.of(t1, t2, t3, t4, t5, t6, t7, t8);
+    }
+
+    /**
+     * Alias for {@link Either#right(Object)}
+     *
+     * @param <L>   Type of left value.
+     * @param <R>   Type of right value.
+     * @param right The value.
+     * @return A new {@link Either.Right} instance.
+     */
+    public static <L, R> Either<L, R> Right(R right) {
+        return Either.right(right);
+    }
+
+    /**
+     * Alias for {@link Either#left(Object)}
+     *
+     * @param <L>  Type of left value.
+     * @param <R>  Type of right value.
+     * @param left The value.
+     * @return A new {@link Either.Left} instance.
+     */
+    public static <L, R> Either<L, R> Left(L left) {
+        return Either.left(left);
     }
 
     //

--- a/javaslang/src-gen/main/java/javaslang/API.java
+++ b/javaslang/src-gen/main/java/javaslang/API.java
@@ -12,6 +12,7 @@ package javaslang;
 import static javaslang.API.Match.*;
 
 import java.util.Comparator;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
@@ -1532,6 +1533,233 @@ public final class API {
      */
     public static <T> PriorityQueue<T> PriorityQueue(Comparator<? super T> comparator, java.util.stream.Stream<? extends T> elements) {
         return PriorityQueue.ofAll(comparator, elements);
+    }
+
+    /**
+     * Alias for {@link LinkedHashMap#empty()}
+     *
+     * @param <K> The key type.
+     * @param <V> The value type.
+     * @return A singleton instance of empty {@link LinkedHashMap}
+     */
+    public static <K, V> LinkedHashMap<K, V> LinkedMap() {
+        return LinkedHashMap.empty();
+    }
+
+    /**
+     * Alias for {@link LinkedHashMap#of(Object, Object)}
+     *
+     * @param <K>   The key type.
+     * @param <V>   The value type.
+     * @param key   A singleton map key.
+     * @param value A singleton map value.
+     * @return A new {@link LinkedHashMap} instance containing the given entry
+     */
+    public static <K, V> LinkedHashMap<K, V> LinkedMap(K key, V value) {
+        return LinkedHashMap.of(key, value);
+    }
+
+    /**
+     * Alias for {@link LinkedHashMap#ofEntries(Tuple2...)}
+     *
+     * @param <K>     The key type.
+     * @param <V>     The value type.
+     * @param entries Map entries.
+     * @return A new {@link LinkedHashMap} instance containing the given entries
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public static <K, V> LinkedHashMap<K, V> LinkedMap(Tuple2<? extends K, ? extends V>... entries) {
+        return LinkedHashMap.ofEntries(entries);
+    }
+
+    /**
+     * Alias for {@link LinkedHashMap#ofAll(Map)}
+     *
+     * @param <K> The key type.
+     * @param <V> The value type.
+     * @param map A map entry.
+     * @return A new {@link LinkedHashMap} instance containing the given map
+     */
+    public static <K, V> LinkedHashMap<K, V> LinkedMap(Map<? extends K, ? extends V> map) {
+        return LinkedHashMap.ofAll(map);
+    }
+
+    /**
+     * Alias for {@link LinkedHashMap#of(Object...)}
+     *
+     * @param <K>   The key type.
+     * @param <V>   The value type.
+     * @param pairs A list of key-value pairs.
+     * @return A new {@link LinkedHashMap} instance containing the given entries
+     */
+    public static <K, V> LinkedHashMap<K, V> LinkedMap(Object... pairs) {
+        return LinkedHashMap.of(pairs);
+    }
+
+    /**
+     * Alias for {@link HashMap#empty()}
+     *
+     * @param <K> The key type.
+     * @param <V> The value type.
+     * @return A singleton instance of empty {@link HashMap}
+     */
+    public static <K, V> HashMap<K, V> Map() {
+        return HashMap.empty();
+    }
+
+    /**
+     * Alias for {@link HashMap#of(Object, Object)}
+     *
+     * @param <K>   The key type.
+     * @param <V>   The value type.
+     * @param key   A singleton map key.
+     * @param value A singleton map value.
+     * @return A new {@link HashMap} instance containing the given entry
+     */
+    public static <K, V> HashMap<K, V> Map(K key, V value) {
+        return HashMap.of(key, value);
+    }
+
+    /**
+     * Alias for {@link HashMap#ofEntries(Tuple2...)}
+     *
+     * @param <K>     The key type.
+     * @param <V>     The value type.
+     * @param entries Map entries.
+     * @return A new {@link HashMap} instance containing the given entries
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public static <K, V> HashMap<K, V> Map(Tuple2<? extends K, ? extends V>... entries) {
+        return HashMap.ofEntries(entries);
+    }
+
+    /**
+     * Alias for {@link HashMap#ofAll(Map)}
+     *
+     * @param <K> The key type.
+     * @param <V> The value type.
+     * @param map A map entry.
+     * @return A new {@link HashMap} instance containing the given map
+     */
+    public static <K, V> HashMap<K, V> Map(Map<? extends K, ? extends V> map) {
+        return HashMap.ofAll(map);
+    }
+
+    /**
+     * Alias for {@link HashMap#of(Object...)}
+     *
+     * @param <K>   The key type.
+     * @param <V>   The value type.
+     * @param pairs A list of key-value pairs.
+     * @return A new {@link HashMap} instance containing the given entries
+     */
+    public static <K, V> HashMap<K, V> Map(Object... pairs) {
+        return HashMap.of(pairs);
+    }
+
+    /**
+     * Alias for {@link TreeMap#empty()}
+     *
+     * @param <K> The key type.
+     * @param <V> The value type.
+     * @return A new empty {@link TreeMap} instance
+     */
+    public static <K extends Comparable<? super K>, V> TreeMap<K, V> SortedMap() {
+        return TreeMap.empty();
+    }
+
+    /**
+     * Alias for {@link TreeMap#empty(Comparator)}
+     *
+     * @param <K>           The key type.
+     * @param <V>           The value type.
+     * @param keyComparator The comparator used to sort the entries by their key
+     * @return A new empty {@link TreeMap} instance
+     */
+    public static <K, V> TreeMap<K, V> SortedMap(Comparator<? super K> keyComparator) {
+        return TreeMap.empty(keyComparator);
+    }
+
+    /**
+     * Alias for {@link TreeMap#of(Comparable, Object)}
+     *
+     * @param <K>   The key type.
+     * @param <V>   The value type.
+     * @param key   A singleton map key.
+     * @param value A singleton map value.
+     * @return A new {@link TreeMap} instance containing the given entry
+     */
+    public static <K extends Comparable<? super K>, V> TreeMap<K, V> SortedMap(K key, V value) {
+        return TreeMap.of(key, value);
+    }
+
+    /**
+     * Alias for {@link TreeMap#of(Comparator, Object, Object)}
+     *
+     * @param <K>           The key type.
+     * @param <V>           The value type.
+     * @param keyComparator The comparator used to sort the entries by their key
+     * @param key           A singleton map key.
+     * @param value         A singleton map value.
+     * @return A new {@link TreeMap} instance containing the given entry
+     */
+    public static <K, V> TreeMap<K, V> SortedMap(Comparator<? super K> keyComparator, K key, V value) {
+        return TreeMap.of(keyComparator, key, value);
+    }
+
+    /**
+     * Alias for {@link TreeMap#ofEntries(Tuple2...)}
+     *
+     * @param <K>     The key type.
+     * @param <V>     The value type.
+     * @param entries Map entries.
+     * @return A new {@link TreeMap} instance containing the given entries
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public static <K extends Comparable<? super K>, V> TreeMap<K, V> SortedMap(Tuple2<? extends K, ? extends V>... entries) {
+        return TreeMap.ofEntries(entries);
+    }
+
+    /**
+     * Alias for {@link TreeMap#ofEntries(Comparator, Tuple2...)}
+     *
+     * @param <K>           The key type.
+     * @param <V>           The value type.
+     * @param keyComparator The comparator used to sort the entries by their key
+     * @param entries       Map entries.
+     * @return A new {@link TreeMap} instance containing the given entry
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public static <K, V> TreeMap<K, V> SortedMap(Comparator<? super K> keyComparator, Tuple2<? extends K, ? extends V>... entries) {
+        return TreeMap.ofEntries(keyComparator, entries);
+    }
+
+    /**
+     * Alias for {@link TreeMap#ofAll(Map)}
+     *
+     * @param <K> The key type.
+     * @param <V> The value type.
+     * @param map A map entry.
+     * @return A new {@link TreeMap} instance containing the given map
+     */
+    public static <K extends Comparable<? super K>, V> TreeMap<K, V> SortedMap(Map<? extends K, ? extends V> map) {
+        return TreeMap.ofAll(map);
+    }
+
+    /**
+     * Alias for {@link TreeMap#of(Object...)}
+     *
+     * @param <K>   The key type.
+     * @param <V>   The value type.
+     * @param pairs A list of key-value pairs.
+     * @return A new {@link TreeMap} instance containing the given entries
+     */
+    public static <K extends Comparable<? super K>, V> TreeMap<K, V> SortedMap(Object... pairs) {
+        return TreeMap.of(pairs);
     }
 
     //

--- a/javaslang/src-gen/main/java/javaslang/API.java
+++ b/javaslang/src-gen/main/java/javaslang/API.java
@@ -17,8 +17,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import javaslang.collection.CharSeq;
-import javaslang.collection.Iterator;
+import javaslang.collection.*;
 import javaslang.concurrent.Future;
 import javaslang.control.Either;
 import javaslang.control.Option;
@@ -769,6 +768,537 @@ public final class API {
      */
     public static CharSeq CharSeq(CharSequence sequence) {
         return CharSeq.of(sequence);
+    }
+
+    /**
+     * Alias for {@link Array#empty()}
+     *
+     * @param <T> Component type of element.
+     * @return A singleton instance of empty {@link Array}
+     */
+    public static <T> Array<T> Array() {
+        return Array.empty();
+    }
+
+    /**
+     * Alias for {@link Array#of(Object)}
+     *
+     * @param <T>     Component type of element.
+     * @param element An element.
+     * @return A new {@link Array} instance containing the given element
+     */
+    public static <T> Array<T> Array(T element) {
+        return Array.of(element);
+    }
+
+    /**
+     * Alias for {@link Array#of(Object...)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link Array} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public static <T> Array<T> Array(T... elements) {
+        return Array.of(elements);
+    }
+
+    /**
+     * Alias for {@link Array#ofAll(Iterable)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link Array} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static <T> Array<T> Array(Iterable<? extends T> elements) {
+        return Array.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link Array#ofAll(java.util.stream.Stream)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link Array} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static <T> Array<T> Array(java.util.stream.Stream<? extends T> elements) {
+        return Array.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link Vector#empty()}
+     *
+     * @param <T> Component type of element.
+     * @return A singleton instance of empty {@link Vector}
+     */
+    public static <T> Vector<T> Vector() {
+        return Vector.empty();
+    }
+
+    /**
+     * Alias for {@link Vector#of(Object)}
+     *
+     * @param <T>     Component type of element.
+     * @param element An element.
+     * @return A new {@link Vector} instance containing the given element
+     */
+    public static <T> Vector<T> Vector(T element) {
+        return Vector.of(element);
+    }
+
+    /**
+     * Alias for {@link Vector#of(Object...)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link Vector} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public static <T> Vector<T> Vector(T... elements) {
+        return Vector.of(elements);
+    }
+
+    /**
+     * Alias for {@link Vector#ofAll(Iterable)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link Vector} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static <T> Vector<T> Vector(Iterable<? extends T> elements) {
+        return Vector.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link Vector#ofAll(java.util.stream.Stream)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link Vector} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static <T> Vector<T> Vector(java.util.stream.Stream<? extends T> elements) {
+        return Vector.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link List#empty()}
+     *
+     * @param <T> Component type of element.
+     * @return A singleton instance of empty {@link List}
+     */
+    public static <T> List<T> List() {
+        return List.empty();
+    }
+
+    /**
+     * Alias for {@link List#of(Object)}
+     *
+     * @param <T>     Component type of element.
+     * @param element An element.
+     * @return A new {@link List} instance containing the given element
+     */
+    public static <T> List<T> List(T element) {
+        return List.of(element);
+    }
+
+    /**
+     * Alias for {@link List#of(Object...)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link List} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public static <T> List<T> List(T... elements) {
+        return List.of(elements);
+    }
+
+    /**
+     * Alias for {@link List#ofAll(Iterable)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link List} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static <T> List<T> List(Iterable<? extends T> elements) {
+        return List.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link List#ofAll(java.util.stream.Stream)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link List} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static <T> List<T> List(java.util.stream.Stream<? extends T> elements) {
+        return List.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link Stream#empty()}
+     *
+     * @param <T> Component type of element.
+     * @return A singleton instance of empty {@link Stream}
+     */
+    public static <T> Stream<T> Stream() {
+        return Stream.empty();
+    }
+
+    /**
+     * Alias for {@link Stream#of(Object)}
+     *
+     * @param <T>     Component type of element.
+     * @param element An element.
+     * @return A new {@link Stream} instance containing the given element
+     */
+    public static <T> Stream<T> Stream(T element) {
+        return Stream.of(element);
+    }
+
+    /**
+     * Alias for {@link Stream#of(Object...)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link Stream} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public static <T> Stream<T> Stream(T... elements) {
+        return Stream.of(elements);
+    }
+
+    /**
+     * Alias for {@link Stream#ofAll(Iterable)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link Stream} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static <T> Stream<T> Stream(Iterable<? extends T> elements) {
+        return Stream.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link Stream#ofAll(java.util.stream.Stream)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link Stream} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static <T> Stream<T> Stream(java.util.stream.Stream<? extends T> elements) {
+        return Stream.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link Queue#empty()}
+     *
+     * @param <T> Component type of element.
+     * @return A singleton instance of empty {@link Queue}
+     */
+    public static <T> Queue<T> Queue() {
+        return Queue.empty();
+    }
+
+    /**
+     * Alias for {@link Queue#of(Object)}
+     *
+     * @param <T>     Component type of element.
+     * @param element An element.
+     * @return A new {@link Queue} instance containing the given element
+     */
+    public static <T> Queue<T> Queue(T element) {
+        return Queue.of(element);
+    }
+
+    /**
+     * Alias for {@link Queue#of(Object...)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link Queue} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public static <T> Queue<T> Queue(T... elements) {
+        return Queue.of(elements);
+    }
+
+    /**
+     * Alias for {@link Queue#ofAll(Iterable)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link Queue} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static <T> Queue<T> Queue(Iterable<? extends T> elements) {
+        return Queue.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link Queue#ofAll(java.util.stream.Stream)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link Queue} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static <T> Queue<T> Queue(java.util.stream.Stream<? extends T> elements) {
+        return Queue.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link LinkedHashSet#empty()}
+     *
+     * @param <T> Component type of element.
+     * @return A singleton instance of empty {@link LinkedHashSet}
+     */
+    public static <T> LinkedHashSet<T> LinkedSet() {
+        return LinkedHashSet.empty();
+    }
+
+    /**
+     * Alias for {@link LinkedHashSet#of(Object)}
+     *
+     * @param <T>     Component type of element.
+     * @param element An element.
+     * @return A new {@link LinkedHashSet} instance containing the given element
+     */
+    public static <T> LinkedHashSet<T> LinkedSet(T element) {
+        return LinkedHashSet.of(element);
+    }
+
+    /**
+     * Alias for {@link LinkedHashSet#of(Object...)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link LinkedHashSet} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public static <T> LinkedHashSet<T> LinkedSet(T... elements) {
+        return LinkedHashSet.of(elements);
+    }
+
+    /**
+     * Alias for {@link LinkedHashSet#ofAll(Iterable)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link LinkedHashSet} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static <T> LinkedHashSet<T> LinkedSet(Iterable<? extends T> elements) {
+        return LinkedHashSet.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link LinkedHashSet#ofAll(java.util.stream.Stream)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link LinkedHashSet} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static <T> LinkedHashSet<T> LinkedSet(java.util.stream.Stream<? extends T> elements) {
+        return LinkedHashSet.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link HashSet#empty()}
+     *
+     * @param <T> Component type of element.
+     * @return A singleton instance of empty {@link HashSet}
+     */
+    public static <T> HashSet<T> Set() {
+        return HashSet.empty();
+    }
+
+    /**
+     * Alias for {@link HashSet#of(Object)}
+     *
+     * @param <T>     Component type of element.
+     * @param element An element.
+     * @return A new {@link HashSet} instance containing the given element
+     */
+    public static <T> HashSet<T> Set(T element) {
+        return HashSet.of(element);
+    }
+
+    /**
+     * Alias for {@link HashSet#of(Object...)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link HashSet} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public static <T> HashSet<T> Set(T... elements) {
+        return HashSet.of(elements);
+    }
+
+    /**
+     * Alias for {@link HashSet#ofAll(Iterable)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link HashSet} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static <T> HashSet<T> Set(Iterable<? extends T> elements) {
+        return HashSet.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link HashSet#ofAll(java.util.stream.Stream)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link HashSet} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static <T> HashSet<T> Set(java.util.stream.Stream<? extends T> elements) {
+        return HashSet.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link List#empty()}
+     *
+     * @param <T> Component type of element.
+     * @return A singleton instance of empty {@link List}
+     */
+    public static <T> List<T> Seq() {
+        return List.empty();
+    }
+
+    /**
+     * Alias for {@link List#of(Object)}
+     *
+     * @param <T>     Component type of element.
+     * @param element An element.
+     * @return A new {@link List} instance containing the given element
+     */
+    public static <T> List<T> Seq(T element) {
+        return List.of(element);
+    }
+
+    /**
+     * Alias for {@link List#of(Object...)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link List} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public static <T> List<T> Seq(T... elements) {
+        return List.of(elements);
+    }
+
+    /**
+     * Alias for {@link List#ofAll(Iterable)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link List} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static <T> List<T> Seq(Iterable<? extends T> elements) {
+        return List.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link List#ofAll(java.util.stream.Stream)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link List} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static <T> List<T> Seq(java.util.stream.Stream<? extends T> elements) {
+        return List.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link Vector#empty()}
+     *
+     * @param <T> Component type of element.
+     * @return A singleton instance of empty {@link Vector}
+     */
+    public static <T> Vector<T> IndexedSeq() {
+        return Vector.empty();
+    }
+
+    /**
+     * Alias for {@link Vector#of(Object)}
+     *
+     * @param <T>     Component type of element.
+     * @param element An element.
+     * @return A new {@link Vector} instance containing the given element
+     */
+    public static <T> Vector<T> IndexedSeq(T element) {
+        return Vector.of(element);
+    }
+
+    /**
+     * Alias for {@link Vector#of(Object...)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link Vector} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public static <T> Vector<T> IndexedSeq(T... elements) {
+        return Vector.of(elements);
+    }
+
+    /**
+     * Alias for {@link Vector#ofAll(Iterable)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link Vector} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static <T> Vector<T> IndexedSeq(Iterable<? extends T> elements) {
+        return Vector.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link Vector#ofAll(java.util.stream.Stream)}
+     *
+     * @param <T>      Component type of elements.
+     * @param elements Zero or more elements.
+     * @return A new {@link Vector} instance containing the given elements
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static <T> Vector<T> IndexedSeq(java.util.stream.Stream<? extends T> elements) {
+        return Vector.ofAll(elements);
     }
 
     //

--- a/javaslang/src-gen/main/java/javaslang/API.java
+++ b/javaslang/src-gen/main/java/javaslang/API.java
@@ -645,6 +645,38 @@ public final class API {
         return Lazy.of(supplier);
     }
 
+    /**
+     * Alias for {@link Option#of(Object)}
+     *
+     * @param <T>   type of the value
+     * @param value A value
+     * @return {@link Option.Some} if value is not {@code null}, {@link Option.None} otherwise
+     */
+    public static <T> Option<T> Option(T value) {
+        return Option.of(value);
+    }
+
+    /**
+     * Alias for {@link Option#some(Object)}
+     *
+     * @param <T>   type of the value
+     * @param value A value
+     * @return {@link Option.Some}
+     */
+    public static <T> Option<T> Some(T value) {
+        return Option.some(value);
+    }
+
+    /**
+     * Alias for {@link Option#none()}
+     *
+     * @param <T> component type
+     * @return the singleton instance of {@link Option.None}
+     */
+    public static <T> Option<T> None() {
+        return Option.none();
+    }
+
     //
     // Java type tweaks
     //

--- a/javaslang/src-gen/main/java/javaslang/API.java
+++ b/javaslang/src-gen/main/java/javaslang/API.java
@@ -21,6 +21,7 @@ import javaslang.collection.Iterator;
 import javaslang.concurrent.Future;
 import javaslang.control.Either;
 import javaslang.control.Option;
+import javaslang.control.Try;
 import javaslang.control.Try.CheckedSupplier;
 
 /**
@@ -675,6 +676,40 @@ public final class API {
      */
     public static <T> Option<T> None() {
         return Option.none();
+    }
+
+    /**
+     * Alias for {@link Try#of(CheckedSupplier)}
+     *
+     * @param <T>      Component type
+     * @param supplier A checked supplier
+     * @return {@link Try.Success} if no exception occurs, otherwise {@link Try.Failure} if an
+     * exception occurs calling {@code supplier.get()}.
+     */
+    public static <T> Try<T> Try(CheckedSupplier<? extends T> supplier) {
+        return Try.of(supplier);
+    }
+
+    /**
+     * Alias for {@link Try#success(Object)}
+     *
+     * @param <T>   Type of the given {@code value}.
+     * @param value A value.
+     * @return A new {@link Try.Success}.
+     */
+    public static <T> Try<T> Success(T value) {
+        return Try.success(value);
+    }
+
+    /**
+     * Alias for {@link Try#failure(Throwable)}
+     *
+     * @param <T>       Component type of the {@code Try}.
+     * @param exception An exception.
+     * @return A new {@link Try.Failure}.
+     */
+    public static <T> Try<T> Failure(Throwable exception) {
+        return Try.failure(exception);
     }
 
     //

--- a/javaslang/src-gen/main/java/javaslang/API.java
+++ b/javaslang/src-gen/main/java/javaslang/API.java
@@ -357,6 +357,175 @@ public final class API {
         return CheckedFunction8.of(methodReference);
     }
 
+    /**
+     * Alias for {@link Tuple#empty()}
+     *
+     * @return the empty tuple.
+     */
+    public static Tuple0 Tuple() {
+        return Tuple.empty();
+    }
+
+    /**
+     * Alias for {@link Tuple#of(Object)}
+     *
+     * Creates a tuple of one element.
+     *
+     * @param <T1> type of the 1st element
+     * @param t1   the 1st element
+     * @return a tuple of one element.
+     */
+    public static <T1> Tuple1<T1> Tuple(T1 t1) {
+        return Tuple.of(t1);
+    }
+
+    /**
+     * Alias for {@link Tuple#of(Object, Object)}
+     *
+     * Creates a tuple of two elements.
+     *
+     * @param <T1> type of the 1st element
+     * @param <T2> type of the 2nd element
+     * @param t1   the 1st element
+     * @param t2   the 2nd element
+     * @return a tuple of two elements.
+     */
+    public static <T1, T2> Tuple2<T1, T2> Tuple(T1 t1, T2 t2) {
+        return Tuple.of(t1, t2);
+    }
+
+    /**
+     * Alias for {@link Tuple#of(Object, Object, Object)}
+     *
+     * Creates a tuple of three elements.
+     *
+     * @param <T1> type of the 1st element
+     * @param <T2> type of the 2nd element
+     * @param <T3> type of the 3rd element
+     * @param t1   the 1st element
+     * @param t2   the 2nd element
+     * @param t3   the 3rd element
+     * @return a tuple of three elements.
+     */
+    public static <T1, T2, T3> Tuple3<T1, T2, T3> Tuple(T1 t1, T2 t2, T3 t3) {
+        return Tuple.of(t1, t2, t3);
+    }
+
+    /**
+     * Alias for {@link Tuple#of(Object, Object, Object, Object)}
+     *
+     * Creates a tuple of 4 elements.
+     *
+     * @param <T1> type of the 1st element
+     * @param <T2> type of the 2nd element
+     * @param <T3> type of the 3rd element
+     * @param <T4> type of the 4th element
+     * @param t1   the 1st element
+     * @param t2   the 2nd element
+     * @param t3   the 3rd element
+     * @param t4   the 4th element
+     * @return a tuple of 4 elements.
+     */
+    public static <T1, T2, T3, T4> Tuple4<T1, T2, T3, T4> Tuple(T1 t1, T2 t2, T3 t3, T4 t4) {
+        return Tuple.of(t1, t2, t3, t4);
+    }
+
+    /**
+     * Alias for {@link Tuple#of(Object, Object, Object, Object, Object)}
+     *
+     * Creates a tuple of 5 elements.
+     *
+     * @param <T1> type of the 1st element
+     * @param <T2> type of the 2nd element
+     * @param <T3> type of the 3rd element
+     * @param <T4> type of the 4th element
+     * @param <T5> type of the 5th element
+     * @param t1   the 1st element
+     * @param t2   the 2nd element
+     * @param t3   the 3rd element
+     * @param t4   the 4th element
+     * @param t5   the 5th element
+     * @return a tuple of 5 elements.
+     */
+    public static <T1, T2, T3, T4, T5> Tuple5<T1, T2, T3, T4, T5> Tuple(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) {
+        return Tuple.of(t1, t2, t3, t4, t5);
+    }
+
+    /**
+     * Alias for {@link Tuple#of(Object, Object, Object, Object, Object, Object)}
+     *
+     * Creates a tuple of 6 elements.
+     *
+     * @param <T1> type of the 1st element
+     * @param <T2> type of the 2nd element
+     * @param <T3> type of the 3rd element
+     * @param <T4> type of the 4th element
+     * @param <T5> type of the 5th element
+     * @param <T6> type of the 6th element
+     * @param t1   the 1st element
+     * @param t2   the 2nd element
+     * @param t3   the 3rd element
+     * @param t4   the 4th element
+     * @param t5   the 5th element
+     * @param t6   the 6th element
+     * @return a tuple of 6 elements.
+     */
+    public static <T1, T2, T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> Tuple(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) {
+        return Tuple.of(t1, t2, t3, t4, t5, t6);
+    }
+
+    /**
+     * Alias for {@link Tuple#of(Object, Object, Object, Object, Object, Object, Object)}
+     *
+     * Creates a tuple of 7 elements.
+     *
+     * @param <T1> type of the 1st element
+     * @param <T2> type of the 2nd element
+     * @param <T3> type of the 3rd element
+     * @param <T4> type of the 4th element
+     * @param <T5> type of the 5th element
+     * @param <T6> type of the 6th element
+     * @param <T7> type of the 7th element
+     * @param t1   the 1st element
+     * @param t2   the 2nd element
+     * @param t3   the 3rd element
+     * @param t4   the 4th element
+     * @param t5   the 5th element
+     * @param t6   the 6th element
+     * @param t7   the 7th element
+     * @return a tuple of 7 elements.
+     */
+    public static <T1, T2, T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> Tuple(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) {
+        return Tuple.of(t1, t2, t3, t4, t5, t6, t7);
+    }
+
+    /**
+     * Alias for {@link Tuple#of(Object, Object, Object, Object, Object, Object, Object, Object)}
+     *
+     * Creates a tuple of 8 elements.
+     *
+     * @param <T1> type of the 1st element
+     * @param <T2> type of the 2nd element
+     * @param <T3> type of the 3rd element
+     * @param <T4> type of the 4th element
+     * @param <T5> type of the 5th element
+     * @param <T6> type of the 6th element
+     * @param <T7> type of the 7th element
+     * @param <T8> type of the 8th element
+     * @param t1   the 1st element
+     * @param t2   the 2nd element
+     * @param t3   the 3rd element
+     * @param t4   the 4th element
+     * @param t5   the 5th element
+     * @param t6   the 6th element
+     * @param t7   the 7th element
+     * @param t8   the 8th element
+     * @return a tuple of 8 elements.
+     */
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> Tuple(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) {
+        return Tuple.of(t1, t2, t3, t4, t5, t6, t7, t8);
+    }
+
     //
     // Java type tweaks
     //

--- a/javaslang/src-gen/main/java/javaslang/API.java
+++ b/javaslang/src-gen/main/java/javaslang/API.java
@@ -11,6 +11,7 @@ package javaslang;
 
 import static javaslang.API.Match.*;
 
+import java.util.Comparator;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
@@ -1299,6 +1300,238 @@ public final class API {
      */
     public static <T> Vector<T> IndexedSeq(java.util.stream.Stream<? extends T> elements) {
         return Vector.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link TreeSet#empty()}
+     *
+     * @param <T> Component type of element.
+     * @return A new {@link TreeSet} empty instance
+     */
+    public static <T extends Comparable<? super T>> TreeSet<T> SortedSet() {
+        return TreeSet.empty();
+    }
+
+    /**
+     * Alias for {@link TreeSet#empty(Comparator)}
+     *
+     * @param <T> Component type of element.
+     * @return A new {@link TreeSet} empty instance
+     */
+    public static <T extends Comparable<? super T>> TreeSet<T> SortedSet(Comparator<? super T> comparator) {
+        return TreeSet.empty(comparator);
+    }
+
+    /**
+     * Alias for {@link TreeSet#of(Comparable)}
+     *
+     * @param <T>     Component type of element.
+     * @param element An element.
+     * @return A new {@link TreeSet} instance containing the given element
+     */
+    public static <T extends Comparable<? super T>> TreeSet<T> SortedSet(T element) {
+        return TreeSet.of(element);
+    }
+
+    /**
+     * Alias for {@link TreeSet#of(Comparator, Object)}
+     *
+     * @param <T>     Component type of element.
+     * @param comparator The comparator used to sort the elements
+     * @param element An element.
+     * @return A new {@link TreeSet} instance containing the given element
+     */
+    public static <T> TreeSet<T> SortedSet(Comparator<? super T> comparator, T element) {
+        return TreeSet.of(comparator, element);
+    }
+
+    /**
+     * Alias for {@link TreeSet#of(Comparable...)}
+     *
+     * @param <T>      Component type of element.
+     * @param elements Zero or more elements.
+     * @return A new {@link TreeSet} instance containing the given elements
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public static <T extends Comparable<? super T>> TreeSet<T> SortedSet(T... elements) {
+        return TreeSet.of(elements);
+    }
+
+    /**
+     * Alias for {@link TreeSet#of(Comparator, Object...)}
+     *
+     * @param <T>      Component type of element.
+     * @param comparator The comparator used to sort the elements
+     * @param elements Zero or more elements.
+     * @return A new {@link TreeSet} instance containing the given elements
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public static <T> TreeSet<T> SortedSet(Comparator<? super T> comparator, T... elements) {
+        return TreeSet.of(comparator, elements);
+    }
+
+    /**
+     * Alias for {@link TreeSet#ofAll(Iterable)}
+     *
+     * @param <T>      Component type of element.
+     * @param elements Zero or more elements.
+     * @return A new {@link TreeSet} instance containing the given elements
+     */
+    public static <T extends Comparable<? super T>> TreeSet<T> SortedSet(Iterable<? extends T> elements) {
+        return TreeSet.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link TreeSet#ofAll(Comparator, Iterable)}
+     *
+     * @param <T>      Component type of element.
+     * @param comparator The comparator used to sort the elements
+     * @param elements Zero or more elements.
+     * @return A new {@link TreeSet} instance containing the given elements
+     */
+    public static <T> TreeSet<T> SortedSet(Comparator<? super T> comparator, Iterable<? extends T> elements) {
+        return TreeSet.ofAll(comparator, elements);
+    }
+
+    /**
+     * Alias for {@link TreeSet#ofAll(java.util.stream.Stream)}
+     *
+     * @param <T>      Component type of element.
+     * @param elements Zero or more elements.
+     * @return A new {@link TreeSet} instance containing the given elements
+     */
+    public static <T extends Comparable<? super T>> TreeSet<T> SortedSet(java.util.stream.Stream<? extends T> elements) {
+        return TreeSet.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link TreeSet#ofAll(Comparator, java.util.stream.Stream)}
+     *
+     * @param <T>      Component type of element.
+     * @param comparator The comparator used to sort the elements
+     * @param elements Zero or more elements.
+     * @return A new {@link TreeSet} instance containing the given elements
+     */
+    public static <T> TreeSet<T> SortedSet(Comparator<? super T> comparator, java.util.stream.Stream<? extends T> elements) {
+        return TreeSet.ofAll(comparator, elements);
+    }
+
+    /**
+     * Alias for {@link PriorityQueue#empty()}
+     *
+     * @param <T> Component type of element.
+     * @return A new {@link PriorityQueue} empty instance
+     */
+    public static <T extends Comparable<T>> PriorityQueue<T> PriorityQueue() {
+        return PriorityQueue.empty();
+    }
+
+    /**
+     * Alias for {@link PriorityQueue#empty(Comparator)}
+     *
+     * @param <T> Component type of element.
+     * @return A new {@link PriorityQueue} empty instance
+     */
+    public static <T extends Comparable<T>> PriorityQueue<T> PriorityQueue(Comparator<? super T> comparator) {
+        return PriorityQueue.empty(comparator);
+    }
+
+    /**
+     * Alias for {@link PriorityQueue#of(Comparable)}
+     *
+     * @param <T>     Component type of element.
+     * @param element An element.
+     * @return A new {@link PriorityQueue} instance containing the given element
+     */
+    public static <T extends Comparable<T>> PriorityQueue<T> PriorityQueue(T element) {
+        return PriorityQueue.of(element);
+    }
+
+    /**
+     * Alias for {@link PriorityQueue#of(Comparator, Object)}
+     *
+     * @param <T>     Component type of element.
+     * @param comparator The comparator used to sort the elements
+     * @param element An element.
+     * @return A new {@link PriorityQueue} instance containing the given element
+     */
+    public static <T> PriorityQueue<T> PriorityQueue(Comparator<? super T> comparator, T element) {
+        return PriorityQueue.of(comparator, element);
+    }
+
+    /**
+     * Alias for {@link PriorityQueue#of(Comparable...)}
+     *
+     * @param <T>      Component type of element.
+     * @param elements Zero or more elements.
+     * @return A new {@link PriorityQueue} instance containing the given elements
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public static <T extends Comparable<T>> PriorityQueue<T> PriorityQueue(T... elements) {
+        return PriorityQueue.of(elements);
+    }
+
+    /**
+     * Alias for {@link PriorityQueue#of(Comparator, Object...)}
+     *
+     * @param <T>      Component type of element.
+     * @param comparator The comparator used to sort the elements
+     * @param elements Zero or more elements.
+     * @return A new {@link PriorityQueue} instance containing the given elements
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public static <T> PriorityQueue<T> PriorityQueue(Comparator<? super T> comparator, T... elements) {
+        return PriorityQueue.of(comparator, elements);
+    }
+
+    /**
+     * Alias for {@link PriorityQueue#ofAll(Iterable)}
+     *
+     * @param <T>      Component type of element.
+     * @param elements Zero or more elements.
+     * @return A new {@link PriorityQueue} instance containing the given elements
+     */
+    public static <T extends Comparable<T>> PriorityQueue<T> PriorityQueue(Iterable<? extends T> elements) {
+        return PriorityQueue.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link PriorityQueue#ofAll(Comparator, Iterable)}
+     *
+     * @param <T>      Component type of element.
+     * @param comparator The comparator used to sort the elements
+     * @param elements Zero or more elements.
+     * @return A new {@link PriorityQueue} instance containing the given elements
+     */
+    public static <T> PriorityQueue<T> PriorityQueue(Comparator<? super T> comparator, Iterable<? extends T> elements) {
+        return PriorityQueue.ofAll(comparator, elements);
+    }
+
+    /**
+     * Alias for {@link PriorityQueue#ofAll(java.util.stream.Stream)}
+     *
+     * @param <T>      Component type of element.
+     * @param elements Zero or more elements.
+     * @return A new {@link PriorityQueue} instance containing the given elements
+     */
+    public static <T extends Comparable<T>> PriorityQueue<T> PriorityQueue(java.util.stream.Stream<? extends T> elements) {
+        return PriorityQueue.ofAll(elements);
+    }
+
+    /**
+     * Alias for {@link PriorityQueue#ofAll(Comparator, java.util.stream.Stream)}
+     *
+     * @param <T>      Component type of element.
+     * @param comparator The comparator used to sort the elements
+     * @param elements Zero or more elements.
+     * @return A new {@link PriorityQueue} instance containing the given elements
+     */
+    public static <T> PriorityQueue<T> PriorityQueue(Comparator<? super T> comparator, java.util.stream.Stream<? extends T> elements) {
+        return PriorityQueue.ofAll(comparator, elements);
     }
 
     //

--- a/javaslang/src-gen/main/java/javaslang/API.java
+++ b/javaslang/src-gen/main/java/javaslang/API.java
@@ -23,6 +23,7 @@ import javaslang.control.Either;
 import javaslang.control.Option;
 import javaslang.control.Try;
 import javaslang.control.Try.CheckedSupplier;
+import javaslang.control.Validation;
 
 /**
  * The most basic Javaslang functionality is accessed through this API class.
@@ -710,6 +711,32 @@ public final class API {
      */
     public static <T> Try<T> Failure(Throwable exception) {
         return Try.failure(exception);
+    }
+
+    /**
+     * Alias for {@link Validation#valid(Object)}
+     *
+     * @param <E>   type of the error
+     * @param <T>   type of the given {@code value}
+     * @param value A value
+     * @return {@link Validation.Valid}
+     * @throws NullPointerException if value is null
+     */
+    public static <E, T> Validation<E, T> Valid(T value) {
+        return Validation.valid(value);
+    }
+
+    /**
+     * Alias for {@link Validation#invalid(Object)}
+     *
+     * @param <E>   type of the given {@code error}
+     * @param <T>   type of the value
+     * @param error An error
+     * @return {@link Validation.Invalid}
+     * @throws NullPointerException if error is null
+     */
+    public static <E, T> Validation<E, T> Invalid(E error) {
+        return Validation.invalid(error);
     }
 
     //

--- a/javaslang/src-gen/main/java/javaslang/API.java
+++ b/javaslang/src-gen/main/java/javaslang/API.java
@@ -17,6 +17,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import javaslang.collection.CharSeq;
 import javaslang.collection.Iterator;
 import javaslang.concurrent.Future;
 import javaslang.control.Either;
@@ -737,6 +738,37 @@ public final class API {
      */
     public static <E, T> Validation<E, T> Invalid(E error) {
         return Validation.invalid(error);
+    }
+
+    /**
+     * Alias for {@link CharSeq#of(char)}
+     *
+     * @param character A character.
+     * @return A new {@link CharSeq} instance containing the given element
+     */
+    public static CharSeq CharSeq(char character) {
+        return CharSeq.of(character);
+    }
+
+    /**
+     * Alias for {@link CharSeq#of(char...)}
+     *
+     * @param characters Zero or more characters.
+     * @return A new {@link CharSeq} instance containing the given characters in the same order.
+     * @throws NullPointerException if {@code elements} is null
+     */
+    public static CharSeq CharSeq(char... characters) {
+        return CharSeq.of(characters);
+    }
+
+    /**
+     * Alias for {@link CharSeq#of(CharSequence)}
+     *
+     * @param sequence {@code CharSequence} instance.
+     * @return A new {@link CharSeq} instance
+     */
+    public static CharSeq CharSeq(CharSequence sequence) {
+        return CharSeq.of(sequence);
     }
 
     //

--- a/javaslang/src-gen/main/java/javaslang/API.java
+++ b/javaslang/src-gen/main/java/javaslang/API.java
@@ -84,6 +84,280 @@ public final class API {
     }
 
     //
+    // Aliases for static factories
+    //
+
+    /**
+     * Alias for {@link Function0#of(Function0)}
+     *
+     * @param <R>             return type
+     * @param methodReference A method reference
+     * @return A {@link Function0}
+     */
+    public static <R> Function0<R> Function0(Function0<R> methodReference) {
+        return Function0.of(methodReference);
+    }
+
+    /**
+     * Alias for {@link Function1#of(Function1)}
+     *
+     * @param <R>             return type
+     * @param <T1>            type of the 1st argument
+     * @param methodReference A method reference
+     * @return A {@link Function1}
+     */
+    public static <T1, R> Function1<T1, R> Function1(Function1<T1, R> methodReference) {
+        return Function1.of(methodReference);
+    }
+
+    /**
+     * Alias for {@link Function2#of(Function2)}
+     *
+     * @param <R>             return type
+     * @param <T1>            type of the 1st argument
+     * @param <T2>            type of the 2nd argument
+     * @param methodReference A method reference
+     * @return A {@link Function2}
+     */
+    public static <T1, T2, R> Function2<T1, T2, R> Function2(Function2<T1, T2, R> methodReference) {
+        return Function2.of(methodReference);
+    }
+
+    /**
+     * Alias for {@link Function3#of(Function3)}
+     *
+     * @param <R>             return type
+     * @param <T1>            type of the 1st argument
+     * @param <T2>            type of the 2nd argument
+     * @param <T3>            type of the 3rd argument
+     * @param methodReference A method reference
+     * @return A {@link Function3}
+     */
+    public static <T1, T2, T3, R> Function3<T1, T2, T3, R> Function3(Function3<T1, T2, T3, R> methodReference) {
+        return Function3.of(methodReference);
+    }
+
+    /**
+     * Alias for {@link Function4#of(Function4)}
+     *
+     * @param <R>             return type
+     * @param <T1>            type of the 1st argument
+     * @param <T2>            type of the 2nd argument
+     * @param <T3>            type of the 3rd argument
+     * @param <T4>            type of the 4th argument
+     * @param methodReference A method reference
+     * @return A {@link Function4}
+     */
+    public static <T1, T2, T3, T4, R> Function4<T1, T2, T3, T4, R> Function4(Function4<T1, T2, T3, T4, R> methodReference) {
+        return Function4.of(methodReference);
+    }
+
+    /**
+     * Alias for {@link Function5#of(Function5)}
+     *
+     * @param <R>             return type
+     * @param <T1>            type of the 1st argument
+     * @param <T2>            type of the 2nd argument
+     * @param <T3>            type of the 3rd argument
+     * @param <T4>            type of the 4th argument
+     * @param <T5>            type of the 5th argument
+     * @param methodReference A method reference
+     * @return A {@link Function5}
+     */
+    public static <T1, T2, T3, T4, T5, R> Function5<T1, T2, T3, T4, T5, R> Function5(Function5<T1, T2, T3, T4, T5, R> methodReference) {
+        return Function5.of(methodReference);
+    }
+
+    /**
+     * Alias for {@link Function6#of(Function6)}
+     *
+     * @param <R>             return type
+     * @param <T1>            type of the 1st argument
+     * @param <T2>            type of the 2nd argument
+     * @param <T3>            type of the 3rd argument
+     * @param <T4>            type of the 4th argument
+     * @param <T5>            type of the 5th argument
+     * @param <T6>            type of the 6th argument
+     * @param methodReference A method reference
+     * @return A {@link Function6}
+     */
+    public static <T1, T2, T3, T4, T5, T6, R> Function6<T1, T2, T3, T4, T5, T6, R> Function6(Function6<T1, T2, T3, T4, T5, T6, R> methodReference) {
+        return Function6.of(methodReference);
+    }
+
+    /**
+     * Alias for {@link Function7#of(Function7)}
+     *
+     * @param <R>             return type
+     * @param <T1>            type of the 1st argument
+     * @param <T2>            type of the 2nd argument
+     * @param <T3>            type of the 3rd argument
+     * @param <T4>            type of the 4th argument
+     * @param <T5>            type of the 5th argument
+     * @param <T6>            type of the 6th argument
+     * @param <T7>            type of the 7th argument
+     * @param methodReference A method reference
+     * @return A {@link Function7}
+     */
+    public static <T1, T2, T3, T4, T5, T6, T7, R> Function7<T1, T2, T3, T4, T5, T6, T7, R> Function7(Function7<T1, T2, T3, T4, T5, T6, T7, R> methodReference) {
+        return Function7.of(methodReference);
+    }
+
+    /**
+     * Alias for {@link Function8#of(Function8)}
+     *
+     * @param <R>             return type
+     * @param <T1>            type of the 1st argument
+     * @param <T2>            type of the 2nd argument
+     * @param <T3>            type of the 3rd argument
+     * @param <T4>            type of the 4th argument
+     * @param <T5>            type of the 5th argument
+     * @param <T6>            type of the 6th argument
+     * @param <T7>            type of the 7th argument
+     * @param <T8>            type of the 8th argument
+     * @param methodReference A method reference
+     * @return A {@link Function8}
+     */
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> Function8(Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> methodReference) {
+        return Function8.of(methodReference);
+    }
+
+    /**
+     * Alias for {@link CheckedFunction0#of(CheckedFunction0)}
+     *
+     * @param <R>             return type
+     * @param methodReference A method reference
+     * @return A {@link CheckedFunction0}
+     */
+    public static <R> CheckedFunction0<R> CheckedFunction0(CheckedFunction0<R> methodReference) {
+        return CheckedFunction0.of(methodReference);
+    }
+
+    /**
+     * Alias for {@link CheckedFunction1#of(CheckedFunction1)}
+     *
+     * @param <R>             return type
+     * @param <T1>            type of the 1st argument
+     * @param methodReference A method reference
+     * @return A {@link CheckedFunction1}
+     */
+    public static <T1, R> CheckedFunction1<T1, R> CheckedFunction1(CheckedFunction1<T1, R> methodReference) {
+        return CheckedFunction1.of(methodReference);
+    }
+
+    /**
+     * Alias for {@link CheckedFunction2#of(CheckedFunction2)}
+     *
+     * @param <R>             return type
+     * @param <T1>            type of the 1st argument
+     * @param <T2>            type of the 2nd argument
+     * @param methodReference A method reference
+     * @return A {@link CheckedFunction2}
+     */
+    public static <T1, T2, R> CheckedFunction2<T1, T2, R> CheckedFunction2(CheckedFunction2<T1, T2, R> methodReference) {
+        return CheckedFunction2.of(methodReference);
+    }
+
+    /**
+     * Alias for {@link CheckedFunction3#of(CheckedFunction3)}
+     *
+     * @param <R>             return type
+     * @param <T1>            type of the 1st argument
+     * @param <T2>            type of the 2nd argument
+     * @param <T3>            type of the 3rd argument
+     * @param methodReference A method reference
+     * @return A {@link CheckedFunction3}
+     */
+    public static <T1, T2, T3, R> CheckedFunction3<T1, T2, T3, R> CheckedFunction3(CheckedFunction3<T1, T2, T3, R> methodReference) {
+        return CheckedFunction3.of(methodReference);
+    }
+
+    /**
+     * Alias for {@link CheckedFunction4#of(CheckedFunction4)}
+     *
+     * @param <R>             return type
+     * @param <T1>            type of the 1st argument
+     * @param <T2>            type of the 2nd argument
+     * @param <T3>            type of the 3rd argument
+     * @param <T4>            type of the 4th argument
+     * @param methodReference A method reference
+     * @return A {@link CheckedFunction4}
+     */
+    public static <T1, T2, T3, T4, R> CheckedFunction4<T1, T2, T3, T4, R> CheckedFunction4(CheckedFunction4<T1, T2, T3, T4, R> methodReference) {
+        return CheckedFunction4.of(methodReference);
+    }
+
+    /**
+     * Alias for {@link CheckedFunction5#of(CheckedFunction5)}
+     *
+     * @param <R>             return type
+     * @param <T1>            type of the 1st argument
+     * @param <T2>            type of the 2nd argument
+     * @param <T3>            type of the 3rd argument
+     * @param <T4>            type of the 4th argument
+     * @param <T5>            type of the 5th argument
+     * @param methodReference A method reference
+     * @return A {@link CheckedFunction5}
+     */
+    public static <T1, T2, T3, T4, T5, R> CheckedFunction5<T1, T2, T3, T4, T5, R> CheckedFunction5(CheckedFunction5<T1, T2, T3, T4, T5, R> methodReference) {
+        return CheckedFunction5.of(methodReference);
+    }
+
+    /**
+     * Alias for {@link CheckedFunction6#of(CheckedFunction6)}
+     *
+     * @param <R>             return type
+     * @param <T1>            type of the 1st argument
+     * @param <T2>            type of the 2nd argument
+     * @param <T3>            type of the 3rd argument
+     * @param <T4>            type of the 4th argument
+     * @param <T5>            type of the 5th argument
+     * @param <T6>            type of the 6th argument
+     * @param methodReference A method reference
+     * @return A {@link CheckedFunction6}
+     */
+    public static <T1, T2, T3, T4, T5, T6, R> CheckedFunction6<T1, T2, T3, T4, T5, T6, R> CheckedFunction6(CheckedFunction6<T1, T2, T3, T4, T5, T6, R> methodReference) {
+        return CheckedFunction6.of(methodReference);
+    }
+
+    /**
+     * Alias for {@link CheckedFunction7#of(CheckedFunction7)}
+     *
+     * @param <R>             return type
+     * @param <T1>            type of the 1st argument
+     * @param <T2>            type of the 2nd argument
+     * @param <T3>            type of the 3rd argument
+     * @param <T4>            type of the 4th argument
+     * @param <T5>            type of the 5th argument
+     * @param <T6>            type of the 6th argument
+     * @param <T7>            type of the 7th argument
+     * @param methodReference A method reference
+     * @return A {@link CheckedFunction7}
+     */
+    public static <T1, T2, T3, T4, T5, T6, T7, R> CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> CheckedFunction7(CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> methodReference) {
+        return CheckedFunction7.of(methodReference);
+    }
+
+    /**
+     * Alias for {@link CheckedFunction8#of(CheckedFunction8)}
+     *
+     * @param <R>             return type
+     * @param <T1>            type of the 1st argument
+     * @param <T2>            type of the 2nd argument
+     * @param <T3>            type of the 3rd argument
+     * @param <T4>            type of the 4th argument
+     * @param <T5>            type of the 5th argument
+     * @param <T6>            type of the 6th argument
+     * @param <T7>            type of the 7th argument
+     * @param <T8>            type of the 8th argument
+     * @param methodReference A method reference
+     * @return A {@link CheckedFunction8}
+     */
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, R> CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> CheckedFunction8(CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> methodReference) {
+        return CheckedFunction8.of(methodReference);
+    }
+
+    //
     // Java type tweaks
     //
 

--- a/javaslang/src-gen/main/java/javaslang/API.java
+++ b/javaslang/src-gen/main/java/javaslang/API.java
@@ -634,6 +634,17 @@ public final class API {
         return Future.failed(executorService, exception);
     }
 
+    /**
+     * Alias for {@link Lazy#of(Supplier)}
+     *
+     * @param <T>      type of the lazy value
+     * @param supplier A supplier
+     * @return A new instance of {@link Lazy}
+     */
+    public static <T> Lazy<T> Lazy(Supplier<? extends T> supplier) {
+        return Lazy.of(supplier);
+    }
+
     //
     // Java type tweaks
     //

--- a/javaslang/src-gen/main/java/javaslang/API.java
+++ b/javaslang/src-gen/main/java/javaslang/API.java
@@ -12,13 +12,16 @@ package javaslang;
 import static javaslang.API.Match.*;
 
 import java.util.Objects;
+import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javaslang.collection.Iterator;
+import javaslang.concurrent.Future;
 import javaslang.control.Either;
 import javaslang.control.Option;
+import javaslang.control.Try.CheckedSupplier;
 
 /**
  * The most basic Javaslang functionality is accessed through this API class.
@@ -549,6 +552,86 @@ public final class API {
      */
     public static <L, R> Either<L, R> Left(L left) {
         return Either.left(left);
+    }
+
+    /**
+     * Alias for {@link Future#of(CheckedSupplier)}
+     *
+     * @param <T>         Type of the computation result.
+     * @param computation A computation.
+     * @return A new {@link Future} instance.
+     * @throws NullPointerException if computation is null.
+     */
+    @GwtIncompatible
+    public static <T> Future<T> Future(CheckedSupplier<? extends T> computation) {
+        return Future.of(computation);
+    }
+
+    /**
+     * Alias for {@link Future#of(ExecutorService, CheckedSupplier)}
+     *
+     * @param <T>             Type of the computation result.
+     * @param executorService An executor service.
+     * @param computation     A computation.
+     * @return A new {@link Future} instance.
+     * @throws NullPointerException if one of executorService or computation is null.
+     */
+    @GwtIncompatible
+    public static <T> Future<T> Future(ExecutorService executorService, CheckedSupplier<? extends T> computation) {
+        return Future.of(executorService, computation);
+    }
+
+    /**
+     * Alias for {@link Future#successful(Object)}
+     *
+     * @param <T>    The value type of a successful result.
+     * @param result The result.
+     * @return A succeeded {@link Future}.
+     */
+    @GwtIncompatible
+    public static <T> Future<T> Future(T result) {
+        return Future.successful(result);
+    }
+
+    /**
+     * Alias for {@link Future#successful(ExecutorService, Object)}
+     *
+     * @param <T>             The value type of a successful result.
+     * @param executorService An {@code ExecutorService}.
+     * @param result          The result.
+     * @return A succeeded {@link Future}.
+     * @throws NullPointerException if executorService is null
+     */
+    @GwtIncompatible
+    public static <T> Future<T> Future(ExecutorService executorService, T result) {
+        return Future.successful(executorService, result);
+    }
+
+    /**
+     * Alias for {@link Future#failed(Throwable)}
+     *
+     * @param <T>       The value type of a successful result.
+     * @param exception The reason why it failed.
+     * @return A failed {@link Future}.
+     * @throws NullPointerException if exception is null
+     */
+    @GwtIncompatible
+    public static <T> Future<T> Future(Throwable exception) {
+        return Future.failed(exception);
+    }
+
+    /**
+     * Alias for {@link Future#failed(ExecutorService, Throwable)}
+     *
+     * @param <T>             The value type of a successful result.
+     * @param executorService An executor service.
+     * @param exception       The reason why it failed.
+     * @return A failed {@link Future}.
+     * @throws NullPointerException if executorService or exception is null
+     */
+    @GwtIncompatible
+    public static <T> Future<T> Future(ExecutorService executorService, Throwable exception) {
+        return Future.failed(executorService, exception);
     }
 
     //

--- a/javaslang/src-gen/test/java/javaslang/APITest.java
+++ b/javaslang/src-gen/test/java/javaslang/APITest.java
@@ -120,6 +120,51 @@ public class APITest {
         assertThat(CheckedFunction8((v1, v2, v3, v4, v5, v6, v7, v8) -> null)).isNotNull();
     }
 
+    @Test
+    public void shouldTuple0ReturnNotNull() {
+        assertThat(Tuple()).isNotNull();
+    }
+
+    @Test
+    public void shouldTuple1ReturnNotNull() {
+        assertThat(Tuple(1)).isNotNull();
+    }
+
+    @Test
+    public void shouldTuple2ReturnNotNull() {
+        assertThat(Tuple(1, 2)).isNotNull();
+    }
+
+    @Test
+    public void shouldTuple3ReturnNotNull() {
+        assertThat(Tuple(1, 2, 3)).isNotNull();
+    }
+
+    @Test
+    public void shouldTuple4ReturnNotNull() {
+        assertThat(Tuple(1, 2, 3, 4)).isNotNull();
+    }
+
+    @Test
+    public void shouldTuple5ReturnNotNull() {
+        assertThat(Tuple(1, 2, 3, 4, 5)).isNotNull();
+    }
+
+    @Test
+    public void shouldTuple6ReturnNotNull() {
+        assertThat(Tuple(1, 2, 3, 4, 5, 6)).isNotNull();
+    }
+
+    @Test
+    public void shouldTuple7ReturnNotNull() {
+        assertThat(Tuple(1, 2, 3, 4, 5, 6, 7)).isNotNull();
+    }
+
+    @Test
+    public void shouldTuple8ReturnNotNull() {
+        assertThat(Tuple(1, 2, 3, 4, 5, 6, 7, 8)).isNotNull();
+    }
+
     // -- run
 
     @Test

--- a/javaslang/src-gen/test/java/javaslang/APITest.java
+++ b/javaslang/src-gen/test/java/javaslang/APITest.java
@@ -13,6 +13,7 @@ import static javaslang.API.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.concurrent.Executors;
 import java.util.stream.Stream;
@@ -617,6 +618,96 @@ public class APITest {
     @Test
     public void shouldPriorityQueueWithStreamAndComparatorReturnNotNull() {
         assertThat(PriorityQueue(Character::compareTo, Stream.of('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldEmptyLinkedMapReturnNotNull() {
+        assertThat(LinkedMap()).isNotNull();
+    }
+
+    @Test
+    public void shouldLinkedMapFromSingleReturnNotNull() {
+        assertThat(LinkedMap(1, '1')).isNotNull();
+    }
+
+    @Test
+    public void shouldLinkedMapFromTuplesReturnNotNull() {
+        assertThat(LinkedMap(Tuple(1, '1'), Tuple(2, '2'), Tuple(3, '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldLinkedMapFromMapReturnNotNull() {
+        assertThat(LinkedMap(Collections.singletonMap(1, '1'))).isNotNull();
+    }
+
+    @Test
+    public void shouldLinkedMapFromPairsReturnNotNull() {
+        assertThat(LinkedMap(1, '1', 2, '2', 3, '3')).isNotNull();
+    }
+
+    @Test
+    public void shouldEmptyMapReturnNotNull() {
+        assertThat(Map()).isNotNull();
+    }
+
+    @Test
+    public void shouldMapFromSingleReturnNotNull() {
+        assertThat(Map(1, '1')).isNotNull();
+    }
+
+    @Test
+    public void shouldMapFromTuplesReturnNotNull() {
+        assertThat(Map(Tuple(1, '1'), Tuple(2, '2'), Tuple(3, '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldMapFromMapReturnNotNull() {
+        assertThat(Map(Collections.singletonMap(1, '1'))).isNotNull();
+    }
+
+    @Test
+    public void shouldMapFromPairsReturnNotNull() {
+        assertThat(Map(1, '1', 2, '2', 3, '3')).isNotNull();
+    }
+
+    @Test
+    public void shouldEmptySortedMapReturnNotNull() {
+        assertThat(SortedMap()).isNotNull();
+    }
+
+    @Test
+    public void shouldSortedMapFromSingleReturnNotNull() {
+        assertThat(SortedMap(1, '1')).isNotNull();
+    }
+
+    @Test
+    public void shouldSortedMapFromTuplesReturnNotNull() {
+        assertThat(SortedMap(Tuple(1, '1'), Tuple(2, '2'), Tuple(3, '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldSortedMapFromMapReturnNotNull() {
+        assertThat(SortedMap(Collections.singletonMap(1, '1'))).isNotNull();
+    }
+
+    @Test
+    public void shouldSortedMapFromPairsReturnNotNull() {
+        assertThat(SortedMap(1, '1', 2, '2', 3, '3')).isNotNull();
+    }
+
+    @Test
+    public void shouldEmptySortedMapFromComparatorReturnNotNull() {
+        assertThat(SortedMap(Integer::compareTo)).isNotNull();
+    }
+
+    @Test
+    public void shouldSortedMapFromSingleAndComparatorReturnNotNull() {
+        assertThat(SortedMap((Comparator<Integer>)Integer::compareTo, 1, '1')).isNotNull();
+    }
+
+    @Test
+    public void shouldSortedMapFromTuplesAndComparatorReturnNotNull() {
+        assertThat(SortedMap((Comparator<Integer>)Integer::compareTo, Tuple(1, '1'), Tuple(2, '2'), Tuple(3, '3'))).isNotNull();
     }
 
     // -- run

--- a/javaslang/src-gen/test/java/javaslang/APITest.java
+++ b/javaslang/src-gen/test/java/javaslang/APITest.java
@@ -267,6 +267,16 @@ public class APITest {
         assertThat(t.isFailure()).isTrue();
     }
 
+    @Test
+    public void shouldValidReturnNotNull() {
+        assertThat(Valid(1)).isNotNull();
+    }
+
+    @Test
+    public void shouldInvalidReturnNotNull() {
+        assertThat(Invalid(new Error())).isNotNull();
+    }
+
     // -- run
 
     @Test

--- a/javaslang/src-gen/test/java/javaslang/APITest.java
+++ b/javaslang/src-gen/test/java/javaslang/APITest.java
@@ -13,8 +13,10 @@ import static javaslang.API.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
+import java.util.concurrent.Executors;
 import javaslang.collection.CharSeq;
 import javaslang.collection.List;
+import javaslang.concurrent.Future;
 import javaslang.control.Option;
 import org.junit.Test;
 
@@ -173,6 +175,54 @@ public class APITest {
     @Test
     public void shouldLeftReturnNotNull() {
         assertThat(Left(null)).isNotNull();
+    }
+
+    @Test
+    public void shouldFutureWithSupplierReturnNotNull() {
+        final Future<?> future = Future(() -> 1);
+        future.await();
+        assertThat(future).isNotNull();
+        assertThat(future.isSuccess()).isTrue();
+    }
+
+    @Test
+    public void shouldFutureWithinExecutorWithSupplierReturnNotNull() {
+        final Future<?> future = Future(Executors.newSingleThreadExecutor(), () -> 1);
+        future.await();
+        assertThat(future).isNotNull();
+        assertThat(future.isSuccess()).isTrue();
+    }
+
+    @Test
+    public void shouldFutureWithValueReturnNotNull() {
+        final Future<?> future = Future(1);
+        future.await();
+        assertThat(future).isNotNull();
+        assertThat(future.isSuccess()).isTrue();
+    }
+
+    @Test
+    public void shouldFutureWithinExecutorWithValueReturnNotNull() {
+        final Future<?> future = Future(Executors.newSingleThreadExecutor(), 1);
+        future.await();
+        assertThat(future).isNotNull();
+        assertThat(future.isSuccess()).isTrue();
+    }
+
+    @Test
+    public void shouldFutureWithErrorReturnNotNull() {
+        final Future<?> future = Future(new Error());
+        future.await();
+        assertThat(future).isNotNull();
+        assertThat(future.isFailure()).isTrue();
+    }
+
+    @Test
+    public void shouldFutureWithinExecutorWithErrorReturnNotNull() {
+        final Future<?> future = Future(Executors.newSingleThreadExecutor(), new Error());
+        future.await();
+        assertThat(future).isNotNull();
+        assertThat(future.isFailure()).isTrue();
     }
 
     // -- run

--- a/javaslang/src-gen/test/java/javaslang/APITest.java
+++ b/javaslang/src-gen/test/java/javaslang/APITest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.concurrent.Executors;
+import java.util.stream.Stream;
 import javaslang.collection.CharSeq;
 import javaslang.collection.List;
 import javaslang.concurrent.Future;
@@ -290,6 +291,231 @@ public class APITest {
     @Test
     public void shouldCharSeqReturnNotNull() {
         assertThat((Iterable<Character>) CharSeq("123")).isNotNull();
+    }
+
+    @Test
+    public void shouldEmptyArrayReturnNotNull() {
+        assertThat(Array()).isNotNull();
+    }
+
+    @Test
+    public void shouldArrayWithSingleReturnNotNull() {
+        assertThat(Array('1')).isNotNull();
+    }
+
+    @Test
+    public void shouldArrayWithVarArgReturnNotNull() {
+        assertThat(Array('1', '2', '3')).isNotNull();
+    }
+
+    @Test
+    public void shouldArrayWithIterableReturnNotNull() {
+        assertThat(Array(CharSeq('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldArrayWithStreamReturnNotNull() {
+        assertThat(Array(Stream.of('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldEmptyVectorReturnNotNull() {
+        assertThat(Vector()).isNotNull();
+    }
+
+    @Test
+    public void shouldVectorWithSingleReturnNotNull() {
+        assertThat(Vector('1')).isNotNull();
+    }
+
+    @Test
+    public void shouldVectorWithVarArgReturnNotNull() {
+        assertThat(Vector('1', '2', '3')).isNotNull();
+    }
+
+    @Test
+    public void shouldVectorWithIterableReturnNotNull() {
+        assertThat(Vector(CharSeq('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldVectorWithStreamReturnNotNull() {
+        assertThat(Vector(Stream.of('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldEmptyListReturnNotNull() {
+        assertThat(List()).isNotNull();
+    }
+
+    @Test
+    public void shouldListWithSingleReturnNotNull() {
+        assertThat(List('1')).isNotNull();
+    }
+
+    @Test
+    public void shouldListWithVarArgReturnNotNull() {
+        assertThat(List('1', '2', '3')).isNotNull();
+    }
+
+    @Test
+    public void shouldListWithIterableReturnNotNull() {
+        assertThat(List(CharSeq('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldListWithStreamReturnNotNull() {
+        assertThat(List(Stream.of('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldEmptyStreamReturnNotNull() {
+        assertThat(Stream()).isNotNull();
+    }
+
+    @Test
+    public void shouldStreamWithSingleReturnNotNull() {
+        assertThat(Stream('1')).isNotNull();
+    }
+
+    @Test
+    public void shouldStreamWithVarArgReturnNotNull() {
+        assertThat(Stream('1', '2', '3')).isNotNull();
+    }
+
+    @Test
+    public void shouldStreamWithIterableReturnNotNull() {
+        assertThat(Stream(CharSeq('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldStreamWithStreamReturnNotNull() {
+        assertThat(Stream(Stream.of('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldEmptyQueueReturnNotNull() {
+        assertThat(Queue()).isNotNull();
+    }
+
+    @Test
+    public void shouldQueueWithSingleReturnNotNull() {
+        assertThat(Queue('1')).isNotNull();
+    }
+
+    @Test
+    public void shouldQueueWithVarArgReturnNotNull() {
+        assertThat(Queue('1', '2', '3')).isNotNull();
+    }
+
+    @Test
+    public void shouldQueueWithIterableReturnNotNull() {
+        assertThat(Queue(CharSeq('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldQueueWithStreamReturnNotNull() {
+        assertThat(Queue(Stream.of('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldEmptyLinkedSetReturnNotNull() {
+        assertThat(LinkedSet()).isNotNull();
+    }
+
+    @Test
+    public void shouldLinkedSetWithSingleReturnNotNull() {
+        assertThat(LinkedSet('1')).isNotNull();
+    }
+
+    @Test
+    public void shouldLinkedSetWithVarArgReturnNotNull() {
+        assertThat(LinkedSet('1', '2', '3')).isNotNull();
+    }
+
+    @Test
+    public void shouldLinkedSetWithIterableReturnNotNull() {
+        assertThat(LinkedSet(CharSeq('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldLinkedSetWithStreamReturnNotNull() {
+        assertThat(LinkedSet(Stream.of('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldEmptySetReturnNotNull() {
+        assertThat(Set()).isNotNull();
+    }
+
+    @Test
+    public void shouldSetWithSingleReturnNotNull() {
+        assertThat(Set('1')).isNotNull();
+    }
+
+    @Test
+    public void shouldSetWithVarArgReturnNotNull() {
+        assertThat(Set('1', '2', '3')).isNotNull();
+    }
+
+    @Test
+    public void shouldSetWithIterableReturnNotNull() {
+        assertThat(Set(CharSeq('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldSetWithStreamReturnNotNull() {
+        assertThat(Set(Stream.of('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldEmptySeqReturnNotNull() {
+        assertThat(Seq()).isNotNull();
+    }
+
+    @Test
+    public void shouldSeqWithSingleReturnNotNull() {
+        assertThat(Seq('1')).isNotNull();
+    }
+
+    @Test
+    public void shouldSeqWithVarArgReturnNotNull() {
+        assertThat(Seq('1', '2', '3')).isNotNull();
+    }
+
+    @Test
+    public void shouldSeqWithIterableReturnNotNull() {
+        assertThat(Seq(CharSeq('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldSeqWithStreamReturnNotNull() {
+        assertThat(Seq(Stream.of('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldEmptyIndexedSeqReturnNotNull() {
+        assertThat(IndexedSeq()).isNotNull();
+    }
+
+    @Test
+    public void shouldIndexedSeqWithSingleReturnNotNull() {
+        assertThat(IndexedSeq('1')).isNotNull();
+    }
+
+    @Test
+    public void shouldIndexedSeqWithVarArgReturnNotNull() {
+        assertThat(IndexedSeq('1', '2', '3')).isNotNull();
+    }
+
+    @Test
+    public void shouldIndexedSeqWithIterableReturnNotNull() {
+        assertThat(IndexedSeq(CharSeq('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldIndexedSeqWithStreamReturnNotNull() {
+        assertThat(IndexedSeq(Stream.of('1', '2', '3'))).isNotNull();
     }
 
     // -- run

--- a/javaslang/src-gen/test/java/javaslang/APITest.java
+++ b/javaslang/src-gen/test/java/javaslang/APITest.java
@@ -165,6 +165,16 @@ public class APITest {
         assertThat(Tuple(1, 2, 3, 4, 5, 6, 7, 8)).isNotNull();
     }
 
+    @Test
+    public void shouldRightReturnNotNull() {
+        assertThat(Right(null)).isNotNull();
+    }
+
+    @Test
+    public void shouldLeftReturnNotNull() {
+        assertThat(Left(null)).isNotNull();
+    }
+
     // -- run
 
     @Test

--- a/javaslang/src-gen/test/java/javaslang/APITest.java
+++ b/javaslang/src-gen/test/java/javaslang/APITest.java
@@ -25,6 +25,101 @@ public class APITest {
         AssertionsExtensions.assertThat(API.class).isNotInstantiable();
     }
 
+    //
+    // Alias should return not null.
+    // More specific test for each aliased class implemented in separate test class
+    //
+
+    @Test
+    public void shouldFunction0ReturnNotNull() {
+        assertThat(Function0(() -> null)).isNotNull();
+    }
+
+    @Test
+    public void shouldCheckedFunction0ReturnNotNull() {
+        assertThat(CheckedFunction0(() -> null)).isNotNull();
+    }
+
+    @Test
+    public void shouldFunction1ReturnNotNull() {
+        assertThat(Function1((v1) -> null)).isNotNull();
+    }
+
+    @Test
+    public void shouldCheckedFunction1ReturnNotNull() {
+        assertThat(CheckedFunction1((v1) -> null)).isNotNull();
+    }
+
+    @Test
+    public void shouldFunction2ReturnNotNull() {
+        assertThat(Function2((v1, v2) -> null)).isNotNull();
+    }
+
+    @Test
+    public void shouldCheckedFunction2ReturnNotNull() {
+        assertThat(CheckedFunction2((v1, v2) -> null)).isNotNull();
+    }
+
+    @Test
+    public void shouldFunction3ReturnNotNull() {
+        assertThat(Function3((v1, v2, v3) -> null)).isNotNull();
+    }
+
+    @Test
+    public void shouldCheckedFunction3ReturnNotNull() {
+        assertThat(CheckedFunction3((v1, v2, v3) -> null)).isNotNull();
+    }
+
+    @Test
+    public void shouldFunction4ReturnNotNull() {
+        assertThat(Function4((v1, v2, v3, v4) -> null)).isNotNull();
+    }
+
+    @Test
+    public void shouldCheckedFunction4ReturnNotNull() {
+        assertThat(CheckedFunction4((v1, v2, v3, v4) -> null)).isNotNull();
+    }
+
+    @Test
+    public void shouldFunction5ReturnNotNull() {
+        assertThat(Function5((v1, v2, v3, v4, v5) -> null)).isNotNull();
+    }
+
+    @Test
+    public void shouldCheckedFunction5ReturnNotNull() {
+        assertThat(CheckedFunction5((v1, v2, v3, v4, v5) -> null)).isNotNull();
+    }
+
+    @Test
+    public void shouldFunction6ReturnNotNull() {
+        assertThat(Function6((v1, v2, v3, v4, v5, v6) -> null)).isNotNull();
+    }
+
+    @Test
+    public void shouldCheckedFunction6ReturnNotNull() {
+        assertThat(CheckedFunction6((v1, v2, v3, v4, v5, v6) -> null)).isNotNull();
+    }
+
+    @Test
+    public void shouldFunction7ReturnNotNull() {
+        assertThat(Function7((v1, v2, v3, v4, v5, v6, v7) -> null)).isNotNull();
+    }
+
+    @Test
+    public void shouldCheckedFunction7ReturnNotNull() {
+        assertThat(CheckedFunction7((v1, v2, v3, v4, v5, v6, v7) -> null)).isNotNull();
+    }
+
+    @Test
+    public void shouldFunction8ReturnNotNull() {
+        assertThat(Function8((v1, v2, v3, v4, v5, v6, v7, v8) -> null)).isNotNull();
+    }
+
+    @Test
+    public void shouldCheckedFunction8ReturnNotNull() {
+        assertThat(CheckedFunction8((v1, v2, v3, v4, v5, v6, v7, v8) -> null)).isNotNull();
+    }
+
     // -- run
 
     @Test

--- a/javaslang/src-gen/test/java/javaslang/APITest.java
+++ b/javaslang/src-gen/test/java/javaslang/APITest.java
@@ -13,6 +13,7 @@ import static javaslang.API.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 import javaslang.collection.CharSeq;
@@ -516,6 +517,106 @@ public class APITest {
     @Test
     public void shouldIndexedSeqWithStreamReturnNotNull() {
         assertThat(IndexedSeq(Stream.of('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldEmptySortedSetReturnNotNull() {
+        assertThat(SortedSet()).isNotNull();
+    }
+
+    @Test
+    public void shouldEmptySortedSetWithComparatorReturnNotNull() {
+        assertThat(SortedSet((Comparator<Character>) Character::compareTo)).isNotNull();
+    }
+
+    @Test
+    public void shouldSortedSetWithSingleReturnNotNull() {
+        assertThat(SortedSet('1')).isNotNull();
+    }
+
+    @Test
+    public void shouldSortedSetWithSingleAndComparatorReturnNotNull() {
+        assertThat(SortedSet(Character::compareTo, '1')).isNotNull();
+    }
+
+    @Test
+    public void shouldSortedSetWithVarArgReturnNotNull() {
+        assertThat(SortedSet('1', '2', '3')).isNotNull();
+    }
+
+    @Test
+    public void shouldSortedSetWithVarArgAndComparatorReturnNotNull() {
+        assertThat(SortedSet((Comparator<Character>) Character::compareTo, '1', '2', '3')).isNotNull();
+    }
+
+    @Test
+    public void shouldSortedSetWithIterableReturnNotNull() {
+        assertThat(SortedSet(CharSeq('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldSortedSetWithIterableAndComparatorReturnNotNull() {
+        assertThat(SortedSet(Character::compareTo, CharSeq('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldSortedSetWithStreamReturnNotNull() {
+        assertThat(SortedSet(Stream.of('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldSortedSetWithStreamAndComparatorReturnNotNull() {
+        assertThat(SortedSet(Character::compareTo, Stream.of('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldEmptyPriorityQueueReturnNotNull() {
+        assertThat(PriorityQueue()).isNotNull();
+    }
+
+    @Test
+    public void shouldEmptyPriorityQueueWithComparatorReturnNotNull() {
+        assertThat(PriorityQueue((Comparator<Character>) Character::compareTo)).isNotNull();
+    }
+
+    @Test
+    public void shouldPriorityQueueWithSingleReturnNotNull() {
+        assertThat(PriorityQueue('1')).isNotNull();
+    }
+
+    @Test
+    public void shouldPriorityQueueWithSingleAndComparatorReturnNotNull() {
+        assertThat(PriorityQueue(Character::compareTo, '1')).isNotNull();
+    }
+
+    @Test
+    public void shouldPriorityQueueWithVarArgReturnNotNull() {
+        assertThat(PriorityQueue('1', '2', '3')).isNotNull();
+    }
+
+    @Test
+    public void shouldPriorityQueueWithVarArgAndComparatorReturnNotNull() {
+        assertThat(PriorityQueue((Comparator<Character>) Character::compareTo, '1', '2', '3')).isNotNull();
+    }
+
+    @Test
+    public void shouldPriorityQueueWithIterableReturnNotNull() {
+        assertThat(PriorityQueue(CharSeq('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldPriorityQueueWithIterableAndComparatorReturnNotNull() {
+        assertThat(PriorityQueue(Character::compareTo, CharSeq('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldPriorityQueueWithStreamReturnNotNull() {
+        assertThat(PriorityQueue(Stream.of('1', '2', '3'))).isNotNull();
+    }
+
+    @Test
+    public void shouldPriorityQueueWithStreamAndComparatorReturnNotNull() {
+        assertThat(PriorityQueue(Character::compareTo, Stream.of('1', '2', '3'))).isNotNull();
     }
 
     // -- run

--- a/javaslang/src-gen/test/java/javaslang/APITest.java
+++ b/javaslang/src-gen/test/java/javaslang/APITest.java
@@ -277,6 +277,21 @@ public class APITest {
         assertThat(Invalid(new Error())).isNotNull();
     }
 
+    @Test
+    public void shouldCharReturnNotNull() {
+        assertThat((Iterable<Character>) CharSeq('1')).isNotNull();
+    }
+
+    @Test
+    public void shouldCharArrayReturnNotNull() {
+        assertThat((Iterable<Character>) CharSeq('1', '2', '3')).isNotNull();
+    }
+
+    @Test
+    public void shouldCharSeqReturnNotNull() {
+        assertThat((Iterable<Character>) CharSeq("123")).isNotNull();
+    }
+
     // -- run
 
     @Test

--- a/javaslang/src-gen/test/java/javaslang/APITest.java
+++ b/javaslang/src-gen/test/java/javaslang/APITest.java
@@ -230,6 +230,21 @@ public class APITest {
         assertThat(Lazy(() -> 1)).isNotNull();
     }
 
+    @Test
+    public void shouldOptionReturnNotNull() {
+        assertThat(Option(1)).isNotNull();
+    }
+
+    @Test
+    public void shouldSomeReturnNotNull() {
+        assertThat(Some(1)).isNotNull();
+    }
+
+    @Test
+    public void shouldNoneReturnNotNull() {
+        assertThat(None()).isNotNull();
+    }
+
     // -- run
 
     @Test

--- a/javaslang/src-gen/test/java/javaslang/APITest.java
+++ b/javaslang/src-gen/test/java/javaslang/APITest.java
@@ -18,6 +18,7 @@ import javaslang.collection.CharSeq;
 import javaslang.collection.List;
 import javaslang.concurrent.Future;
 import javaslang.control.Option;
+import javaslang.control.Try;
 import org.junit.Test;
 
 public class APITest {
@@ -243,6 +244,27 @@ public class APITest {
     @Test
     public void shouldNoneReturnNotNull() {
         assertThat(None()).isNotNull();
+    }
+
+    @Test
+    public void shouldTryReturnNotNull() {
+        final Try<?> t = Try(() -> 1);
+        assertThat(t).isNotNull();
+        assertThat(t.isSuccess()).isTrue();
+    }
+
+    @Test
+    public void shouldSuccessReturnNotNull() {
+        final Try<?> t = Success(1);
+        assertThat(t).isNotNull();
+        assertThat(t.isSuccess()).isTrue();
+    }
+
+    @Test
+    public void shouldFailureReturnNotNull() {
+        final Try<?> t = Failure(new Error());
+        assertThat(t).isNotNull();
+        assertThat(t.isFailure()).isTrue();
     }
 
     // -- run

--- a/javaslang/src-gen/test/java/javaslang/APITest.java
+++ b/javaslang/src-gen/test/java/javaslang/APITest.java
@@ -225,6 +225,11 @@ public class APITest {
         assertThat(future.isFailure()).isTrue();
     }
 
+    @Test
+    public void shouldLazyReturnNotNull() {
+        assertThat(Lazy(() -> 1)).isNotNull();
+    }
+
     // -- run
 
     @Test

--- a/javaslang/src/test/java/javaslang/MatchTest.java
+++ b/javaslang/src/test/java/javaslang/MatchTest.java
@@ -16,7 +16,10 @@ import java.math.BigDecimal;
 import java.time.Year;
 import java.util.function.Predicate;
 
-import static javaslang.API.*;
+import static javaslang.API.$;
+import static javaslang.API.Case;
+import static javaslang.API.Match;
+import static javaslang.API.run;
 import static javaslang.MatchTest_DeveloperPatterns.Developer;
 import static javaslang.Patterns.*;
 import static javaslang.Predicates.*;


### PR DESCRIPTION
Fixes #1431

Add aliases for:
* Functions
* Tuples
* Either
* Future
* Lazy
* Option
* Try
* Validation
* CharSeq
* Traversable
* Sorted traversable
* Maps
