### PR TITLE
Removed abstractmultimap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,8 @@ Note: Detailed information about performing a release can be found in the SCM se
 * Commits do not mix change sets of different domains/purpose.
 * Commit messages provide enough detail to extract a changelog for a new release.
 
+_**Note:** We develop in IntelliJ IDEA. Please don't forget to check before a release that the latest Eclipse also has no compiler errors._ 
+
 ### Branching Model
 
 We following a simple git workflow/branching model:

--- a/javaslang/src/main/java/javaslang/collection/AbstractMultimap.java
+++ b/javaslang/src/main/java/javaslang/collection/AbstractMultimap.java
@@ -26,18 +26,6 @@ import java.util.function.*;
  */
 abstract class AbstractMultimap<K, V, M extends Multimap<K, V>> implements Multimap<K, V> {
 
-    @Override
-    public <K2, V2> Multimap<K2, V2> map(BiFunction<? super K, ? super V, Tuple2<K2, V2>> mapper) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        return foldLeft(this.emptyInstance(), (acc, entry) -> acc.put(mapper.apply(entry._1, entry._2)));
-    }
-
-    @Override
-    public <V2> Multimap<K, V2> mapValues(Function<? super V, ? extends V2> valueMapper) {
-        Objects.requireNonNull(valueMapper, "valueMapper is null");
-        return map((k, v) -> Tuple.of(k, valueMapper.apply(v)));
-    }
-
     @SuppressWarnings("unchecked")
     @Override
     public M put(K key, V value) {

--- a/javaslang/src/main/java/javaslang/collection/HashMultimap.java
+++ b/javaslang/src/main/java/javaslang/collection/HashMultimap.java
@@ -21,7 +21,7 @@ import java.util.stream.Collector;
  *
  * @param <K> Key type
  * @param <V> Value type
- * @author Ruslan Sennov
+ * @author Ruslan Sennov, Daniel Dietrich
  * @since 2.1.0
  */
 public final class HashMultimap<K, V> implements Multimap<K, V>, Serializable {
@@ -229,7 +229,7 @@ public final class HashMultimap<K, V> implements Multimap<K, V>, Serializable {
 
     @Override
     public String stringPrefix() {
-        return getClass().getSimpleName() + "[" + emptyContainer.get().stringPrefix() + "]";
+        return "HashMultimap[" + emptyContainer.get().stringPrefix() + "]";
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/LinkedHashMultimap.java
+++ b/javaslang/src/main/java/javaslang/collection/LinkedHashMultimap.java
@@ -192,12 +192,12 @@ public final class LinkedHashMultimap<K, V> implements Multimap<K, V>, Serializa
 
     @Override
     public <K2, V2> LinkedHashMultimap<K2, V2> map(BiFunction<? super K, ? super V, Tuple2<K2, V2>> mapper) {
-        return null; // TODO ...
+        return Multimaps.map(this, emptyInstance(), mapper);
     }
 
     @Override
     public <V2> LinkedHashMultimap<K, V2> mapValues(Function<? super V, ? extends V2> valueMapper) {
-        return null; // TODO ...
+        return Multimaps.mapValues(this, emptyInstance(), valueMapper);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/LinkedHashMultimap.java
+++ b/javaslang/src/main/java/javaslang/collection/LinkedHashMultimap.java
@@ -5,7 +5,6 @@
  */
 package javaslang.collection;
 
-import javaslang.Tuple;
 import javaslang.Tuple2;
 import javaslang.collection.Multimaps.OfMap;
 import javaslang.control.Option;
@@ -23,19 +22,19 @@ import java.util.stream.Collector;
  *
  * @param <K> Key type
  * @param <V> Value type
- * @author Ruslan Sennov
+ * @author Ruslan Sennov, Daniel Dietrich
  * @since 2.1.0
  */
 public final class LinkedHashMultimap<K, V> implements Multimap<K, V>, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private final Map<K, Traversable<V>> back;
+    private final Map<K, Traversable<V>> delegate;
     private final ContainerType containerType;
     private final Traversable<V> emptyContainer;
 
-    private LinkedHashMultimap(Map<K, Traversable<V>> back, ContainerType containerType, Traversable<V> emptyContainer) {
-        this.back = back;
+    private LinkedHashMultimap(Map<K, Traversable<V>> delegate, ContainerType containerType, Traversable<V> emptyContainer) {
+        this.delegate = delegate;
         this.containerType = containerType;
         this.emptyContainer = emptyContainer;
     }
@@ -155,7 +154,7 @@ public final class LinkedHashMultimap<K, V> implements Multimap<K, V>, Serializa
 
     @Override
     public boolean containsKey(K key) {
-        return back.containsKey(key);
+        return delegate.containsKey(key);
     }
 
     @Override
@@ -165,22 +164,22 @@ public final class LinkedHashMultimap<K, V> implements Multimap<K, V>, Serializa
 
     @Override
     public Option<Traversable<V>> get(K key) {
-        return back.get(key);
+        return delegate.get(key);
     }
 
     @Override
     public Set<K> keySet() {
-        return back.keySet();
+        return delegate.keySet();
     }
 
     @Override
     public int size() {
-        return Multimaps.size(back);
+        return Multimaps.size(delegate);
     }
 
     @Override
     public String stringPrefix() {
-        return getClass().getSimpleName() + "[" + emptyContainer.stringPrefix() + "]";
+        return "LinkedHashMultimap[" + emptyContainer.stringPrefix() + "]";
     }
 
     @Override
@@ -190,7 +189,7 @@ public final class LinkedHashMultimap<K, V> implements Multimap<K, V>, Serializa
 
     @Override
     public Traversable<V> values() {
-        return Iterator.concat(back.values()).toStream();
+        return Iterator.concat(delegate.values()).toStream();
     }
 
     // -- Adjusted return types of Multimap
@@ -230,7 +229,7 @@ public final class LinkedHashMultimap<K, V> implements Multimap<K, V>, Serializa
             return true;
         } else if (o instanceof LinkedHashMultimap) {
             final LinkedHashMultimap<?, ?> that = (LinkedHashMultimap<?, ?>) o;
-            return this.back.equals(that.back);
+            return this.delegate.equals(that.delegate);
         } else {
             return false;
         }
@@ -238,7 +237,7 @@ public final class LinkedHashMultimap<K, V> implements Multimap<K, V>, Serializa
 
     @Override
     public int hashCode() {
-        return back.hashCode();
+        return delegate.hashCode();
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/LinkedHashMultimap.java
+++ b/javaslang/src/main/java/javaslang/collection/LinkedHashMultimap.java
@@ -154,25 +154,8 @@ public final class LinkedHashMultimap<K, V> implements Multimap<K, V>, Serializa
     // -- non-static API
 
     @Override
-    public <K2, V2> LinkedHashMultimap<K2, V2> bimap(Function<? super K, ? extends K2> keyMapper, Function<? super V, ? extends V2> valueMapper) {
-        return Multimaps.bimap(this, builder()::ofEntries, keyMapper, valueMapper);
-    }
-
-    @Override
     public boolean containsKey(K key) {
         return back.containsKey(key);
-    }
-
-    // TODO: Move this implementation to Multimaps and use Map Builder instead of Multimap.put
-    @Override
-    public <K2, V2> LinkedHashMultimap<K2, V2> flatMap(BiFunction<? super K, ? super V, ? extends Iterable<Tuple2<K2, V2>>> mapper) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        return foldLeft(emptyInstance(), (acc, entry) -> {
-            for (Tuple2<? extends K2, V2> mappedEntry : mapper.apply(entry._1, entry._2)) {
-                acc = acc.put(mappedEntry);
-            }
-            return acc;
-        });
     }
 
     @Override
@@ -191,18 +174,13 @@ public final class LinkedHashMultimap<K, V> implements Multimap<K, V>, Serializa
     }
 
     @Override
-    public <K2, V2> LinkedHashMultimap<K2, V2> map(BiFunction<? super K, ? super V, Tuple2<K2, V2>> mapper) {
-        return Multimaps.map(this, emptyInstance(), mapper);
-    }
-
-    @Override
-    public <V2> LinkedHashMultimap<K, V2> mapValues(Function<? super V, ? extends V2> valueMapper) {
-        return Multimaps.mapValues(this, emptyInstance(), valueMapper);
-    }
-
-    @Override
     public int size() {
         return Multimaps.size(back);
+    }
+
+    @Override
+    public String stringPrefix() {
+        return getClass().getSimpleName() + "[" + emptyContainer.stringPrefix() + "]";
     }
 
     @Override
@@ -213,6 +191,35 @@ public final class LinkedHashMultimap<K, V> implements Multimap<K, V>, Serializa
     @Override
     public Traversable<V> values() {
         return Iterator.concat(back.values()).toStream();
+    }
+
+    // -- Adjusted return types of Multimap
+
+    @Override
+    public <K2, V2> LinkedHashMultimap<K2, V2> bimap(Function<? super K, ? extends K2> keyMapper, Function<? super V, ? extends V2> valueMapper) {
+        return Multimaps.bimap(this, builder()::ofEntries, keyMapper, valueMapper);
+    }
+
+    // TODO: Move this implementation to Multimaps and use Map Builder instead of Multimap.put
+    @Override
+    public <K2, V2> LinkedHashMultimap<K2, V2> flatMap(BiFunction<? super K, ? super V, ? extends Iterable<Tuple2<K2, V2>>> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        return foldLeft(emptyInstance(), (acc, entry) -> {
+            for (Tuple2<? extends K2, V2> mappedEntry : mapper.apply(entry._1, entry._2)) {
+                acc = acc.put(mappedEntry);
+            }
+            return acc;
+        });
+    }
+
+    @Override
+    public <K2, V2> LinkedHashMultimap<K2, V2> map(BiFunction<? super K, ? super V, Tuple2<K2, V2>> mapper) {
+        return Multimaps.map(this, emptyInstance(), mapper);
+    }
+
+    @Override
+    public <V2> LinkedHashMultimap<K, V2> mapValues(Function<? super V, ? extends V2> valueMapper) {
+        return Multimaps.mapValues(this, emptyInstance(), valueMapper);
     }
 
     // -- Object
@@ -232,11 +239,6 @@ public final class LinkedHashMultimap<K, V> implements Multimap<K, V>, Serializa
     @Override
     public int hashCode() {
         return back.hashCode();
-    }
-
-    @Override
-    public String stringPrefix() {
-        return getClass().getSimpleName() + "[" + emptyContainer.stringPrefix() + "]";
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/LinkedHashMultimap.java
+++ b/javaslang/src/main/java/javaslang/collection/LinkedHashMultimap.java
@@ -5,16 +5,17 @@
  */
 package javaslang.collection;
 
+import javaslang.Tuple;
 import javaslang.Tuple2;
+import javaslang.collection.Multimaps.OfMap;
+import javaslang.control.Option;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Objects;
-import java.util.function.BiConsumer;
-import java.util.function.BinaryOperator;
-import java.util.function.Function;
-import java.util.function.Supplier;
+import java.util.function.*;
 import java.util.stream.Collector;
 
 /**
@@ -25,105 +26,96 @@ import java.util.stream.Collector;
  * @author Ruslan Sennov
  * @since 2.1.0
  */
-public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, LinkedHashMultimap<K, V>> implements Serializable {
+public final class LinkedHashMultimap<K, V> implements Multimap<K, V>, Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    private final Map<K, Traversable<V>> back;
+    private final ContainerType containerType;
+    private final Traversable<V> emptyContainer;
+
+    private LinkedHashMultimap(Map<K, Traversable<V>> back, ContainerType containerType, Traversable<V> emptyContainer) {
+        this.back = back;
+        this.containerType = containerType;
+        this.emptyContainer = emptyContainer;
+    }
+
+    // -- static API
+
     public static <V> Builder<V> withSeq() {
-        return new Builder<>(ContainerType.SEQ, List::empty);
+        return new Builder<>(ContainerType.SEQ, List.empty());
     }
 
     public static <V> Builder<V> withSet() {
-        return new Builder<>(ContainerType.SET, HashSet::empty);
+        return new Builder<>(ContainerType.SET, HashSet.empty());
     }
 
     public static <V extends Comparable<? super V>> Builder<V> withSortedSet() {
-        return new Builder<>(ContainerType.SORTED_SET, TreeSet::empty);
+        return new Builder<>(ContainerType.SORTED_SET, TreeSet.empty());
     }
 
     public static <V> Builder<V> withSortedSet(Comparator<? super V> comparator) {
-        return new Builder<>(ContainerType.SORTED_SET, () -> TreeSet.empty(comparator));
+        return new Builder<>(ContainerType.SORTED_SET, TreeSet.empty(comparator));
     }
 
-    public static class Builder<V> {
+    public static class Builder<V> extends Multimaps.Builder<V> {
 
-        private final ContainerType containerType;
-        private final SerializableSupplier<Traversable<?>> emptyContainer;
-
-        private Builder(ContainerType containerType, SerializableSupplier<Traversable<?>> emptyContainer) {
-            this.containerType = containerType;
-            this.emptyContainer = emptyContainer;
+        private Builder(ContainerType containerType, Traversable<V> emptyContainer) {
+            super(containerType, emptyContainer);
         }
 
+        @Override
         public <K, V2 extends V> LinkedHashMultimap<K, V2> empty() {
-            return new LinkedHashMultimap<>(LinkedHashMap.empty(), containerType, emptyContainer);
+            return ofMap(emptyMap());
         }
 
-        public <K, V2 extends V> LinkedHashMultimap<K, V2> ofEntries(Iterable<? extends Tuple2<? extends K, ? extends V2>> entries) {
-            Objects.requireNonNull(entries, "entries is null");
-            LinkedHashMultimap<K, V2> result = empty();
-            for (Tuple2<? extends K, ? extends V2> entry : entries) {
-                result = result.put(entry._1, entry._2);
-            }
-            return result;
-        }
-
-        @SafeVarargs
-        public final <K, V2 extends V> LinkedHashMultimap<K, V2> ofEntries(Tuple2<? extends K, ? extends V2>... entries) {
-            Objects.requireNonNull(entries, "entries is null");
-            LinkedHashMultimap<K, V2> result = empty();
-            for (Tuple2<? extends K, ? extends V2> entry : entries) {
-                result = result.put(entry._1, entry._2);
-            }
-            return result;
-        }
-
-        @SafeVarargs
-        public final <K, V2 extends V> LinkedHashMultimap<K, V2> ofEntries(java.util.Map.Entry<? extends K, ? extends V2>... entries) {
-            Objects.requireNonNull(entries, "entries is null");
-            LinkedHashMultimap<K, V2> result = empty();
-            for (java.util.Map.Entry<? extends K, ? extends V2> entry : entries) {
-                result = result.put(entry.getKey(), entry.getValue());
-            }
-            return result;
-        }
-
-        @SuppressWarnings("unchecked")
-        public <K, V2 extends V> LinkedHashMultimap<K, V2> tabulate(int n, Function<? super Integer, ? extends Tuple2<? extends K, ? extends V2>> f) {
-            Objects.requireNonNull(f, "f is null");
-            return ofEntries(Collections.tabulate(n, (Function<? super Integer, ? extends Tuple2<K, V2>>) f));
-        }
-
-        @SuppressWarnings("unchecked")
-        public <K, V2 extends V> LinkedHashMultimap<K, V2> fill(int n, Supplier<? extends Tuple2<? extends K, ? extends V2>> s) {
-            Objects.requireNonNull(s, "s is null");
-            return ofEntries(Collections.fill(n, (Supplier<? extends Tuple2<K, V2>>) s));
-        }
-
-        public <K, V2 extends V> LinkedHashMultimap<K, V2> of(K key, V2 value) {
-            final LinkedHashMultimap<K, V2> e = empty();
-            return e.put(key, value);
-        }
-
-        public <K, V2 extends V> LinkedHashMultimap<K, V2> of(Tuple2<? extends K, ? extends V2> entry) {
-            final LinkedHashMultimap<K, V2> e = empty();
-            return e.put(entry._1, entry._2);
-        }
-
+        @Override
         @SuppressWarnings("unchecked")
         public <K, V2 extends V> LinkedHashMultimap<K, V2> of(Object... pairs) {
-            Objects.requireNonNull(pairs, "pairs is null");
-            if ((pairs.length & 1) != 0) {
-                throw new IllegalArgumentException("Odd length of key-value pairs list");
-            }
-            LinkedHashMultimap<K, V2> result = empty();
-            for (int i = 0; i < pairs.length; i += 2) {
-                result = result.put((K) pairs[i], (V2) pairs[i + 1]);
-            }
-            return result;
+            final Entries<K, V2> entries = new Entries(pairs);
+            return build(entries, entries::getKey, entries::getValue, this::ofMap);
         }
 
-        public <K, V2 extends V> Collector<Tuple2<K, V2>, ArrayList<Tuple2<K, V2>>, Multimap<K, V2>> collector() {
+        @Override
+        public <K, V2 extends V> LinkedHashMultimap<K, V2> of(K key, V2 value) {
+            return empty().put(key, value);
+        }
+
+        @Override
+        public <K, V2 extends V> LinkedHashMultimap<K, V2> of(Tuple2<? extends K, ? extends V2> entry) {
+            return empty().put(entry);
+        }
+
+        @Override
+        public <K, V2 extends V> LinkedHashMultimap<K, V2> ofEntries(Iterable<? extends Tuple2<? extends K, ? extends V2>> entries) {
+            return build(entries, Tuple2::_1, Tuple2::_2, (OfMap<K, V2, LinkedHashMultimap<K, V2>>) this::ofMap);
+        }
+
+        @Override
+        @SafeVarargs
+        public final <K, V2 extends V> LinkedHashMultimap<K, V2> ofEntries(Tuple2<? extends K, ? extends V2>... entries) {
+            return ofEntries(Iterator.of(entries));
+        }
+
+        @Override
+        @SafeVarargs
+        public final <K, V2 extends V> LinkedHashMultimap<K, V2> ofEntries(java.util.Map.Entry<? extends K, ? extends V2>... entries) {
+            return build(Iterator.of(entries), java.util.Map.Entry::getKey, java.util.Map.Entry::getValue, (OfMap<K, V2, LinkedHashMultimap<K, V2>>) this::ofMap);
+        }
+
+        @Override
+        public <K, V2 extends V> LinkedHashMultimap<K, V2> fill(int n, Supplier<Tuple2<? extends K, ? extends V2>> supplier) {
+            Objects.requireNonNull(supplier, "s is null");
+            return ofEntries(Collections.fill(n, supplier));
+        }
+
+        @Override
+        public <K, V2 extends V> LinkedHashMultimap<K, V2> tabulate(int n, Function<? super Integer, Tuple2<? extends K, ? extends V2>> f) {
+            return ofEntries(Collections.tabulate(n, f));
+        }
+
+        @Override
+        public <K, V2 extends V> Collector<Tuple2<K, V2>, ArrayList<Tuple2<K, V2>>, LinkedHashMultimap<K, V2>> collector() {
             final Supplier<ArrayList<Tuple2<K, V2>>> supplier = ArrayList::new;
             final BiConsumer<ArrayList<Tuple2<K, V2>>, Tuple2<K, V2>> accumulator = ArrayList::add;
             final BinaryOperator<ArrayList<Tuple2<K, V2>>> combiner = (left, right) -> {
@@ -132,11 +124,21 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
             };
             return Collector.of(supplier, accumulator, combiner, this::ofEntries);
         }
+
+        @Override
+        <K, V2 extends V> Map<K, Traversable<V2>> emptyMap() {
+            return LinkedHashMap.empty();
+        }
+
+        @Override
+        <K, V2 extends V> LinkedHashMultimap<K, V2> ofMap(Map<K, Traversable<V2>> back) {
+            return new LinkedHashMultimap<>(back, containerType(), emptyContainer());
+        }
     }
 
     /**
      * Narrows a widened {@code HashMultimap<? extends K, ? extends V>} to {@code HashMultimap<K, V>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param map A {@code Map}.
@@ -149,24 +151,107 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
         return (LinkedHashMultimap<K, V>) map;
     }
 
-    private LinkedHashMultimap(Map<K, Traversable<V>> back, ContainerType containerType, SerializableSupplier<Traversable<?>> emptyContainer) {
-        super(back, containerType, emptyContainer);
+    // -- non-static API
+
+    @Override
+    public <K2, V2> LinkedHashMultimap<K2, V2> bimap(Function<? super K, ? extends K2> keyMapper, Function<? super V, ? extends V2> valueMapper) {
+        return Multimaps.bimap(this, builder()::ofEntries, keyMapper, valueMapper);
     }
 
     @Override
-    protected <K2, V2> Map<K2, V2> emptyMapSupplier() {
-        return LinkedHashMap.empty();
+    public boolean containsKey(K key) {
+        return back.containsKey(key);
     }
 
-    @SuppressWarnings("unchecked")
+    // TODO: Move this implementation to Multimaps and use Map Builder instead of Multimap.put
     @Override
-    protected <K2, V2> LinkedHashMultimap<K2, V2> emptyInstance() {
-        return new LinkedHashMultimap<>(LinkedHashMap.empty(), getContainerType(), emptyContainer);
+    public <K2, V2> LinkedHashMultimap<K2, V2> flatMap(BiFunction<? super K, ? super V, ? extends Iterable<Tuple2<K2, V2>>> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        return foldLeft(emptyInstance(), (acc, entry) -> {
+            for (Tuple2<? extends K2, V2> mappedEntry : mapper.apply(entry._1, entry._2)) {
+                acc = acc.put(mappedEntry);
+            }
+            return acc;
+        });
     }
 
     @Override
-    protected <K2, V2> LinkedHashMultimap<K2, V2> createFromMap(Map<K2, Traversable<V2>> back) {
-        return new LinkedHashMultimap<>(back, getContainerType(), emptyContainer);
+    public ContainerType getContainerType() {
+        return containerType;
     }
 
+    @Override
+    public Option<Traversable<V>> get(K key) {
+        return back.get(key);
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return back.keySet();
+    }
+
+    @Override
+    public <K2, V2> LinkedHashMultimap<K2, V2> map(BiFunction<? super K, ? super V, Tuple2<K2, V2>> mapper) {
+        return null; // TODO ...
+    }
+
+    @Override
+    public <V2> LinkedHashMultimap<K, V2> mapValues(Function<? super V, ? extends V2> valueMapper) {
+        return null; // TODO ...
+    }
+
+    @Override
+    public int size() {
+        return Multimaps.size(back);
+    }
+
+    @Override
+    public java.util.Map<K, Collection<V>> toJavaMap() {
+        return Multimaps.toJavaMap(this);
+    }
+
+    @Override
+    public Traversable<V> values() {
+        return Iterator.concat(back.values()).toStream();
+    }
+
+    // -- Object
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        } else if (o instanceof LinkedHashMultimap) {
+            final LinkedHashMultimap<?, ?> that = (LinkedHashMultimap<?, ?>) o;
+            return this.back.equals(that.back);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return back.hashCode();
+    }
+
+    @Override
+    public String stringPrefix() {
+        return getClass().getSimpleName() + "[" + emptyContainer.stringPrefix() + "]";
+    }
+
+    @Override
+    public String toString() {
+        return mkString(stringPrefix() + "(", ", ", ")");
+    }
+
+    // -- helpers
+
+    private <K2, V2> LinkedHashMultimap<K2, V2> emptyInstance() {
+        return builder().empty();
+    }
+
+    private <V2> Builder<V2> builder() {
+        // TODO: THIS IS WRONG - WE NEED TO OBTAIN A NEW EMPTY CONTAINER IN THE CASE OF SORTABLE COLLECTIONS BECAUSE OF THE COMPARATOR!
+        return new Builder<>(containerType, emptyContainer);
+    }
 }

--- a/javaslang/src/main/java/javaslang/collection/Multimap.java
+++ b/javaslang/src/main/java/javaslang/collection/Multimap.java
@@ -82,24 +82,30 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
 
         SET(
                 (Traversable<?> set, Object elem) -> ((Set<Object>) set).add(elem),
-                (Traversable<?> set, Object elem) -> ((Set<Object>) set).remove(elem)
+                (Traversable<?> set, Object elem) -> ((Set<Object>) set).remove(elem),
+                java.util.HashSet::new
         ),
         SORTED_SET(
                 (Traversable<?> set, Object elem) -> ((Set<Object>) set).add(elem),
-                (Traversable<?> set, Object elem) -> ((Set<Object>) set).remove(elem)
+                (Traversable<?> set, Object elem) -> ((Set<Object>) set).remove(elem),
+                java.util.TreeSet::new
         ),
         SEQ(
                 (Traversable<?> seq, Object elem) -> ((List<Object>) seq).append(elem),
-                (Traversable<?> seq, Object elem) -> ((List<Object>) seq).remove(elem)
+                (Traversable<?> seq, Object elem) -> ((List<Object>) seq).remove(elem),
+                java.util.ArrayList::new
         );
 
         private final BiFunction<Traversable<?>, Object, Traversable<?>> add;
         private final BiFunction<Traversable<?>, Object, Traversable<?>> remove;
+        private final Supplier<? extends Collection<?>> javaContainerSupplier;
 
         ContainerType(BiFunction<Traversable<?>, Object, Traversable<?>> add,
-                      BiFunction<Traversable<?>, Object, Traversable<?>> remove) {
+                      BiFunction<Traversable<?>, Object, Traversable<?>> remove,
+                      Supplier<? extends Collection<?>> javaContainerSupplier) {
             this.add = add;
             this.remove = remove;
+            this.javaContainerSupplier = javaContainerSupplier;
         }
 
         <T> Traversable<T> add(Traversable<?> container, T elem) {
@@ -108,6 +114,10 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
 
         <T> Traversable<T> remove(Traversable<?> container, T elem) {
             return (Traversable<T>) remove.apply(container, elem);
+        }
+
+        <T> Supplier<Collection<T>> getJavaContainerSupplier() {
+            return (Supplier<Collection<T>>) javaContainerSupplier;
         }
     }
 

--- a/javaslang/src/main/java/javaslang/collection/Multimaps.java
+++ b/javaslang/src/main/java/javaslang/collection/Multimaps.java
@@ -1,0 +1,171 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2016 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+import javaslang.Tuple;
+import javaslang.Tuple2;
+import javaslang.collection.Multimap.ContainerType;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+/**
+ * Implementations of common {@code Map} functions (not intended to be public).
+ *
+ * @author Ruslan Sennov, Daniel Dietrich
+ * @since 2.1.0
+ */
+final class Multimaps {
+
+    static <K, V, K2, V2, M extends Multimap<K2, V2>> M bimap(
+            Multimap<K, V> multimap,
+            OfEntries<K2, V2, M> ofEntries,
+            Function<? super K, ? extends K2> keyMapper,
+            Function<? super V, ? extends V2> valueMapper) {
+        Objects.requireNonNull(keyMapper, "keyMapper is null");
+        Objects.requireNonNull(valueMapper, "valueMapper is null");
+        final Iterator<Tuple2<K2, V2>> entries = multimap.iterator().map(entry -> Tuple.of(keyMapper.apply(entry._1), valueMapper.apply(entry._2)));
+        return ofEntries.apply(entries);
+    }
+
+    static <K, V> int size(Map<K, Traversable<V>> back) {
+        return back.foldLeft(0, (s, t) -> s + t._2.size());
+    }
+
+    static <K, V> java.util.Map<K, Collection<V>> toJavaMap(Multimap<K, V> multimap) {
+        final java.util.Map<K, Collection<V>> javaMap = new java.util.HashMap<>();
+        final Supplier<Collection<V>> javaContainerSupplier;
+        final ContainerType containerType = multimap.getContainerType();
+        if (containerType == ContainerType.SEQ) {
+            javaContainerSupplier = java.util.ArrayList::new;
+        } else if (containerType == ContainerType.SET) {
+            javaContainerSupplier = java.util.HashSet::new;
+        } else if (containerType == ContainerType.SORTED_SET) {
+            javaContainerSupplier = java.util.TreeSet::new;
+        } else {
+            throw new IllegalStateException("Unknown ContainerType: " + containerType);
+        }
+        for (Tuple2<K, V> t : multimap) {
+            javaMap.computeIfAbsent(t._1, k -> javaContainerSupplier.get()).add(t._2);
+        }
+        return javaMap;
+    }
+
+    abstract static class Builder<V> {
+
+        private final ContainerType containerType;
+        private final Traversable<V> emptyContainer;
+
+        protected Builder(ContainerType containerType, Traversable<V> emptyContainer) {
+            this.containerType = containerType;
+            this.emptyContainer = emptyContainer;
+        }
+
+        public abstract <K, V2 extends V> Multimap<K, V2> empty();
+
+        public abstract <K, V2 extends V> Multimap<K, V2> of(Object... pairs);
+
+        public abstract <K, V2 extends V> Multimap<K, V2> of(K key, V2 value);
+
+        public abstract <K, V2 extends V> Multimap<K, V2> of(Tuple2<? extends K, ? extends V2> entry);
+
+        public abstract <K, V2 extends V> Multimap<K, V2> ofEntries(Iterable<? extends Tuple2<? extends K, ? extends V2>> entries);
+
+        @SuppressWarnings("unchecked")
+        public abstract <K, V2 extends V> Multimap<K, V2> ofEntries(Tuple2<? extends K, ? extends V2>... entries);
+
+        @SuppressWarnings("unchecked")
+        public abstract <K, V2 extends V> Multimap<K, V2> ofEntries(java.util.Map.Entry<? extends K, ? extends V2>... entries);
+
+        public abstract <K, V2 extends V> Multimap<K, V2> fill(int n, Supplier<Tuple2<? extends K, ? extends V2>> supplier);
+
+        public abstract <K, V2 extends V> Multimap<K, V2> tabulate(int n, Function<? super Integer, Tuple2<? extends K, ? extends V2>> f);
+
+        public abstract <K, V2 extends V> Collector<Tuple2<K, V2>, ArrayList<Tuple2<K, V2>>, ? extends Multimap<K, V2>> collector();
+
+        // Returns the empty Map used as back for Multimap
+        abstract <K, V2 extends V> Map<K, Traversable<V2>> emptyMap();
+
+        // Implementations must override the return type. Typically passed to `build()` using `this::ofMap`.
+        abstract <K, V2 extends V> Multimap<K, V2> ofMap(Map<K, Traversable<V2>> back);
+
+        // Use by factory methods. Automatically casts to Multimap type.
+        final <T, K, V2 extends V, M extends Multimap<K, V2>> M build(
+                Iterable<T> entries,
+                Function<T, K> getKey,
+                Function<T, V2> getValue,
+                OfMap<K, V2, M> ofMap) {
+            Objects.requireNonNull(entries, "entries is null");
+            Map<K, Traversable<V2>> back = emptyMap();
+            for (T entry : entries) {
+                final K key = getKey.apply(entry);
+                final V2 value = getValue.apply(entry);
+                // TODO(#1543): replace with `back.getOrElse(key, emptyContainer());`
+                final Traversable<V2> container = back.containsKey(key) ? back.get(key).get() : emptyContainer();
+                back = back.put(key, containerType.add(container, value));
+            }
+            return ofMap.apply(back);
+        }
+
+        ContainerType containerType() {
+            return containerType;
+        }
+
+        // Notes on type-safety of widening the generic argument of the empty container:
+        // - This should be ok for empty instances because no breaking up-casts take place.
+        // - Also a Comparator should be reusable that is covariant in its argument type.
+        @SuppressWarnings("unchecked")
+        <V2 extends V> Traversable<V2> emptyContainer() {
+            return (Traversable<V2>) emptyContainer;
+        }
+
+        static class Entries<K, V> implements Iterator<Object[]> {
+
+            int index = 0;
+            Object[] pairs;
+
+            Entries(Object[] pairs) {
+                Objects.requireNonNull(pairs, "pairs is null");
+                if ((pairs.length & 1) != 0) {
+                    throw new IllegalArgumentException("Odd length of key-value pairs");
+                }
+                this.pairs = pairs;
+            }
+
+            @Override
+            public boolean hasNext() {
+                return index < pairs.length;
+            }
+            @Override
+            public Object[] next() {
+                index += 2;
+                return pairs;
+            }
+
+            @SuppressWarnings("unchecked")
+            K getKey(Object[] pair) {
+                return (K) pair[index - 2];
+            }
+
+            @SuppressWarnings("unchecked")
+            V getValue(Object[] pair) {
+                return (V) pair[index - 1];
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface OfEntries<K, V, M extends Multimap<K, V>> extends Function<Iterable<Tuple2<K, V>>, M> {
+    }
+
+    @FunctionalInterface
+    interface OfMap<K, V, M extends Multimap<K, V>> extends Function<Map<K, Traversable<V>>, M> {
+    }
+}

--- a/javaslang/src/main/java/javaslang/collection/TreeMultimap.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeMultimap.java
@@ -21,7 +21,7 @@ import java.util.stream.Collector;
  *
  * @param <K> Key type
  * @param <V> Value type
- * @author Ruslan Sennov
+ * @author Ruslan Sennov, Daniel Dietrich
  * @since 2.1.0
  */
 public final class TreeMultimap<K, V> implements Multimap<K, V>, Serializable {
@@ -287,7 +287,7 @@ public final class TreeMultimap<K, V> implements Multimap<K, V>, Serializable {
 
     @Override
     public String stringPrefix() {
-        return getClass().getSimpleName() + "[" + emptyContainer.get().stringPrefix() + "]";
+        return "TreeMultimap[" + emptyContainer.get().stringPrefix() + "]";
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/TreeMultimap.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeMultimap.java
@@ -6,15 +6,14 @@
 package javaslang.collection;
 
 import javaslang.Tuple2;
+import javaslang.control.Option;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Objects;
-import java.util.function.BiConsumer;
-import java.util.function.BinaryOperator;
-import java.util.function.Function;
-import java.util.function.Supplier;
+import java.util.function.*;
 import java.util.stream.Collector;
 
 /**
@@ -25,9 +24,21 @@ import java.util.stream.Collector;
  * @author Ruslan Sennov
  * @since 2.1.0
  */
-public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultimap<K, V>> implements Serializable {
+public final class TreeMultimap<K, V> implements Multimap<K, V>, Serializable {
 
     private static final long serialVersionUID = 1L;
+
+    private final Map<K, Traversable<V>> back;
+    private final SerializableSupplier<Traversable<?>> emptyContainer;
+    private final ContainerType containerType;
+
+    private TreeMultimap(Map<K, Traversable<V>> back, ContainerType containerType, SerializableSupplier<Traversable<?>> emptyContainer) {
+        this.back = back;
+        this.containerType = containerType;
+        this.emptyContainer = emptyContainer;
+    }
+
+    // static API
 
     public static <V> Builder<V> withSeq() {
         return new Builder<>(ContainerType.SEQ, List::empty);
@@ -194,7 +205,7 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
 
     /**
      * Narrows a widened {@code HashMultimap<? extends K, ? extends V>} to {@code HashMultimap<K, V>}
-     * by performing a type safe-cast. This is eligible because immutable/read-only
+     * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.
      *
      * @param map A {@code Map}.
@@ -207,24 +218,92 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         return (TreeMultimap<K, V>) map;
     }
 
-    private TreeMultimap(Map<K, Traversable<V>> back, ContainerType containerType, SerializableSupplier<Traversable<?>> emptyContainer) {
-        super(back, containerType, emptyContainer);
+    // non-static API
+
+    @Override
+    public boolean containsKey(K key) {
+        return back.containsKey(key);
     }
 
     @Override
-    protected <K2, V2> Map<K2, V2> emptyMapSupplier() {
+    public ContainerType getContainerType() {
+        return containerType;
+    }
+
+    @Override
+    public Option<Traversable<V>> get(K key) {
+        return back.get(key);
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return back.keySet();
+    }
+
+    @Override
+    public <K2, V2> TreeMultimap<K2, V2> flatMap(BiFunction<? super K, ? super V, ? extends Iterable<Tuple2<K2, V2>>> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        return foldLeft(emptyInstance(), (acc, entry) -> {
+            for (Tuple2<? extends K2, ? extends V2> mappedEntry : mapper.apply(entry._1, entry._2)) {
+                acc = acc.put(mappedEntry);
+            }
+            return acc;
+        });
+    }
+
+    @Override
+    public int size() {
+        return back.foldLeft(0, (s, t) -> s + t._2.size());
+    }
+
+    @Override
+    public java.util.Map<K, Collection<V>> toJavaMap() {
+        return Multimaps.toJavaMap(this);
+    }
+
+    @Override
+    public Traversable<V> values() {
+        return Iterator.concat(back.values()).toStream();
+    }
+
+    // -- Object
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        } else if (o instanceof TreeMultimap) {
+            final TreeMultimap<?, ?> that = (TreeMultimap<?, ?>) o;
+            return this.back.equals(that.back);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return back.hashCode();
+    }
+
+    @Override
+    public String stringPrefix() {
+        return getClass().getSimpleName() + "[" + emptyContainer.get().stringPrefix() + "]";
+    }
+
+    @Override
+    public String toString() {
+        return mkString(stringPrefix() + "(", ", ", ")");
+    }
+
+    private <K2, V2> Map<K2, V2> emptyMapSupplier() {
         return TreeMap.empty(Comparators.naturalComparator());
     }
 
-    @SuppressWarnings("unchecked")
-    @Override
-    protected <K2, V2> TreeMultimap<K2, V2> emptyInstance() {
-        return new TreeMultimap<>(emptyMapSupplier(), getContainerType(), emptyContainer);
+    private <K2, V2> TreeMultimap<K2, V2> emptyInstance() {
+        return new TreeMultimap<>(emptyMapSupplier(), containerType, emptyContainer);
     }
 
-    @Override
-    protected <K2, V2> TreeMultimap<K2, V2> createFromMap(Map<K2, Traversable<V2>> back) {
-        return new TreeMultimap<>(back, getContainerType(), emptyContainer);
+    private <K2, V2> TreeMultimap<K2, V2> createFromMap(Map<K2, Traversable<V2>> back) {
+        return new TreeMultimap<>(back, containerType, emptyContainer);
     }
-
 }

--- a/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
@@ -309,6 +309,17 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
         assertThat(javaslang.toJavaMap()).isEqualTo(java);
     }
 
+    @Test
+    public void shouldConvertToJavaMapUsingIdentityFunction() {
+        final Map<String, Integer> javaslang = mapOfPairs("1", 1, "2", 2, "3", 3);
+        final java.util.Map<String, Integer> actual = javaslang.toJavaMap(Function.identity());
+        final java.util.Map<String, Integer> expected = javaEmptyMap();
+        expected.put("1", 1);
+        expected.put("2", 2);
+        expected.put("3", 3);
+        assertThat(actual).isEqualTo(expected);
+    }
+
     // -- apply
 
     @Test


### PR DESCRIPTION
Hi @ruslansennov, @paplorinc,@zsolt-donca,

this is an ongoing (currently dirty) draft of the bugfix of #1326. I created an early PR so that you can track the changes.

This is one of several PRs. The checklist is updated [here](https://github.com/javaslang/javaslang/issues/1326#issuecomment-240726519).

**Goal:**

Remove all package-private super classes because method-references do not work for default implementations (JDK bug!).

**What I did so far:**

* Added Multimaps helper class similar to the new Maps class.
* Found another abstraction for a common Multimap Builder
* Started to move methods from AbstractMultimap to Multimaps. The generics and method arguments change.
* Changes LinkedHashMultimap to use Multimaps.

**TODO:**

* Move the remaining methods from AbstractMultimap to Multimaps
* Override missing methods and adjust return types in LinkedHashMap
* Do the same for HashMultimap and TreeMultimap
* **Fix the problem with the emptyInstance() when an underlying Comparator is present and the generic type changes. This blows up the Multimap when the original comparator is used on a new type.**
* Delete AbstractMultimap

