### PR TITLE
Vector optimizations

### DIFF
--- a/javaslang-gwt/src/test/java/client/CollectionsTestGwt.java
+++ b/javaslang-gwt/src/test/java/client/CollectionsTestGwt.java
@@ -60,7 +60,8 @@ public class CollectionsTestGwt extends GWTTestCase {
         applyCollection(chars -> TreeSet.ofAll(Iterator.ofAll(chars)));
     }
 
+    @SuppressWarnings("Convert2MethodRef")
     public void testCompileVector() {
-        applyCollection(Vector::ofAll);
+        applyCollection(chars -> Vector.ofAll(chars));
     }
 }

--- a/javaslang/src/main/java/javaslang/collection/Arrays.java
+++ b/javaslang/src/main/java/javaslang/collection/Arrays.java
@@ -16,15 +16,44 @@ final class Arrays {
     private static final Object[] EMPTY = {};
     static Object[] empty() { return EMPTY; }
 
+    @SuppressWarnings("unchecked")
+    static <T> T newInstance(int length) { return (T) copy(empty(), length); }
+
     /** Create a single element array */
     static Object[] asArray(Object element) {
-        return copyUpdate(empty(), 0, element);
+        final Object[] copy = newInstance(1);
+        copy[0] = element;
+        return copy;
+    }
+
+    /** Store the content of an iterable in an array */
+    static Object[] asArray(java.util.Iterator<?> it, int length) {
+        final Object[] array = newInstance(length);
+        for (int i = 0; i < length; i++) {
+            array[i] = it.next();
+        }
+        return array;
     }
 
     /** System.arrayCopy with same source and destination */
     static Object[] copyRange(Object array, int from, int to) {
         final int length = to - from;
         return arrayCopy(length, array, from, 0, length);
+    }
+
+    /** Repeatedly group an array into equal sized sub-trees */
+    static Object[] grouped(Object[] array, int groupSize) {
+        assert array.length > groupSize;
+        final Object[] results = newInstance(1 + ((array.length - 1) / groupSize));
+        results[0] = copyRange(array, 0, groupSize);
+
+        for (int start = groupSize, i = 1; start < array.length; i++) {
+            final int nextLength = Math.min(groupSize, array.length - (i * groupSize));
+            results[i] = copyRange(array, start, start + nextLength);
+            start += nextLength;
+        }
+
+        return results;
     }
 
     /** clone the source and set the value at the given position */

--- a/javaslang/src/main/java/javaslang/collection/Arrays.java
+++ b/javaslang/src/main/java/javaslang/collection/Arrays.java
@@ -12,7 +12,7 @@ package javaslang.collection;
  * @author Pap Lőrinc
  * @since 2.1.0
  */
-final class Arrays { // TODO reuse these in `Array` also
+final class Arrays {
     private static final Object[] EMPTY = {};
     static Object[] empty() { return EMPTY; }
 

--- a/javaslang/src/main/java/javaslang/collection/BitMappedTrie.java
+++ b/javaslang/src/main/java/javaslang/collection/BitMappedTrie.java
@@ -8,6 +8,7 @@ package javaslang.collection;
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static javaslang.collection.Arrays.*;
 import static javaslang.collection.NodeModifier.*;
@@ -262,6 +263,25 @@ final class BitMappedTrie<T> implements Serializable {
         return globalIndex;
     }
 
+    BitMappedTrie<T> filter(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+
+        final Object[] results = new Object[length()];
+        final int length = this.<T> visit((index, leaf, start, end) -> {
+            for (int i = start; i < end; i++) {
+                final T value = leaf[i];
+                if (predicate.test(value)) {
+                    results[index++] = value;
+                }
+            }
+            return index;
+        });
+
+        return (length() == length)
+               ? this
+               : BitMappedTrie.ofAll(copyRange(results, 0, length));
+    }
+
     <U> BitMappedTrie<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
 
@@ -273,7 +293,7 @@ final class BitMappedTrie<T> implements Serializable {
             return index;
         });
 
-        return BitMappedTrie.ofAll(results, length);
+        return BitMappedTrie.ofAll(results);
     }
 
     int length() { return length; }

--- a/javaslang/src/main/java/javaslang/collection/BitMappedTrie.java
+++ b/javaslang/src/main/java/javaslang/collection/BitMappedTrie.java
@@ -59,6 +59,19 @@ final class BitMappedTrie<T> implements Serializable {
         return branchCount * fullBranchSize;
     }
 
+    static <T> BitMappedTrie<T> ofAll(Object[] array) {
+        final int size = array.length;
+        if (size == 0) {
+            return empty();
+        } else {
+            int shift = 0;
+            for (; array.length > BRANCHING_FACTOR; shift += BRANCHING_BASE) {
+                array = grouped(array, BRANCHING_FACTOR);
+            }
+            return new BitMappedTrie<>(array, 0, size, shift);
+        }
+    }
+
     BitMappedTrie<T> prepend(T leading) {
         final int newSize = length() + 1;
         if (length() == 0) {

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -14,7 +14,9 @@ import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;
 
-import static javaslang.collection.Collections.*;
+import static javaslang.collection.Arrays.asArray;
+import static javaslang.collection.Collections.areEqual;
+import static javaslang.collection.Collections.seq;
 
 /**
  * Vector is the default Seq implementation that provides effectively constant time access to any element.
@@ -159,12 +161,13 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
         Objects.requireNonNull(iterable, "iterable is null");
         if (iterable instanceof Vector) {
             return (Vector<T>) iterable;
+        } else if (iterable instanceof Collection<?>) {
+            final Object[] array = ((Collection<? extends T>) iterable).toArray();
+            return ofAll(BitMappedTrie.ofAll(array));
         } else {
-            BitMappedTrie<T> trie = BitMappedTrie.empty();
-            for (T element : iterable) {
-                trie = trie.append(element);
-            }
-            return ofAll(trie);
+            final Seq<? extends T> elems = seq(iterable);
+            final Object[] array = asArray(elems.iterator(), elems.size());
+            return ofAll(BitMappedTrie.ofAll(array));
         }
     }
 

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -669,10 +669,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public Vector<T> filter(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
-        final Vector<T> results = ofAll(iterator().filter(predicate));
-        return (results.length() == length()) ? this
-                                              : results;
+        return wrap(trie.filter(predicate));
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -775,10 +775,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public <U> Vector<U> map(Function<? super T, ? extends U> mapper) {
-        Objects.requireNonNull(mapper, "mapper is null");
-
-        final Iterator<? extends U> results = iterator().map(mapper);
-        return ofAll(results);
+        return ofAll(trie.map(mapper));
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -33,8 +33,8 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     final BitMappedTrie<T> trie;
     private Vector(BitMappedTrie<T> trie) {
-        assert (EMPTY == null) || (trie.length() > 0);
         this.trie = trie;
+        assert (EMPTY == null) || (length() > 0);
     }
 
     @SuppressWarnings("ObjectEquality")
@@ -57,9 +57,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @return The empty Vector.
      */
     @SuppressWarnings("unchecked")
-    public static <T> Vector<T> empty() {
-        return (Vector<T>) EMPTY;
-    }
+    public static <T> Vector<T> empty() { return (Vector<T>) EMPTY; }
 
     /**
      * Returns a {@link Collector} which may be used in conjunction with
@@ -89,9 +87,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @return the given {@code vector} instance as narrowed type {@code Vector<T>}.
      */
     @SuppressWarnings("unchecked")
-    public static <T> Vector<T> narrow(Vector<? extends T> vector) {
-        return (Vector<T>) vector;
-    }
+    public static <T> Vector<T> narrow(Vector<? extends T> vector) { return (Vector<T>) vector; }
 
     /**
      * Returns a singleton {@code Vector}, i.e. a {@code Vector} of one element.
@@ -154,18 +150,18 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * if the iteration order of the elements is stable.
      *
      * @param <T>      Component type of the Vector.
-     * @param elements An Iterable of elements.
+     * @param iterable An Iterable of elements.
      * @return A vector containing the given elements in the same order.
      * @throws NullPointerException if {@code elements} is null
      */
     @SuppressWarnings("unchecked")
-    public static <T> Vector<T> ofAll(Iterable<? extends T> elements) {
-        Objects.requireNonNull(elements, "elements is null");
-        if (elements instanceof Vector) {
-            return (Vector<T>) elements;
+    public static <T> Vector<T> ofAll(Iterable<? extends T> iterable) {
+        Objects.requireNonNull(iterable, "iterable is null");
+        if (iterable instanceof Vector) {
+            return (Vector<T>) iterable;
         } else {
             BitMappedTrie<T> trie = BitMappedTrie.empty();
-            for (T element : elements) {
+            for (T element : iterable) {
                 trie = trie.append(element);
             }
             return ofAll(trie);
@@ -190,7 +186,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @param array a boolean array
      * @return A new Vector of Boolean values
      */
-    public static Vector<Boolean> ofAll(boolean[] array) {
+    public static Vector<Boolean> ofAll(boolean... array) {
         Objects.requireNonNull(array, "array is null");
         return ofAll(Iterator.ofAll(array));
     }
@@ -201,7 +197,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @param array a byte array
      * @return A new Vector of Byte values
      */
-    public static Vector<Byte> ofAll(byte[] array) {
+    public static Vector<Byte> ofAll(byte... array) {
         Objects.requireNonNull(array, "array is null");
         return ofAll(Iterator.ofAll(array));
     }
@@ -212,7 +208,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @param array a char array
      * @return A new Vector of Character values
      */
-    public static Vector<Character> ofAll(char[] array) {
+    public static Vector<Character> ofAll(char... array) {
         Objects.requireNonNull(array, "array is null");
         return ofAll(Iterator.ofAll(array));
     }
@@ -223,7 +219,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @param array a double array
      * @return A new Vector of Double values
      */
-    public static Vector<Double> ofAll(double[] array) {
+    public static Vector<Double> ofAll(double... array) {
         Objects.requireNonNull(array, "array is null");
         return ofAll(Iterator.ofAll(array));
     }
@@ -234,7 +230,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @param array a float array
      * @return A new Vector of Float values
      */
-    public static Vector<Float> ofAll(float[] array) {
+    public static Vector<Float> ofAll(float... array) {
         Objects.requireNonNull(array, "array is null");
         return ofAll(Iterator.ofAll(array));
     }
@@ -245,7 +241,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @param array an int array
      * @return A new Vector of Integer values
      */
-    public static Vector<Integer> ofAll(int[] array) {
+    public static Vector<Integer> ofAll(int... array) {
         Objects.requireNonNull(array, "array is null");
         return ofAll(Iterator.ofAll(array));
     }
@@ -256,7 +252,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @param array a long array
      * @return A new Vector of Long values
      */
-    public static Vector<Long> ofAll(long[] array) {
+    public static Vector<Long> ofAll(long... array) {
         Objects.requireNonNull(array, "array is null");
         return ofAll(Iterator.ofAll(array));
     }
@@ -267,7 +263,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @param array a short array
      * @return A new Vector of Short values
      */
-    public static Vector<Short> ofAll(short[] array) {
+    public static Vector<Short> ofAll(short... array) {
         Objects.requireNonNull(array, "array is null");
         return ofAll(Iterator.ofAll(array));
     }
@@ -589,24 +585,16 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public Vector<Vector<T>> combinations() {
-        return rangeClosed(0, length()).map(this::combinations).flatMap(Function.identity());
-    }
+    public Vector<Vector<T>> combinations() { return rangeClosed(0, length()).map(this::combinations).flatMap(Function.identity()); }
 
     @Override
-    public Vector<Vector<T>> combinations(int k) {
-        return Combinations.apply(this, Math.max(k, 0));
-    }
+    public Vector<Vector<T>> combinations(int k) { return Combinations.apply(this, Math.max(k, 0)); }
 
     @Override
-    public Iterator<Vector<T>> crossProduct(int power) {
-        return Collections.crossProduct(empty(), this, power);
-    }
+    public Iterator<Vector<T>> crossProduct(int power) { return Collections.crossProduct(empty(), this, power); }
 
     @Override
-    public Vector<T> distinct() {
-        return distinctBy(Function.identity());
-    }
+    public Vector<T> distinct() { return distinctBy(Function.identity()); }
 
     @Override
     public Vector<T> distinctBy(Comparator<? super T> comparator) {
@@ -710,19 +698,13 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public <C> Map<C, Vector<T>> groupBy(Function<? super T, ? extends C> classifier) {
-        return Collections.groupBy(this, classifier, Vector::ofAll);
-    }
+    public <C> Map<C, Vector<T>> groupBy(Function<? super T, ? extends C> classifier) { return Collections.groupBy(this, classifier, Vector::ofAll); }
 
     @Override
-    public Iterator<Vector<T>> grouped(int size) {
-        return sliding(size, size);
-    }
+    public Iterator<Vector<T>> grouped(int size) { return sliding(size, size); }
 
     @Override
-    public boolean hasDefiniteSize() {
-        return true;
-    }
+    public boolean hasDefiniteSize() { return true; }
 
     @Override
     public int indexOf(T element, int from) {
@@ -744,44 +726,35 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public Option<Vector<T>> initOption() {
-        return isEmpty() ? Option.none() : Option.some(init());
-    }
+    public Option<Vector<T>> initOption() { return isEmpty() ? Option.none() : Option.some(init()); }
 
     @Override
-    public Vector<T> insert(int index, T element) {
-        return insertAll(index, Iterator.of(element));
-    }
+    public Vector<T> insert(int index, T element) { return insertAll(index, Iterator.of(element)); }
 
     @Override
     public Vector<T> insertAll(int index, Iterable<? extends T> elements) {
         if ((index < 0) || (index > length())) {
             throw new IndexOutOfBoundsException("insert(" + index + ", e) on Vector of length " + length());
+        } else {
+            final Vector<T> begin = take(index);
+            final Vector<T> end = drop(index);
+            return begin.appendAll(elements).appendAll(end);
         }
-
-        final Vector<T> begin = take(index);
-        final Vector<T> end = drop(index);
-        return begin.appendAll(elements).appendAll(end);
     }
 
     @Override
-    public Vector<T> intersperse(T element) {
-        return ofAll(iterator().intersperse(element));
-    }
+    public Vector<T> intersperse(T element) { return ofAll(iterator().intersperse(element)); }
 
     @Override
-    public boolean isEmpty() {
-        return length() == 0;
-    }
+    public boolean isEmpty() { return length() == 0; }
 
     @Override
-    public boolean isTraversableAgain() {
-        return true;
-    }
+    public boolean isTraversableAgain() { return true; }
 
     @Override
     public Iterator<T> iterator() {
-        return isEmpty() ? Iterator.empty() : trie.iterator();
+        return isEmpty() ? Iterator.empty()
+                         : trie.iterator();
     }
 
     @Override
@@ -795,9 +768,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public int length() {
-        return trie.length();
-    }
+    public int length() { return trie.length(); }
 
     @Override
     public <U> Vector<U> map(Function<? super T, ? extends U> mapper) {
@@ -810,9 +781,10 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     @Override
     public Vector<T> padTo(int length, T element) {
         final int actualLength = length();
-        return (length <= actualLength) ? this
-                                        : appendAll(Iterator.continually(element)
-                                                            .take(length - actualLength));
+        return (length <= actualLength)
+               ? this
+               : appendAll(Iterator.continually(element)
+                .take(length - actualLength));
     }
 
     @Override
@@ -1107,9 +1079,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public Option<Vector<T>> tailOption() {
-        return isEmpty() ? Option.none() : Option.some(tail());
-    }
+    public Option<Vector<T>> tailOption() { return isEmpty() ? Option.none() : Option.some(tail()); }
 
     @Override
     public Vector<T> take(int n) {
@@ -1165,9 +1135,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public <U> Vector<U> unit(Iterable<? extends U> iterable) {
-        return ofAll(iterable);
-    }
+    public <U> Vector<U> unit(Iterable<? extends U> iterable) { return ofAll(iterable); }
 
     @Override
     public <T1, T2> Tuple2<Vector<T1>, Vector<T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
@@ -1243,7 +1211,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public int hashCode() { return hash(this); }
+    public int hashCode() { return Collections.hash(this); }
 
     @Override
     public String stringPrefix() { return "Vector"; }

--- a/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
@@ -8,28 +8,22 @@ package javaslang.collection;
 import javaslang.Function2;
 import javaslang.Tuple;
 import javaslang.Tuple2;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
-import static javaslang.collection.BitMappedTrie.BRANCHING_BASE;
-import static javaslang.collection.BitMappedTrie.branchingFactor;
+import static javaslang.collection.BitMappedTrie.BRANCHING_FACTOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class VectorPropertyTest {
-    @Before
-    public void setUp() { BRANCHING_BASE = 2; }
-    @After
-    public void tearDown() { BRANCHING_BASE = 5; }
-
     @Test
     public void shouldCreateAndGet() {
-        for (int i = 0; i < 5000; i++) {
+        for (int i = 0; i < 2000; i++) {
             final Seq<Integer> expected = Array.range(0, i);
             final Vector<Integer> actual = Vector.ofAll(expected);
             for (int j = 0; j < actual.size(); j++) {
@@ -54,8 +48,8 @@ public class VectorPropertyTest {
         Seq<Integer> expected = Array.empty();
         Vector<Integer> actual = Vector.empty();
 
-        for (int drop = 0; drop <= (branchingFactor() + 1); drop++) {
-            for (Integer value : Iterator.range(0, getMaxSizeForDepth(3) + branchingFactor())) {
+        for (int drop = 0; drop <= (BRANCHING_FACTOR + 1); drop++) {
+            for (Integer value : Iterator.range(0, getMaxSizeForDepth(3) + BRANCHING_FACTOR)) {
                 expected = expected.drop(drop);
                 actual = assertAreEqual(actual, drop, Vector::drop, expected);
 
@@ -70,8 +64,8 @@ public class VectorPropertyTest {
         Seq<Integer> expected = Array.empty();
         Vector<Integer> actual = Vector.empty();
 
-        for (int drop = 0; drop <= (branchingFactor() + 1); drop++) {
-            for (Integer value : Iterator.range(0, getMaxSizeForDepth(2) + branchingFactor())) {
+        for (int drop = 0; drop <= (BRANCHING_FACTOR + 1); drop++) {
+            for (Integer value : Iterator.range(0, getMaxSizeForDepth(2) + BRANCHING_FACTOR)) {
                 expected = expected.drop(drop);
                 actual = assertAreEqual(actual, drop, Vector::drop, expected);
 
@@ -86,9 +80,9 @@ public class VectorPropertyTest {
         final Function<Integer, Integer> mapper = i -> i + 1;
 
         for (byte depth = 0; depth <= 6; depth++) {
-            final int length = getMaxSizeForDepth(depth) + branchingFactor();
+            final int length = getMaxSizeForDepth(depth) + BRANCHING_FACTOR;
 
-            for (int drop = 0; drop <= (branchingFactor() + 1); drop++) {
+            for (int drop = 0; drop <= (BRANCHING_FACTOR + 1); drop++) {
                 Seq<Integer> expected = Array.range(0, length);
                 Vector<Integer> actual = Vector.ofAll(expected);
 
@@ -107,7 +101,7 @@ public class VectorPropertyTest {
 
     @Test
     public void shouldDrop() {
-        final int length = getMaxSizeForDepth(6) + branchingFactor();
+        final int length = getMaxSizeForDepth(6) + BRANCHING_FACTOR;
 
         final Seq<Integer> expected = Array.range(0, length);
         final Vector<Integer> actual = Vector.ofAll(expected);
@@ -125,7 +119,7 @@ public class VectorPropertyTest {
 
     @Test
     public void shouldDropRight() {
-        final int length = getMaxSizeForDepth(4) + branchingFactor();
+        final int length = getMaxSizeForDepth(4) + BRANCHING_FACTOR;
 
         final Seq<Integer> expected = Array.range(0, length);
         final Vector<Integer> actual = Vector.ofAll(expected);
@@ -143,7 +137,7 @@ public class VectorPropertyTest {
 
     @Test
     public void shouldSlice() {
-        for (int length = 1, end = getMaxSizeForDepth(2) + branchingFactor(); length <= end; length++) {
+        for (int length = 1, end = getMaxSizeForDepth(2) + BRANCHING_FACTOR; length <= end; length++) {
             Seq<Integer> expected = Array.range(0, length);
             Vector<Integer> actual = Vector.ofAll(expected);
 
@@ -156,50 +150,49 @@ public class VectorPropertyTest {
 
     @Test
     public void shouldBehaveLikeArray() {
-        Random random = new Random();
-        final int seed = random.nextInt();
+        final int seed = ThreadLocalRandom.current().nextInt();
         System.out.println("using seed " + seed);
-        random = new Random(seed);
+        final Random random = new Random(seed);
 
         for (int i = 1; i < 10; i++) {
-            BRANCHING_BASE = i;
-            Seq<Integer> expected = Array.empty();
-            Vector<Integer> actual = Vector.empty();
+            Seq<Object> expected = Array.empty();
+            Vector<Object> actual = Vector.empty();
             for (int j = 0; j < 50_000; j++) {
-                Seq<Tuple2<Seq<Integer>, Vector<Integer>>> history = Array.empty();
+                Seq<Tuple2<Seq<Object>, Vector<Object>>> history = Array.empty();
 
-                if (random.nextInt(100) < 20) {
-                    final ArrayList<Integer> values = new ArrayList<>();
+                if (percent(random) < 20) {
+                    final ArrayList<Object> values = new ArrayList<>();
                     for (int k = 0; k < random.nextInt(j + 1); k++) {
                         values.add(random.nextInt());
                     }
                     expected = Array.ofAll(values);
-                    actual = assertAreEqual(values, null, (v, p) -> Vector.ofAll(v), expected);
+                    actual = Vector.ofAll(values);
+                    assertAreEqual(expected, actual);
                     history = history.append(Tuple.of(expected, actual));
                 }
 
-                if (random.nextInt(100) < 50) {
-                    final Integer value = randomOrNull(random);
+                if (percent(random) < 50) {
+                    final Object value = randomValue(random);
                     expected = expected.append(value);
                     actual = assertAreEqual(actual, value, Vector::append, expected);
                     history = history.append(Tuple.of(expected, actual));
                 }
 
-                if (random.nextInt(100) < 50) {
-                    final Integer value = randomOrNull(random);
+                if (percent(random) < 50) {
+                    final Object value = randomValue(random);
                     expected = expected.prepend(value);
                     actual = assertAreEqual(actual, value, Vector::prepend, expected);
                     history = history.append(Tuple.of(expected, actual));
                 }
 
-                if (random.nextInt(100) < 30) {
+                if (percent(random) < 30) {
                     final int n = random.nextInt(expected.size() + 1);
                     expected = expected.drop(n);
                     actual = assertAreEqual(actual, n, Vector::drop, expected);
                     history = history.append(Tuple.of(expected, actual));
                 }
 
-                if (random.nextInt(100) < 30) {
+                if (percent(random) < 30) {
                     final int n = random.nextInt(expected.size() + 1);
                     expected = expected.take(n);
                     actual = assertAreEqual(actual, n, Vector::take, expected);
@@ -218,17 +211,31 @@ public class VectorPropertyTest {
                     history = history.append(Tuple.of(expected, actual));
                 }
 
-                if (random.nextInt(100) < 50) {
+                if (percent(random) < 50) {
                     if (!expected.isEmpty()) {
                         final int index = random.nextInt(expected.size());
-                        final Integer value = randomOrNull(random);
+                        final Object value = randomValue(random);
                         expected = expected.update(index, value);
                         actual = assertAreEqual(actual, null, (a, p) -> a.update(index, value), expected);
                         history = history.append(Tuple.of(expected, actual));
                     }
                 }
 
-                if (random.nextInt(100) < 30) {
+                if (percent(random) < 20) {
+                    final Function<Object, Object> mapper = val -> (val instanceof Integer) ? ((Integer) val + 1) : val;
+                    expected = expected.map(mapper);
+                    actual = assertAreEqual(actual, null, (a, p) -> a.map(mapper), expected);
+                    history = history.append(Tuple.of(expected, actual));
+                }
+
+                if (percent(random) < 30) {
+                    final Predicate<Object> filter = val -> (String.valueOf(val).length() % 10) == 0;
+                    expected = expected.filter(filter);
+                    actual = assertAreEqual(actual, null, (a, p) -> a.filter(filter), expected);
+                    history = history.append(Tuple.of(expected, actual));
+                }
+
+                if (percent(random) < 30) {
                     for (int k = 0; k < 2; k++) {
                         if (!expected.isEmpty()) {
                             final int to = random.nextInt(expected.size());
@@ -244,12 +251,22 @@ public class VectorPropertyTest {
             }
         }
     }
-    private Integer randomOrNull(Random random) {
-        return (random.nextInt(100) < 5) ? null : random.nextInt();
+
+    private int percent(Random random) { return random.nextInt(100); }
+
+    private Object randomValue(Random random) {
+        final int percent = percent(random);
+        if (percent < 5) {
+            return null;
+        } else if (percent < 10) {
+            return "String";
+        } else {
+            return random.nextInt();
+        }
     }
 
-    private static <T1, T2> Vector<Integer> assertAreEqual(T1 previousActual, T2 param, Function2<T1, T2, Vector<Integer>> actualProvider, Seq<Integer> expected) {
-        final Vector<Integer> actual = actualProvider.apply(previousActual, param);
+    private static <T extends Seq<?>, P> T assertAreEqual(T previousActual, P param, Function2<T, P, T> actualProvider, Seq<?> expected) {
+        final T actual = actualProvider.apply(previousActual, param);
         assertAreEqual(expected, actual);
         return actual; // makes debugging a lot easier, as the frame can be dropped and rerun on AssertError
     }
@@ -261,7 +278,7 @@ public class VectorPropertyTest {
     }
 
     private static int getMaxSizeForDepth(int depth) {
-        final int max = branchingFactor() + (int) Math.pow(branchingFactor(), depth) + branchingFactor();
+        final int max = BRANCHING_FACTOR + (int) Math.pow(BRANCHING_FACTOR, depth) + BRANCHING_FACTOR;
         return Math.min(max, 10_000);
     }
 }

--- a/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
@@ -41,6 +41,21 @@ public class VectorPropertyTest {
                 assertAreEqual(actual, expected);
             }
         }
+
+        Seq<Integer> expected = Array.range(0, 1000);
+        Vector<Integer> actual = Vector.ofAll(expected);
+        for (int drop = 0; drop <= (BRANCHING_FACTOR + 1); drop++) {
+            final Iterator<Integer> expectedIterator = expected.iterator();
+            actual.trie.<Object> visit((index, leaf, start, end) -> {
+                for (int i = start; i < end; i++) {
+                    assertThat(leaf[i]).isEqualTo(expectedIterator.next());
+                }
+                return -1;
+            });
+
+            expected = expected.tail().init();
+            actual = actual.tail().init();
+        }
     }
 
     @Test


### PR DESCRIPTION
Optimizes #1504

Every commit introduces a new type of optimization, i.e. 
* **Optimized `ofAll` for `Vector`**
  * `~150×` faster by building the tree from bottom up
* ~~**Optimized `prepend` and `append` for `Vector`**~~
  * ~~`~6×` faster by adding the `trailing` and `leading` arrays as depthless staging areas (i.e. only modify the tree if these two are full)~~  - **removed, as it hinders maintainability**
* **Optimized `drop` and `take` for `Vector`**
  * `>6×` faster by keeping the leafs intact on drops, as the middle tree already has an `offset` and a `length` that can mask them
* **Optimized `map` for `Vector`** and **Optimized `filter` for `Vector`**
  * `>14×` faster by using the internal `visitor` with `ofAll`

---
[Benchmarks](https://github.com/paplorinc/javaslang/blob/VectorOptimizations/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java#L49):

```java
Operation Ratio                                          32     1024    32768 
Create    slang_persistent/java_mutable               1.59×    0.93×    1.11×
Create    slang_persistent/fjava_persistent         198.49×  187.60×  179.09×
Create    slang_persistent/pcollections_persistent  115.43×  220.62×  351.42×
Create    slang_persistent/ecollections_persistent    1.93×    0.91×    1.12×
Create    slang_persistent/clojure_persistent         0.98×   13.66×   11.09×
Create    slang_persistent/scala_persistent          13.76×    8.23×    6.02×
          
Head      slang_persistent/java_mutable               0.80×    0.58×    0.44×
Head      slang_persistent/fjava_persistent           1.02×    0.74×    0.56×
Head      slang_persistent/pcollections_persistent    2.50×    4.21×    4.80×
Head      slang_persistent/ecollections_persistent    0.94×    0.68×    0.52×
Head      slang_persistent/clojure_persistent         0.85×    0.97×    1.00×
Head      slang_persistent/scala_persistent           0.96×    0.69×    0.52×
          
Tail      slang_persistent/java_mutable               0.98×    0.70×    0.52×
Tail      slang_persistent/fjava_persistent          69.30×   61.65×   64.54×
Tail      slang_persistent/pcollections_persistent    7.94×   10.77×   15.30×
Tail      slang_persistent/ecollections_persistent   23.08×  178.94× 5353.95×
Tail      slang_persistent/clojure_persistent         1.23×    0.88×    0.75×
Tail      slang_persistent/scala_persistent           4.15×    6.05×    7.77×
          
Get       slang_persistent/java_mutable               0.77×    0.46×    0.38×
Get       slang_persistent/fjava_persistent          61.60×  114.97×   88.71×
Get       slang_persistent/pcollections_persistent    8.43×   15.06×   18.61×
Get       slang_persistent/ecollections_persistent    0.85×    0.38×    0.36×
Get       slang_persistent/clojure_persistent         0.97×    1.43×    1.49×
Get       slang_persistent/scala_persistent           1.20×    1.20×    0.99×
          
Update    slang_persistent/java_mutable               0.10×    0.05×    0.03×
Update    slang_persistent/fjava_persistent         115.25×  241.74×  245.64×
Update    slang_persistent/pcollections_persistent    2.32×    4.11×    5.46×
Update    slang_persistent/ecollections_persistent   13.21×  154.34× 3096.27×
Update    slang_persistent/clojure_persistent         0.83×    1.25×    1.25×
Update    slang_persistent/scala_persistent           0.98×    1.05×    1.37×
          
Map       slang_persistent/java_mutable_loop          0.69×    0.70×    0.62×
Map       slang_persistent/java_mutable               2.82×    2.47×    2.11×
Map       slang_persistent/ecollections_persistent    1.45×    1.17×    1.17×
Map       slang_persistent/scala_persistent           1.34×    1.56×    1.95×
          
Filter    slang_persistent/java_mutable               2.44×    1.92×    1.45×
Filter    slang_persistent/ecollections_persistent    1.91×    1.37×    1.04×
Filter    slang_persistent/scala_persistent           1.63×    1.68×    1.72×
          
Prepend   slang_persistent/java_mutable               0.38×    0.72×   12.15×
Prepend   slang_persistent/fjava_persistent           1.59×    1.64×    1.18×
Prepend   slang_persistent/pcollections_persistent    1.06×    2.58×    3.10×
Prepend   slang_persistent/ecollections_persistent    2.74×   28.35×  615.48×
Prepend   slang_persistent/clojure_persistent         6.39×  132.62× 3502.23×
Prepend   slang_persistent/scala_persistent           0.26×    0.24×    0.18×
         
Append    slang_persistent/java_mutable               0.25×    0.06×    0.03×
Append    slang_persistent/fjava_persistent           4.99×    1.68×    1.04×
Append    slang_persistent/pcollections_persistent    2.64×    2.06×    2.23×
Append    slang_persistent/ecollections_persistent    8.74×   43.27×  562.24×
Append    slang_persistent/clojure_persistent         1.05×    0.27×    0.19×
Append    slang_persistent/scala_persistent           0.99×    0.27×    0.17×
                                                    
GroupBy   slang_persistent/java_mutable               0.40×    0.91×    0.83×
GroupBy   slang_persistent/scala_persistent           1.47×    1.09×    1.21×
                                                    
Slice     slang_persistent/java_mutable               0.65×    0.56×    0.57×
Slice     slang_persistent/pcollections_persistent    0.57×    0.48×    0.51×
Slice     slang_persistent/clojure_persistent         0.63×    0.53×    0.55×
Slice     slang_persistent/scala_persistent           2.66×    6.17×   10.82×
                                                    
Iterate   slang_persistent/java_mutable               1.10×    0.32×    0.49×
Iterate   slang_persistent/fjava_persistent         422.22×  306.40×  363.16×
Iterate   slang_persistent/pcollections_persistent   12.27×    9.77×   11.87×
Iterate   slang_persistent/ecollections_persistent    2.62×    1.18×    1.68×
Iterate   slang_persistent/clojure_persistent         0.88×    0.84×    1.06×
Iterate   slang_persistent/scala_persistent           1.97×    1.01×    1.12×
```

i.e. this PR made the following methods faster (for `32768` elements, compared to `Scala`)
```java
Create   6.02 / 0.04 = ~150.50× faster
Head     0.52 / 0.45 =   ~1.15× faster
Tail     7.77 / 1.02 =   ~7.61× faster
Get      0.99 / 0.85 =   ~1.16× faster
Update   1.37 / 0.50 =   ~2.74× faster
Map      1.95 / 0.06 =  ~32.50× faster
Filter   1.72 / 0.12 =  ~14.33× faster
Slice   10.82 / 1.61 =   ~6.72× faster
Iterate  1.12 / 1.08 =   ~1.03× faster
```

and memory usages:
```java
for `32` elements
  Java mutable @ ArrayList                            →   504 bytes
  Functional Java persistent @ Seq                    → 3,064 bytes
  PCollections persistent @ TreePVector               → 1,712 bytes
  Eclipse Collections persistent @ ImmutableArrayList →   496 bytes
  Clojure persistent @ PersistentVector               →   704 bytes
  Scala persistent @ Vector                           →   536 bytes
  Javaslang persistent @ Vector                       →   528 bytes

for `1024` elements
  Java mutable @ ArrayList                            →  19,064 bytes
  Functional Java persistent @ Seq                    → 104,760 bytes
  PCollections persistent @ TreePVector               →  55,984 bytes
  Eclipse Collections persistent @ ImmutableArrayList →  19,056 bytes
  Clojure persistent @ PersistentVector               →  20,504 bytes
  Scala persistent @ Vector                           →  19,736 bytes
  Javaslang persistent @ Vector                       →  19,728 bytes

for `32768` elements
  Java mutable @ ArrayList                            →   653,672 bytes
  Functional Java persistent @ Seq                    → 3,408,624 bytes
  PCollections persistent @ TreePVector               → 1,833,376 bytes
  Eclipse Collections persistent @ ImmutableArrayList →   653,664 bytes
  Clojure persistent @ PersistentVector               →   700,168 bytes
  Scala persistent @ Vector                           →   674,824 bytes
  Javaslang persistent @ Vector                       →   674,816 bytes
```

Note: only very simple optimizations were kept, favoring maintainability over raw speed.
Note2: all collections store boxed, non-primitive values for now.