### PR TITLE
Map multimap doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,56 @@ Just a few notes here. In general it is good to look at existing code to get a c
 * Package private classes are used in order to hide non-public API.
 * Inner classes are preferred over package private classes in case of one-to-one dependencies.
 
+### File structure
+
+We organize our classes and interfaces in the following way:
+
+* The Javadoc of the type contains an overview of the new (i.e. not overridden) API declared in the actual type.
+* The type consists of three sections:
+   1. static API
+   2. non-static API
+   3. adjusted return types
+* The methods of each of these sections are alphabetically ordered. 
+
+```java
+/**
+ * Description of this class.
+ * 
+ * <ul>
+ * <li>{@link #containsKey(Object)}}</li>
+ * <li>{@link ...}</li>
+ * </ul>
+ * 
+ * @author ...
+ * @since ...
+ */
+public interface Map<K, V> extends Traversable<Tuple2<K, V>> {
+    
+    // -- static API
+    
+    static <K, V> Tuple2<K, V> entry(K key, V value) { ... }
+    
+    ...
+    
+    // -- non-static API
+
+    @Override
+    default boolean contains(Tuple2<K, V> element) { ... }
+    
+    boolean containsKey(K key);
+    
+    ...
+    
+    // -- Adjusted return types
+
+    @Override
+    Map<K, V> distinct();
+    
+    ...
+    
+}
+```
+
 ### Unit tests
 
 * Public API is tested.

