### PR TITLE
Fixes Future bug with escaping RejectedExecutionException

### DIFF
--- a/javaslang/src/test/java/javaslang/concurrent/RejectingExecutorService.java
+++ b/javaslang/src/test/java/javaslang/concurrent/RejectingExecutorService.java
@@ -1,0 +1,94 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2016 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.concurrent;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.*;
+
+/**
+ * A submitted Callable is immediately rejected
+ */
+final class RejectingExecutorService implements ExecutorService {
+
+    private static final RejectingExecutorService INSTANCE = new RejectingExecutorService();
+
+    private RejectingExecutorService() {
+    }
+
+    public static RejectingExecutorService instance() {
+        return INSTANCE;
+    }
+
+    // -- relevant methods
+
+    @Override
+    public <T> java.util.concurrent.Future<T> submit(Callable<T> task) {
+        throw new RejectedExecutionException("test");
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        command.run();
+    }
+
+    // -- not needed
+
+    @Override
+    public void shutdown() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> java.util.concurrent.Future<T> submit(Runnable task, T result) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.util.concurrent.Future<?> submit(Runnable task) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> List<java.util.concurrent.Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> List<java.util.concurrent.Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
@mattjtodd wrote:

I'm looking at approaches to apply back pressure using spring's `DeferredResult` and a limited-size Thread pool. In the case where all available Threads in the pools are in use, and a `RejectedExecutionException` is thrown, how this can be expressed using as little spring as possible.

Here's the a basic `CompletableFuture` version:

```java
private DeferredResult<ResponseEntity<HashResponse>> eexample1(@RequestBody HashRequest request) {
        DeferredResult<ResponseEntity<HashResponse>> deferredResult = new DeferredResult<>(Long.MAX_VALUE);

        try {
            CompletableFuture
                .supplyAsync(() -> {
                    try {
                        return encode(request, randomSource);
                    } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
                        throw new IllegalStateException(e);
                    }
                }, executor)
                .thenApply(ResponseEntity::ok)
                .whenComplete((success, thrown) -> {
                    if (Objects.nonNull(thrown)) {
                        deferredResult.setErrorResult(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build());
                    } else {
                        deferredResult.setResult(success);
                    }

                });
        } catch (RejectedExecutionException e) {
            deferredResult.setErrorResult(ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build());
        }

        return deferredResult;
    }
```

and the `Future` version. much neater :grinning:

```java
    private DeferredResult<ResponseEntity<HashResponse>> hash2(@RequestBody HashRequest request) {
        DeferredResult<ResponseEntity<HashResponse>> deferredResult = new DeferredResult<>(Long.MAX_VALUE);

        Try
            .of(() -> Future.of(executor, () -> encode(request, randomSource)))
            .getOrElseGet(Future::failed)
            .map(ResponseEntity::ok)
            .onFailure(thrown -> deferredResult.setErrorResult(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()))
            .onSuccess(deferredResult::setResult);

        return deferredResult;

    }
```

The second example doesn't offer the `SERVICE_UNAVAILABLE 503` response but it would be easy with `Match` / `Case` constructs. What's puzzling me now is that the first example handles the `RejectedExecutionException` as expected. The second example blocks forever on the first request once a second request is made which is then rejected. Unless there's something I'm missing, there could be a subtle bug in there somewhere.