### PR TITLE
Add tests for map with null keys

### DIFF
--- a/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
@@ -954,4 +954,24 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
         final Map<Integer, String> dst = src.removeValues(v -> isDigits.matcher(v).matches());
         assertThat(dst).isEqualTo(emptyIntString().put(10, "a").put(11, "b").put(12, "c").put(13, "d").put(14, "e").put(15, "f"));
     }
+
+    // -- get with nulls
+
+    @Test
+    public void shouldReturnOptionOfNullWhenAccessingKeysSetToNull() {
+        final Map<String, String> map = mapOf("1", null);
+        assertThat(map.get("1")).isEqualTo(Option.some(null));
+    }
+
+    @Test
+    public void shouldReturnOptionOfKeyWhenAccessingPresentKeysInAMapWithNulls () {
+        final Map<String, String> map = mapOf("1", "a").put("2", null);
+        assertThat(map.get("1")).isEqualTo(Option.of("a"));
+    }
+
+    @Test
+    public void shouldReturnNoneWhenAccessingAbsentKeysInAMapWithNulls() {
+        final Map<String, String> map = mapOf("1", "a").put("2", null);
+        assertThat(map.get("3")).isEqualTo(Option.none());
+    }
 }


### PR DESCRIPTION
I ran into a bug in v2.0.3 which caused a TreeMap.get to throw an NPE
when _any_ of the keys were null. These tests show that the bug has been
cleared up as of this commit.

Original report: #1549 