--- a/javaslang/src/main/java/javaslang/Lazy.java
+++ b/javaslang/src/main/java/javaslang/Lazy.java
@@ -53,7 +53,7 @@ public final class Lazy<T> implements Value<T>, Supplier<T>, Serializable {
 
     /**
      * Narrows a widened {@code Lazy<? extends T>} to {@code Lazy<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param lazy A {@code Lazy}.

--- a/javaslang/src/main/java/javaslang/Value.java
+++ b/javaslang/src/main/java/javaslang/Value.java
@@ -128,7 +128,7 @@ public interface Value<T> extends Iterable<T> {
 
     /**
      * Narrows a widened {@code Value<? extends T>} to {@code Value<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param value A {@code Value}.

--- a/javaslang/src/main/java/javaslang/collection/Array.java
+++ b/javaslang/src/main/java/javaslang/collection/Array.java
@@ -66,7 +66,7 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
 
     /**
      * Narrows a widened {@code Array<? extends T>} to {@code Array<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param array An {@code Array}.

--- a/javaslang/src/main/java/javaslang/collection/Collections.java
+++ b/javaslang/src/main/java/javaslang/collection/Collections.java
@@ -181,9 +181,9 @@ final class Collections {
         }
     }
 
-    static <T> Iterator<T> fill(int n, Supplier<? extends T> s) {
-        Objects.requireNonNull(s, "s is null");
-        return tabulate(n, anything -> s.get());
+    static <T> Iterator<T> fill(int n, Supplier<? extends T> supplier) {
+        Objects.requireNonNull(supplier, "supplier is null");
+        return tabulate(n, ignored -> supplier.get());
     }
 
     @SuppressWarnings("unchecked")

--- a/javaslang/src/main/java/javaslang/collection/HashMap.java
+++ b/javaslang/src/main/java/javaslang/collection/HashMap.java
@@ -63,7 +63,7 @@ public final class HashMap<K, V> implements Kind2<HashMap<?, ?>, K, V>, Map<K, V
 
     /**
      * Narrows a widened {@code HashMap<? extends K, ? extends V>} to {@code HashMap<K, V>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param hashMap A {@code HashMap}.

--- a/javaslang/src/main/java/javaslang/collection/HashSet.java
+++ b/javaslang/src/main/java/javaslang/collection/HashSet.java
@@ -63,7 +63,7 @@ public final class HashSet<T> implements Kind1<HashSet<?>, T>, Set<T>, Serializa
 
     /**
      * Narrows a widened {@code HashSet<? extends T>} to {@code HashSet<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param hashSet A {@code HashSet}.

--- a/javaslang/src/main/java/javaslang/collection/IndexedSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/IndexedSeq.java
@@ -29,7 +29,7 @@ public interface IndexedSeq<T> extends Seq<T> {
 
     /**
      * Narrows a widened {@code IndexedSeq<? extends T>} to {@code IndexedSeq<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param indexedSeq An {@code IndexedSeq}.

--- a/javaslang/src/main/java/javaslang/collection/Iterator.java
+++ b/javaslang/src/main/java/javaslang/collection/Iterator.java
@@ -114,7 +114,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
 
     /**
      * Narrows a widened {@code Iterator<? extends T>} to {@code Iterator<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param iterator An {@code Iterator}.

--- a/javaslang/src/main/java/javaslang/collection/LinearSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/LinearSeq.java
@@ -28,7 +28,7 @@ public interface LinearSeq<T> extends Seq<T> {
 
     /**
      * Narrows a widened {@code LinearSeq<? extends T>} to {@code LinearSeq<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param linearSeq A {@code LinearSeq}.

--- a/javaslang/src/main/java/javaslang/collection/LinkedHashMap.java
+++ b/javaslang/src/main/java/javaslang/collection/LinkedHashMap.java
@@ -63,7 +63,7 @@ public final class LinkedHashMap<K, V> implements Kind2<LinkedHashMap<?, ?>, K, 
 
     /**
      * Narrows a widened {@code LinkedHashMap<? extends K, ? extends V>} to {@code LinkedHashMap<K, V>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param linkedHashMap A {@code LinkedHashMap}.

--- a/javaslang/src/main/java/javaslang/collection/LinkedHashSet.java
+++ b/javaslang/src/main/java/javaslang/collection/LinkedHashSet.java
@@ -63,7 +63,7 @@ public final class LinkedHashSet<T> implements Kind1<LinkedHashSet<?>, T>, Set<T
 
     /**
      * Narrows a widened {@code LinkedHashSet<? extends T>} to {@code LinkedHashSet<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param linkedHashSet A {@code LinkedHashSet}.

--- a/javaslang/src/main/java/javaslang/collection/List.java
+++ b/javaslang/src/main/java/javaslang/collection/List.java
@@ -126,7 +126,7 @@ public interface List<T> extends Kind1<List<?>, T>, LinearSeq<T>, Stack<T> {
 
     /**
      * Narrows a widened {@code List<? extends T>} to {@code List<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param list A {@code List}.

--- a/javaslang/src/main/java/javaslang/collection/Multimap.java
+++ b/javaslang/src/main/java/javaslang/collection/Multimap.java
@@ -14,6 +14,60 @@ import java.util.function.*;
 /**
  * An immutable {@code Multimap} interface.
  *
+ * <p>
+ * Basic operations:
+ *
+ * <ul>
+ * <li>{@link #containsKey(Object)}</li>
+ * <li>{@link #containsValue(Object)}</li>
+ * <li>{@link #get(Object)}</li>
+ * <li>{@link #getContainerType()}</li>
+ * <li>{@link #keySet()}</li>
+ * <li>{@link #merge(Multimap)}</li>
+ * <li>{@link #merge(Multimap, BiFunction)}</li>
+ * <li>{@link #put(Object, Object)}</li>
+ * <li>{@link #put(Tuple2)}</li>
+ * <li>{@link #values()}</li>
+ * </ul>
+ *
+ * Conversion:
+ * <ul>
+ * <li>{@link #toJavaMap()}</li>
+ * </ul>
+ *
+ * Filtering:
+ *
+ * <ul>
+ * <li>{@link #filter(BiPredicate)}</li>
+ * <li>{@link #filterKeys(Predicate)}</li>
+ * <li>{@link #filterValues(Predicate)}</li>
+ * <li>{@link #remove(Object)}</li>
+ * <li>{@link #remove(Object, Object)}</li>
+ * <li>{@link #removeAll(BiPredicate)}</li>
+ * <li>{@link #removeAll(Iterable)}</li>
+ * <li>{@link #removeKeys(Predicate)}</li>
+ * <li>{@link #removeValues(Predicate)}</li>
+ * </ul>
+ *
+ * Iteration:
+ *
+ * <ul>
+ * <li>{@link #forEach(BiConsumer)}</li>
+ * <li>{@link #traverse(BiFunction)}</li>
+ * </ul>
+ *
+ * Transformation:
+ *
+ * <ul>
+ * <li>{@link #bimap(Function, Function)}</li>
+ * <li>{@link #flatMap(BiFunction)}</li>
+ * <li>{@link #map(BiFunction)}</li>
+ * <li>{@link #mapValues(Function)}</li>
+ * <li>{@link #transform(Function)}</li>
+ * <li>{@link #unzip(BiFunction)}</li>
+ * <li>{@link #unzip3(BiFunction)}</li>
+ * </ul>
+ *
  * @param <K> Key type
  * @param <V> Value type
  * @author Ruslan Sennov
@@ -43,7 +97,7 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
         private final BiFunction<Traversable<?>, Object, Traversable<?>> remove;
 
         ContainerType(BiFunction<Traversable<?>, Object, Traversable<?>> add,
-                              BiFunction<Traversable<?>, Object, Traversable<?>> remove) {
+                      BiFunction<Traversable<?>, Object, Traversable<?>> remove) {
             this.add = add;
             this.remove = remove;
         }
@@ -56,6 +110,23 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
             return (Traversable<T>) remove.apply(container, elem);
         }
     }
+
+    /**
+     * Narrows a widened {@code Multimap<? extends K, ? extends V>} to {@code Multimap<K, V>}
+     * by performing a type-safe cast. This is eligible because immutable/read-only
+     * collections are covariant.
+     *
+     * @param map A {@code Multimap}.
+     * @param <K> Key type
+     * @param <V> Value type
+     * @return the given {@code map} instance as narrowed type {@code Map<K, V>}.
+     */
+    @SuppressWarnings("unchecked")
+    static <K, V> Multimap<K, V> narrow(Multimap<? extends K, ? extends V> map) {
+        return (Multimap<K, V>) map;
+    }
+
+    // -- non-static API
 
     @Override
     default Traversable<V> apply(K key) {
@@ -74,6 +145,11 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
      */
     <K2, V2> Multimap<K2, V2> bimap(Function<? super K, ? extends K2> keyMapper, Function<? super V, ? extends V2> valueMapper);
 
+    @Override
+    default boolean contains(Tuple2<K, V> element) {
+        return get(element._1).map(v -> Objects.equals(v, element._2)).getOrElse(false);
+    }
+
     /**
      * Returns <code>true</code> if this multimap contains a mapping for the specified key.
      *
@@ -81,8 +157,6 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
      * @return <code>true</code> if this multimap contains a mapping for the specified key
      */
     boolean containsKey(K key);
-
-    ContainerType getContainerType();
 
     /**
      * Returns <code>true</code> if this multimap maps one or more keys to the
@@ -97,6 +171,33 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
     }
 
     /**
+     * Returns a new Multimap consisting of all elements which satisfy the given predicate.
+     *
+     * @param predicate the predicate used to test elements
+     * @return a new Multimap
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    Multimap<K, V> filter(BiPredicate<? super K, ? super V> predicate);
+
+    /**
+     * Returns a new Multimap consisting of all elements with keys which satisfy the given predicate.
+     *
+     * @param predicate the predicate used to test keys of elements
+     * @return a new Multimap
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    Multimap<K, V> filterKeys(Predicate<? super K> predicate);
+
+    /**
+     * Returns a new Multimap consisting of all elements with values which satisfy the given predicate.
+     *
+     * @param predicate the predicate used to test values of elements
+     * @return a new Multimap
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    Multimap<K, V> filterValues(Predicate<? super V> predicate);
+
+    /**
      * FlatMaps this {@code Multimap} to a new {@code Multimap} with different component type.
      *
      * @param mapper A mapper
@@ -106,6 +207,19 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
      * @throws NullPointerException if {@code mapper} is null
      */
     <K2, V2> Multimap<K2, V2> flatMap(BiFunction<? super K, ? super V, ? extends Iterable<Tuple2<K2, V2>>> mapper);
+
+    /**
+     * Performs an action on key, value pair.
+     *
+     * @param action A {@code BiConsumer}
+     * @throws NullPointerException if {@code action} is null
+     */
+    default void forEach(BiConsumer<K, V> action) {
+        Objects.requireNonNull(action, "action is null");
+        for (Tuple2<K, V> t : this) {
+            action.accept(t._1, t._2);
+        }
+    }
 
     /**
      * Returns the {@code Some} of value to which the specified key
@@ -119,11 +233,36 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
     Option<Traversable<V>> get(K key);
 
     /**
+     * Returns the type of the {@code Traversable} value container of this {@code MultiMap}.
+     *
+     * @return an enum value representing the container type
+     */
+    ContainerType getContainerType();
+
+    @Override
+    default boolean hasDefiniteSize() {
+        return true;
+    }
+
+    @Override
+    default boolean isTraversableAgain() {
+        return true;
+    }
+
+    @Override
+    Iterator<Tuple2<K, V>> iterator();
+
+    /**
      * Returns the keys contained in this multimap.
      *
      * @return {@code Set} of the keys contained in this multimap.
      */
     Set<K> keySet();
+
+    @Override
+    default int length() {
+        return size();
+    }
 
     /**
      * Maps the entries of this {@code Multimap} to form a new {@code Multimap}.
@@ -137,6 +276,23 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
     <K2, V2> Multimap<K2, V2> map(BiFunction<? super K, ? super V, Tuple2<K2, V2>> mapper);
 
     /**
+     * Maps the {@code Multimap} entries to a sequence of values.
+     * <p>
+     * Please use {@link #map(BiFunction)} if the result has to be of type {@code Multimap}.
+     *
+     * @param mapper A mapper
+     * @param <U>    Component type
+     * @return A sequence of mapped values.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    default <U> Seq<U> map(Function<? super Tuple2<K, V>, ? extends U> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        // don't remove cast, doesn't compile in Eclipse without it
+        return (Seq<U>) iterator().map(mapper).toStream();
+    }
+
+    /**
      * Maps the values of this {@code Multimap} while preserving the corresponding keys.
      *
      * @param <V2>        the new value type
@@ -145,6 +301,33 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
      * @throws NullPointerException if {@code valueMapper} is null
      */
     <V2> Multimap<K, V2> mapValues(Function<? super V, ? extends V2> valueMapper);
+
+    /**
+     * Creates a new multimap which by merging the entries of {@code this} multimap and {@code that} multimap.
+     * <p>
+     * If collisions occur, the value of {@code this} multimap is taken.
+     *
+     * @param that the other multimap
+     * @return A merged multimap
+     * @throws NullPointerException if that multimap is null
+     */
+    Multimap<K, V> merge(Multimap<? extends K, ? extends V> that);
+
+    /**
+     * Creates a new multimap which by merging the entries of {@code this} multimap and {@code that} multimap.
+     * <p>
+     * Uses the specified collision resolution function if two keys are the same.
+     * The collision resolution function will always take the first argument from <code>this</code> multimap
+     * and the second from <code>that</code> multimap.
+     *
+     * @param <K2>                key type of that Multimap
+     * @param <V2>                value type of that Multimap
+     * @param that                the other multimap
+     * @param collisionResolution the collision resolution function
+     * @return A merged multimap
+     * @throws NullPointerException if that multimap or the given collision resolution function is null
+     */
+    <K2 extends K, V2 extends V> Multimap<K, V> merge(Multimap<K2, V2> that, BiFunction<Traversable<V>, Traversable<V2>, Traversable<V>> collisionResolution);
 
     /**
      * Associates the specified value with the specified key in this multimap.
@@ -185,6 +368,15 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
     Multimap<K, V> remove(K key, V value);
 
     /**
+     * Returns a new Multimap consisting of all elements which do not satisfy the given predicate.
+     *
+     * @param predicate the predicate used to test elements
+     * @return a new Multimap
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    Multimap<K, V> removeAll(BiPredicate<? super K, ? super V> predicate);
+
+    /**
      * Removes the mapping for a key from this multimap if it is present.
      *
      * @param keys keys are to be removed from the multimap
@@ -193,8 +385,43 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
      */
     Multimap<K, V> removeAll(Iterable<? extends K> keys);
 
+    /**
+     * Returns a new Multimap consisting of all elements with keys which do not satisfy the given predicate.
+     *
+     * @param predicate the predicate used to test keys of elements
+     * @return a new Multimap
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    Multimap<K, V> removeKeys(Predicate<? super K> predicate);
+
+    /**
+     * Returns a new Multimap consisting of all elements with values which do not satisfy the given predicate.
+     *
+     * @param predicate the predicate used to test values of elements
+     * @return a new Multimap
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    Multimap<K, V> removeValues(Predicate<? super V> predicate);
+
+    @Override
+    default <U> Seq<U> scanLeft(U zero, BiFunction<? super U, ? super Tuple2<K, V>, ? extends U> operation) {
+        Objects.requireNonNull(operation, "operation is null");
+        return Collections.scanLeft(this, zero, operation, List.empty(), List::prepend, List::reverse);
+    }
+
+    @Override
+    default <U> Seq<U> scanRight(U zero, BiFunction<? super Tuple2<K, V>, ? super U, ? extends U> operation) {
+        Objects.requireNonNull(operation, "operation is null");
+        return Collections.scanRight(this, zero, operation, List.empty(), List::prepend, Function.identity());
+    }
+
     @Override
     int size();
+
+    @Override
+    default Spliterator<Tuple2<K, V>> spliterator() {
+        return Spliterators.spliterator(iterator(), length(), Spliterator.ORDERED | Spliterator.IMMUTABLE);
+    }
 
     /**
      * Converts this Javaslang {@code Map} to a {@code java.util.Map} while preserving characteristics
@@ -227,19 +454,56 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
         return unzip(entry -> unzipper.apply(entry._1, entry._2));
     }
 
+    @Override
+    default <T1, T2> Tuple2<Seq<T1>, Seq<T2>> unzip(Function<? super Tuple2<K, V>, Tuple2<? extends T1, ? extends T2>> unzipper) {
+        Objects.requireNonNull(unzipper, "unzipper is null");
+        return iterator().unzip(unzipper).map(Stream::ofAll, Stream::ofAll);
+    }
+
     default <T1, T2, T3> Tuple3<Seq<T1>, Seq<T2>, Seq<T3>> unzip3(BiFunction<? super K, ? super V, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
         return unzip3(entry -> unzipper.apply(entry._1, entry._2));
     }
 
+    @Override
+    default <T1, T2, T3> Tuple3<Seq<T1>, Seq<T2>, Seq<T3>> unzip3(
+            Function<? super Tuple2<K, V>, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
+        Objects.requireNonNull(unzipper, "unzipper is null");
+        return iterator().unzip3(unzipper).map(Stream::ofAll, Stream::ofAll, Stream::ofAll);
+    }
+
     Traversable<V> values();
 
-    // -- Adjusted return types of Traversable methods
+    @Override
+    default <U> Seq<Tuple2<Tuple2<K, V>, U>> zip(Iterable<? extends U> that) {
+        return zipWith(that, Tuple::of);
+    }
 
     @Override
-    default boolean contains(Tuple2<K, V> element) {
-        return get(element._1).map(v -> Objects.equals(v, element._2)).getOrElse(false);
+    default <U> Seq<Tuple2<Tuple2<K, V>, U>> zipAll(Iterable<? extends U> that, Tuple2<K, V> thisElem, U thatElem) {
+        Objects.requireNonNull(that, "that is null");
+        return Stream.ofAll(iterator().zipAll(that, thisElem, thatElem));
     }
+
+    @Override
+    default <U, R> Seq<R> zipWith(Iterable<? extends U> that, BiFunction<? super Tuple2<K, V>, ? super U, ? extends R> mapper) {
+        Objects.requireNonNull(that, "that is null");
+        Objects.requireNonNull(mapper, "mapper is null");
+        return Stream.ofAll(iterator().zipWith(that, mapper));
+    }
+
+    @Override
+    default Seq<Tuple2<Tuple2<K, V>, Integer>> zipWithIndex() {
+        return zipWithIndex(Tuple::of);
+    }
+
+    @Override
+    default <U> Seq<U> zipWithIndex(BiFunction<? super Tuple2<K, V>, ? super Integer, ? extends U> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        return Stream.ofAll(iterator().zipWithIndex(mapper));
+    }
+
+    // -- Adjusted return types of Traversable methods
 
     @Override
     Multimap<K, V> distinct();
@@ -264,60 +528,6 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
 
     @Override
     Multimap<K, V> filter(Predicate<? super Tuple2<K, V>> predicate);
-
-    /**
-     * Returns a new Multimap consisting of all elements which satisfy the given predicate.
-     *
-     * @param predicate the predicate used to test elements
-     * @return a new Multimap
-     * @throws NullPointerException if {@code predicate} is null
-     */
-    Multimap<K, V> filter(BiPredicate<? super K, ? super V> predicate);
-
-    /**
-     * Returns a new Multimap consisting of all elements with keys which satisfy the given predicate.
-     *
-     * @param predicate the predicate used to test keys of elements
-     * @return a new Multimap
-     * @throws NullPointerException if {@code predicate} is null
-     */
-    Multimap<K, V> filterKeys(Predicate<? super K> predicate);
-
-    /**
-     * Returns a new Multimap consisting of all elements with values which satisfy the given predicate.
-     *
-     * @param predicate the predicate used to test values of elements
-     * @return a new Multimap
-     * @throws NullPointerException if {@code predicate} is null
-     */
-    Multimap<K, V> filterValues(Predicate<? super V> predicate);
-
-    /**
-     * Returns a new Multimap consisting of all elements which do not satisfy the given predicate.
-     *
-     * @param predicate the predicate used to test elements
-     * @return a new Multimap
-     * @throws NullPointerException if {@code predicate} is null
-     */
-    Multimap<K, V> removeAll(BiPredicate<? super K, ? super V> predicate);
-
-    /**
-     * Returns a new Multimap consisting of all elements with keys which do not satisfy the given predicate.
-     *
-     * @param predicate the predicate used to test keys of elements
-     * @return a new Multimap
-     * @throws NullPointerException if {@code predicate} is null
-     */
-    Multimap<K, V> removeKeys(Predicate<? super K> predicate);
-
-    /**
-     * Returns a new Multimap consisting of all elements with values which do not satisfy the given predicate.
-     *
-     * @param predicate the predicate used to test values of elements
-     * @return a new Multimap
-     * @throws NullPointerException if {@code predicate} is null
-     */
-    Multimap<K, V> removeValues(Predicate<? super V> predicate);
 
     /**
      * Flat-maps this entries to a sequence of values.
@@ -349,72 +559,10 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
     Iterator<? extends Multimap<K, V>> grouped(int size);
 
     @Override
-    default boolean hasDefiniteSize() {
-        return true;
-    }
-
-    @Override
     Multimap<K, V> init();
 
     @Override
     Option<? extends Multimap<K, V>> initOption();
-
-    @Override
-    default boolean isTraversableAgain() {
-        return true;
-    }
-
-    @Override
-    Iterator<Tuple2<K, V>> iterator();
-
-    @Override
-    default int length() {
-        return size();
-    }
-
-    /**
-     * Maps the {@code Multimap} entries to a sequence of values.
-     * <p>
-     * Please use {@link #map(BiFunction)} if the result has to be of type {@code Multimap}.
-     *
-     * @param mapper A mapper
-     * @param <U>    Component type
-     * @return A sequence of mapped values.
-     */
-    @SuppressWarnings("unchecked")
-    @Override
-    default <U> Seq<U> map(Function<? super Tuple2<K, V>, ? extends U> mapper) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        // don't remove cast, doesn't compile in Eclipse without it
-        return (Seq<U>) iterator().map(mapper).toStream();
-    }
-
-    /**
-     * Creates a new multimap which by merging the entries of {@code this} multimap and {@code that} multimap.
-     * <p>
-     * If collisions occur, the value of {@code this} multimap is taken.
-     *
-     * @param that the other multimap
-     * @return A merged multimap
-     * @throws NullPointerException if that multimap is null
-     */
-    Multimap<K, V> merge(Multimap<? extends K, ? extends V> that);
-
-    /**
-     * Creates a new multimap which by merging the entries of {@code this} multimap and {@code that} multimap.
-     * <p>
-     * Uses the specified collision resolution function if two keys are the same.
-     * The collision resolution function will always take the first argument from <code>this</code> multimap
-     * and the second from <code>that</code> multimap.
-     *
-     * @param <K2>                key type of that Multimap
-     * @param <V2>                value type of that Multimap
-     * @param that                the other multimap
-     * @param collisionResolution the collision resolution function
-     * @return A merged multimap
-     * @throws NullPointerException if that multimap or the given collision resolution function is null
-     */
-    <K2 extends K, V2 extends V> Multimap<K, V> merge(Multimap<K2, V2> that, BiFunction<Traversable<V>, Traversable<V2>, Traversable<V>> collisionResolution);
 
     @Override
     Tuple2<? extends Multimap<K, V>, ? extends Multimap<K, V>> partition(Predicate<? super Tuple2<K, V>> predicate);
@@ -436,18 +584,6 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
                         BiFunction<? super Tuple2<K, V>, ? super Tuple2<K, V>, ? extends Tuple2<K, V>> operation);
 
     @Override
-    default <U> Seq<U> scanLeft(U zero, BiFunction<? super U, ? super Tuple2<K, V>, ? extends U> operation) {
-        Objects.requireNonNull(operation, "operation is null");
-        return Collections.scanLeft(this, zero, operation, List.empty(), List::prepend, List::reverse);
-    }
-
-    @Override
-    default <U> Seq<U> scanRight(U zero, BiFunction<? super Tuple2<K, V>, ? super U, ? extends U> operation) {
-        Objects.requireNonNull(operation, "operation is null");
-        return Collections.scanRight(this, zero, operation, List.empty(), List::prepend, Function.identity());
-    }
-
-    @Override
     Iterator<? extends Multimap<K, V>> sliding(int size);
 
     @Override
@@ -455,11 +591,6 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
 
     @Override
     Tuple2<? extends Multimap<K, V>, ? extends Multimap<K, V>> span(Predicate<? super Tuple2<K, V>> predicate);
-
-    @Override
-    default Spliterator<Tuple2<K, V>> spliterator() {
-        return Spliterators.spliterator(iterator(), length(), Spliterator.ORDERED | Spliterator.IMMUTABLE);
-    }
 
     @Override
     Multimap<K, V> tail();
@@ -479,58 +610,4 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
     @Override
     Multimap<K, V> takeWhile(Predicate<? super Tuple2<K, V>> predicate);
 
-    @Override
-    default <T1, T2> Tuple2<Seq<T1>, Seq<T2>> unzip(Function<? super Tuple2<K, V>, Tuple2<? extends T1, ? extends T2>> unzipper) {
-        Objects.requireNonNull(unzipper, "unzipper is null");
-        return iterator().unzip(unzipper).map(Stream::ofAll, Stream::ofAll);
-    }
-
-    @Override
-    default <T1, T2, T3> Tuple3<Seq<T1>, Seq<T2>, Seq<T3>> unzip3(
-            Function<? super Tuple2<K, V>, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
-        Objects.requireNonNull(unzipper, "unzipper is null");
-        return iterator().unzip3(unzipper).map(Stream::ofAll, Stream::ofAll, Stream::ofAll);
-    }
-
-    @Override
-    default <U> Seq<Tuple2<Tuple2<K, V>, U>> zip(Iterable<? extends U> that) {
-        return zipWith(that, Tuple::of);
-    }
-
-    @Override
-    default <U, R> Seq<R> zipWith(Iterable<? extends U> that, BiFunction<? super Tuple2<K, V>, ? super U, ? extends R> mapper) {
-        Objects.requireNonNull(that, "that is null");
-        Objects.requireNonNull(mapper, "mapper is null");
-        return Stream.ofAll(iterator().zipWith(that, mapper));
-    }
-
-    @Override
-    default <U> Seq<Tuple2<Tuple2<K, V>, U>> zipAll(Iterable<? extends U> that, Tuple2<K, V> thisElem, U thatElem) {
-        Objects.requireNonNull(that, "that is null");
-        return Stream.ofAll(iterator().zipAll(that, thisElem, thatElem));
-    }
-
-    @Override
-    default Seq<Tuple2<Tuple2<K, V>, Integer>> zipWithIndex() {
-        return zipWithIndex(Tuple::of);
-    }
-
-    @Override
-    default <U> Seq<U> zipWithIndex(BiFunction<? super Tuple2<K, V>, ? super Integer, ? extends U> mapper) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        return Stream.ofAll(iterator().zipWithIndex(mapper));
-    }
-
-    /**
-     * Performs an action on key, value pair.
-     *
-     * @param action A {@code BiConsumer}
-     * @throws NullPointerException if {@code action} is null
-     */
-    default void forEach(BiConsumer<K, V> action) {
-        Objects.requireNonNull(action, "action is null");
-        for (Tuple2<K, V> t : this) {
-            action.accept(t._1, t._2);
-        }
-    }
 }

--- a/javaslang/src/main/java/javaslang/collection/PriorityQueue.java
+++ b/javaslang/src/main/java/javaslang/collection/PriorityQueue.java
@@ -149,7 +149,7 @@ public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> 
 
     /**
      * Narrows a widened {@code PriorityQueue<? extends T>} to {@code PriorityQueue<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param queue An {@code PriorityQueue}.

--- a/javaslang/src/main/java/javaslang/collection/Queue.java
+++ b/javaslang/src/main/java/javaslang/collection/Queue.java
@@ -95,7 +95,7 @@ public final class Queue<T> extends AbstractsQueue<T, Queue<T>> implements Linea
 
     /**
      * Narrows a widened {@code Queue<? extends T>} to {@code Queue<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param queue An {@code Queue}.

--- a/javaslang/src/main/java/javaslang/collection/Seq.java
+++ b/javaslang/src/main/java/javaslang/collection/Seq.java
@@ -21,10 +21,17 @@ import java.util.function.Predicate;
 /**
  * Interface for immutable sequential data structures.
  * <p>
- * Creation:
+ * Basic operations:
  *
  * <ul>
+ * <li>{@link #append(Object)}</li>
+ * <li>{@link #appendAll(Iterable)}</li>
+ * <li>{@link #insert(int, Object)}</li>
+ * <li>{@link #insertAll(int, Iterable)}</li>
+ * <li>{@link #prepend(Object)}</li>
+ * <li>{@link #prependAll(Iterable)}</li>
  * <li>{@link #unit(Iterable)}</li>
+ * <li>{@link #update(int, Object)}</li>
  * </ul>
  *
  * Filtering:
@@ -36,18 +43,6 @@ import java.util.function.Predicate;
  * <li>{@link #removeAt(int)}</li>
  * <li>{@link #removeFirst(Predicate)}</li>
  * <li>{@link #removeLast(Predicate)}</li>
- * </ul>
- *
- * Mutation:
- *
- * <ul>
- * <li>{@link #append(Object)}</li>
- * <li>{@link #appendAll(Iterable)}</li>
- * <li>{@link #insert(int, Object)}</li>
- * <li>{@link #insertAll(int, Iterable)}</li>
- * <li>{@link #prepend(Object)}</li>
- * <li>{@link #prependAll(Iterable)}</li>
- * <li>{@link #update(int, Object)}</li>
  * </ul>
  *
  * Selection:
@@ -100,7 +95,7 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T> {
 
     /**
      * Narrows a widened {@code Seq<? extends T>} to {@code Seq<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param seq A {@code Seq}.

--- a/javaslang/src/main/java/javaslang/collection/Set.java
+++ b/javaslang/src/main/java/javaslang/collection/Set.java
@@ -31,7 +31,7 @@ public interface Set<T> extends Traversable<T>, Function1<T, Boolean> {
 
     /**
      * Narrows a widened {@code Set<? extends T>} to {@code Set<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param set A {@code Set}.

--- a/javaslang/src/main/java/javaslang/collection/SortedMap.java
+++ b/javaslang/src/main/java/javaslang/collection/SortedMap.java
@@ -26,7 +26,7 @@ public interface SortedMap<K, V> extends Map<K, V> {
 
     /**
      * Narrows a widened {@code SortedMap<? extends K, ? extends V>} to {@code SortedMap<K, V>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      * <p>
      * CAUTION: If {@code K} is narrowed, the underlying {@code Comparator} might fail!

--- a/javaslang/src/main/java/javaslang/collection/SortedSet.java
+++ b/javaslang/src/main/java/javaslang/collection/SortedSet.java
@@ -29,7 +29,7 @@ public interface SortedSet<T> extends Set<T> {
 
     /**
      * Narrows a widened {@code SortedSet<? extends T>} to {@code SortedSet<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      * <p>
      * CAUTION: The underlying {@code Comparator} might fail!

--- a/javaslang/src/main/java/javaslang/collection/Stack.java
+++ b/javaslang/src/main/java/javaslang/collection/Stack.java
@@ -37,7 +37,7 @@ public interface Stack<T> {
 
     /**
      * Narrows a widened {@code Stack<? extends T>} to {@code Stack<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param stack A {@code Stack}.

--- a/javaslang/src/main/java/javaslang/collection/Stream.java
+++ b/javaslang/src/main/java/javaslang/collection/Stream.java
@@ -220,7 +220,7 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
 
     /**
      * Narrows a widened {@code Stream<? extends T>} to {@code Stream<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param stream A {@code Stream}.

--- a/javaslang/src/main/java/javaslang/collection/Traversable.java
+++ b/javaslang/src/main/java/javaslang/collection/Traversable.java
@@ -139,7 +139,7 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
 
     /**
      * Narrows a widened {@code Traversable<? extends T>} to {@code Traversable<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param traversable An {@code Traversable}.

--- a/javaslang/src/main/java/javaslang/collection/Tree.java
+++ b/javaslang/src/main/java/javaslang/collection/Tree.java
@@ -61,7 +61,7 @@ public interface Tree<T> extends Traversable<T> {
 
     /**
      * Narrows a widened {@code Tree<? extends T>} to {@code Tree<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param tree An {@code Tree}.

--- a/javaslang/src/main/java/javaslang/collection/TreeMap.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeMap.java
@@ -102,7 +102,7 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
 
     /**
      * Narrows a widened {@code TreeMap<? extends K, ? extends V>} to {@code TreeMap<K, V>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      * <p>
      * CAUTION: If {@code K} is narrowed, the underlying {@code Comparator} might fail!

--- a/javaslang/src/main/java/javaslang/collection/TreeSet.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeSet.java
@@ -83,7 +83,7 @@ public final class TreeSet<T> implements Kind1<TreeSet<?>, T>, SortedSet<T>, Ser
 
     /**
      * Narrows a widened {@code TreeSet<? extends T>} to {@code TreeSet<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      * <p>
      * CAUTION: The underlying {@code Comparator} might fail!

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -81,7 +81,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     /**
      * Narrows a widened {@code Vector<? extends T>} to {@code Vector<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param vector An {@code Vector}.

--- a/javaslang/src/main/java/javaslang/concurrent/Future.java
+++ b/javaslang/src/main/java/javaslang/concurrent/Future.java
@@ -275,7 +275,7 @@ public interface Future<T> extends Value<T> {
 
     /**
      * Narrows a widened {@code Future<? extends T>} to {@code Future<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param future A {@code Future}.

--- a/javaslang/src/main/java/javaslang/concurrent/Promise.java
+++ b/javaslang/src/main/java/javaslang/concurrent/Promise.java
@@ -145,7 +145,7 @@ public interface Promise<T> {
 
     /**
      * Narrows a widened {@code Promise<? extends T>} to {@code Promise<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param promise A {@code Promise}.

--- a/javaslang/src/main/java/javaslang/control/Either.java
+++ b/javaslang/src/main/java/javaslang/control/Either.java
@@ -70,7 +70,7 @@ public interface Either<L, R> extends Value<R> {
 
     /**
      * Narrows a widened {@code Either<? extends L, ? extends R>} to {@code Either<L, R>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param either A {@code Either}.

--- a/javaslang/src/main/java/javaslang/control/Option.java
+++ b/javaslang/src/main/java/javaslang/control/Option.java
@@ -106,7 +106,7 @@ public interface Option<T> extends Value<T> {
 
     /**
      * Narrows a widened {@code Option<? extends T>} to {@code Option<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param option A {@code Option}.
@@ -151,11 +151,11 @@ public interface Option<T> extends Value<T> {
      * @param <T>      type of the value
      * @return {@code Some(optional.get())} if value is Java {@code Optional} is present, {@code None} otherwise
      */
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     static <T> Option<T> ofOptional(Optional<? extends T> optional) {
         Objects.requireNonNull(optional, "optional is null");
         return optional.isPresent() ? of(optional.get()) : none();
     }
-
 
     /**
      * Returns true, if this is {@code None}, otherwise false, if this is {@code Some}.

--- a/javaslang/src/main/java/javaslang/control/Try.java
+++ b/javaslang/src/main/java/javaslang/control/Try.java
@@ -102,7 +102,7 @@ public interface Try<T> extends Value<T> {
 
     /**
      * Narrows a widened {@code Try<? extends T>} to {@code Try<T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param t   A {@code Try}.

--- a/javaslang/src/main/java/javaslang/control/Validation.java
+++ b/javaslang/src/main/java/javaslang/control/Validation.java
@@ -132,7 +132,7 @@ public interface Validation<E, T> extends Value<T> {
 
     /**
      * Narrows a widened {@code Validation<? extends E, ? extends T>} to {@code Validation<E, T>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param validation A {@code Validation}.


### PR DESCRIPTION
In the first commit d805e42 I added javadoc to Map and Multimap and reordered the methods. The underlying coding convention was added to CONTRIBUTING.md. This commit includes a minor change to a method parameter name.

In the second commit 633e447 I made a minor change to one javadoc sentence that is used throughout most of the Javaslang types.