### PR TITLE
Automatic, internal primitive storage support for `Vector`

### DIFF
--- a/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java
@@ -5,7 +5,6 @@ import org.eclipse.collections.api.list.MutableList;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
-import scala.Tuple2;
 import scala.collection.generic.CanBuildFrom;
 import scala.compat.java8.functionConverterImpls.FromJavaFunction;
 import scala.compat.java8.functionConverterImpls.FromJavaPredicate;
@@ -48,12 +47,12 @@ public class VectorBenchmark {
 
     public static void main(String... args) {
         JmhRunner.runDebugWithAsserts(CLASSES);
-        JmhRunner.runNormalNoAsserts(CLASSES, /*FUNCTIONAL_JAVA, PCOLLECTIONS, ECOLLECTIONS,*/ JAVA, CLOJURE, SCALA, JAVASLANG);
+        JmhRunner.runNormalNoAsserts(CLASSES, JAVA, FUNCTIONAL_JAVA, PCOLLECTIONS, ECOLLECTIONS, CLOJURE, SCALA, JAVASLANG);
     }
 
     @State(Scope.Benchmark)
     public static class Base {
-        @Param({ "100", "10000" })
+        @Param({ "10", "100", "1026" })
         public int CONTAINER_SIZE;
 
         int EXPECTED_AGGREGATE;

--- a/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java
@@ -5,15 +5,17 @@ import org.eclipse.collections.api.list.MutableList;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
+import scala.Tuple2;
 import scala.collection.generic.CanBuildFrom;
 import scala.compat.java8.functionConverterImpls.FromJavaFunction;
 import scala.compat.java8.functionConverterImpls.FromJavaPredicate;
 
 import java.util.Objects;
 import java.util.Random;
-import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
 import static javaslang.JmhRunner.Includes.*;
 import static javaslang.JmhRunner.*;
 import static javaslang.collection.Collections.areEqual;
@@ -32,7 +34,10 @@ public class VectorBenchmark {
             Map.class,
             Filter.class,
             Prepend.class,
+            PrependAll.class,
             Append.class,
+            AppendAll.class,
+            Insert.class,
             GroupBy.class,
             Slice.class,
             Iterate.class
@@ -43,16 +48,17 @@ public class VectorBenchmark {
 
     public static void main(String... args) {
         JmhRunner.runDebugWithAsserts(CLASSES);
-        JmhRunner.runNormalNoAsserts(CLASSES, JAVA, FUNCTIONAL_JAVA, PCOLLECTIONS, ECOLLECTIONS, CLOJURE, SCALA, JAVASLANG);
+        JmhRunner.runNormalNoAsserts(CLASSES, /*FUNCTIONAL_JAVA, PCOLLECTIONS, ECOLLECTIONS,*/ JAVA, CLOJURE, SCALA, JAVASLANG);
     }
 
     @State(Scope.Benchmark)
     public static class Base {
-        @Param({ "32", "1024", "32768" /*, "1048576", "33554432", "1073741824" */ }) /* i.e. depth 1,2,3(,4,5,6) for a branching factor of 32 */
+        @Param({ "100", "10000" })
         public int CONTAINER_SIZE;
 
         int EXPECTED_AGGREGATE;
         Integer[] ELEMENTS;
+        int[] INT_ELEMENTS;
         int[] RANDOMIZED_INDICES;
 
         /* Only use this for non-mutating operations */
@@ -64,11 +70,14 @@ public class VectorBenchmark {
         clojure.lang.PersistentVector clojurePersistent;
         scala.collection.immutable.Vector<Integer> scalaPersistent;
         javaslang.collection.Vector<Integer> slangPersistent;
+        javaslang.collection.Vector<Integer> slangPersistentInt;
+        javaslang.collection.Vector<Byte> slangPersistentByte;
 
         @Setup
         public void setup() {
             final Random random = new Random(0);
             ELEMENTS = getRandomValues(CONTAINER_SIZE, false, random);
+            INT_ELEMENTS = ArrayType.asPrimitives(int.class, Array.of(ELEMENTS));
             RANDOMIZED_INDICES = shuffle(Array.range(0, CONTAINER_SIZE).toJavaStream().mapToInt(Integer::intValue).toArray(), random);
 
             EXPECTED_AGGREGATE = Array.of(ELEMENTS).reduce(JmhRunner::aggregate);
@@ -80,6 +89,11 @@ public class VectorBenchmark {
             clojurePersistent = create(clojure.lang.PersistentVector::create, javaMutable, v -> areEqual(v, javaMutable));
             scalaPersistent = create(v -> (scala.collection.immutable.Vector<Integer>) scala.collection.immutable.Vector$.MODULE$.apply(asScalaBuffer(v)), javaMutable, v -> areEqual(asJavaCollection(v), javaMutable));
             slangPersistent = create(javaslang.collection.Vector::ofAll, javaMutable, v -> areEqual(v, javaMutable));
+            slangPersistentInt = create(v -> javaslang.collection.Vector.ofAll(INT_ELEMENTS), javaMutable, v -> areEqual(v, javaMutable) && (v.trie.type.type() == int.class));
+
+            final byte[] BYTE_ELEMENTS = new byte[CONTAINER_SIZE];
+            random.nextBytes(BYTE_ELEMENTS);
+            slangPersistentByte = create(v -> javaslang.collection.Vector.ofAll(BYTE_ELEMENTS), javaMutable, v -> areEqual(v, Array.ofAll(BYTE_ELEMENTS)) && (v.trie.type.type() == byte.class));
         }
     }
 
@@ -88,6 +102,23 @@ public class VectorBenchmark {
         @Benchmark
         public Object java_mutable() {
             final java.util.List<Integer> values = new java.util.ArrayList<>(java.util.Arrays.asList(ELEMENTS));
+            assert areEqual(values, javaMutable);
+            return values;
+        }
+
+        @Benchmark
+        public Object java_mutable_boxed() {
+            final java.util.List<Integer> values = new java.util.ArrayList<>();
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values.add(INT_ELEMENTS[i]);
+            }
+            assert areEqual(values, javaMutable);
+            return values;
+        }
+
+        @Benchmark
+        public Object java_mutable_boxed_stream() {
+            final java.util.List<Integer> values = java.util.Arrays.stream(INT_ELEMENTS).boxed().collect(toList());
             assert areEqual(values, javaMutable);
             return values;
         }
@@ -131,6 +162,13 @@ public class VectorBenchmark {
         public Object slang_persistent() {
             final javaslang.collection.Vector<Integer> values = javaslang.collection.Vector.ofAll(javaMutable);
             assert areEqual(values, javaMutable);
+            return values;
+        }
+
+        @Benchmark
+        public Object slang_persistent_int() {
+            final javaslang.collection.Vector<Integer> values = javaslang.collection.Vector.ofAll(INT_ELEMENTS);
+            assert (values.trie.type.type() == int.class) && areEqual(values, javaMutable);
             return values;
         }
     }
@@ -198,9 +236,7 @@ public class VectorBenchmark {
             }
 
             @TearDown(Level.Invocation)
-            public void tearDown() {
-                javaMutable.clear();
-            }
+            public void tearDown() { javaMutable.clear(); }
         }
 
         @Benchmark
@@ -265,6 +301,16 @@ public class VectorBenchmark {
         @Benchmark
         public Object slang_persistent() {
             javaslang.collection.Vector<Integer> values = slangPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.tail();
+            }
+            assert values.isEmpty();
+            return values;
+        }
+
+        @Benchmark
+        public Object slang_persistent_int() {
+            javaslang.collection.Vector<Integer> values = slangPersistentInt;
             for (int i = 0; i < CONTAINER_SIZE; i++) {
                 values = values.tail();
             }
@@ -359,9 +405,7 @@ public class VectorBenchmark {
             }
 
             @TearDown(Level.Invocation)
-            public void tearDown() {
-                javaMutable.clear();
-            }
+            public void tearDown() { javaMutable.clear(); }
         }
 
         @Benchmark
@@ -435,9 +479,20 @@ public class VectorBenchmark {
             assert values.forAll(e -> e == 0);
             return values;
         }
+
+        @Benchmark
+        public Object slang_persistent_int() {
+            javaslang.collection.Vector<Integer> values = slangPersistentInt;
+            for (int i : RANDOMIZED_INDICES) {
+                values = values.update(i, 0);
+            }
+            assert (values.trie.type.type() == int.class) && values.forAll(e -> e == 0);
+            return values;
+        }
     }
 
     public static class Map extends Base {
+        final CanBuildFrom canBuildFrom = scala.collection.immutable.Vector.canBuildFrom();
         private static int mapper(int i) { return i + 1; }
 
         @Benchmark
@@ -452,7 +507,7 @@ public class VectorBenchmark {
 
         @Benchmark
         public Object java_mutable() {
-            final java.util.List<Integer> values = javaMutable.stream().map(Map::mapper).collect(Collectors.toList());
+            final java.util.List<Integer> values = javaMutable.stream().map(Map::mapper).collect(toList());
             assert areEqual(values, Array.of(ELEMENTS).map(Map::mapper));
             return values;
         }
@@ -466,7 +521,6 @@ public class VectorBenchmark {
 
         @Benchmark
         public Object scala_persistent() {
-            final CanBuildFrom canBuildFrom = scala.collection.immutable.Vector.canBuildFrom();
             final scala.collection.immutable.Vector<Integer> values = (scala.collection.immutable.Vector<Integer>) scalaPersistent.map(new FromJavaFunction<>(Map::mapper), canBuildFrom);
             assert areEqual(asJavaCollection(values), Array.of(ELEMENTS).map(Map::mapper));
             return values;
@@ -478,6 +532,13 @@ public class VectorBenchmark {
             assert areEqual(values, Array.of(ELEMENTS).map(Map::mapper));
             return values;
         }
+
+        @Benchmark
+        public Object slang_persistent_int() {
+            final javaslang.collection.Vector<Integer> values = slangPersistentInt.map(Map::mapper);
+            assert areEqual(values, Array.of(ELEMENTS).map(Map::mapper));
+            return values;
+        }
     }
 
     public static class Filter extends Base {
@@ -485,7 +546,7 @@ public class VectorBenchmark {
 
         @Benchmark
         public Object java_mutable() {
-            final java.util.List<Integer> someValues = javaMutable.stream().filter(Filter::isOdd).collect(Collectors.toList());
+            final java.util.List<Integer> someValues = javaMutable.stream().filter(Filter::isOdd).collect(toList());
             assert areEqual(someValues, Array.of(ELEMENTS).filter(Filter::isOdd));
             return someValues;
         }
@@ -508,6 +569,13 @@ public class VectorBenchmark {
         public Object slang_persistent() {
             final javaslang.collection.Vector<Integer> someValues = slangPersistent.filter(Filter::isOdd);
             assert areEqual(someValues, Array.of(ELEMENTS).filter(Filter::isOdd));
+            return someValues;
+        }
+
+        @Benchmark
+        public Object slang_persistent_int() {
+            final javaslang.collection.Vector<Integer> someValues = slangPersistentInt.filter(Filter::isOdd);
+            assert (someValues.trie.type.type() == int.class) && areEqual(someValues, Array.of(ELEMENTS).filter(Filter::isOdd));
             return someValues;
         }
     }
@@ -588,6 +656,29 @@ public class VectorBenchmark {
             assert areEqual(values.reverse(), javaMutable);
             return values;
         }
+
+        @Benchmark
+        public Object slang_persistent_int() {
+            javaslang.collection.Vector<Integer> values = javaslang.collection.Vector.ofAll(ELEMENTS[0]);
+            for (int i = 1; i < ELEMENTS.length; i++) {
+                values = values.prepend(ELEMENTS[i]);
+            }
+            assert (values.trie.type.type() == int.class) && areEqual(values.reverse(), javaMutable);
+            return values;
+        }
+    }
+
+    public static class PrependAll extends Base {
+        @Benchmark
+        public void slang_persistent(Blackhole bh) {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                final java.util.List<Integer> front = javaMutable.subList(0, i);
+                final javaslang.collection.Vector<Integer> back = slangPersistent.slice(i, CONTAINER_SIZE);
+                final javaslang.collection.Vector<Integer> values = back.prependAll(front);
+                assert areEqual(values, javaMutable);
+                bh.consume(values);
+            }
+        }
     }
 
     /** Add all elements (one-by-one, as we're not testing bulk operations) */
@@ -663,23 +754,64 @@ public class VectorBenchmark {
             assert areEqual(values, javaMutable);
             return values;
         }
+
+        @Benchmark
+        public Object slang_persistent_int() {
+            javaslang.collection.Vector<Integer> values = javaslang.collection.Vector.ofAll(INT_ELEMENTS[0]);
+            for (int i = 1; i < INT_ELEMENTS.length; i++) {
+                values = values.append(INT_ELEMENTS[i]);
+            }
+            assert (values.trie.type.type() == int.class) && areEqual(values, javaMutable);
+            return values;
+        }
+    }
+
+    public static class AppendAll extends Base {
+        final CanBuildFrom canBuildFrom = scala.collection.immutable.Vector.canBuildFrom();
+
+        @Benchmark
+        public void scala_persistent(Blackhole bh) {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                final scala.collection.immutable.Vector<Integer> front = scalaPersistent.slice(0, i);
+                final java.util.List<Integer> back = javaMutable.subList(i, CONTAINER_SIZE);
+                final scala.collection.immutable.Vector<Integer> values = front.$plus$plus(asScalaBuffer(back), (CanBuildFrom<scala.collection.immutable.Vector<Integer>, Integer, scala.collection.immutable.Vector<Integer>>) canBuildFrom);
+                assert areEqual(asJavaCollection(values), javaMutable);
+                bh.consume(values);
+            }
+        }
+
+        @Benchmark
+        public void slang_persistent(Blackhole bh) {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                final javaslang.collection.Vector<Integer> front = slangPersistent.slice(0, i);
+                final java.util.List<Integer> back = javaMutable.subList(i, CONTAINER_SIZE);
+                final javaslang.collection.Vector<Integer> values = front.appendAll(back);
+                assert areEqual(values, javaMutable);
+                bh.consume(values);
+            }
+        }
+    }
+
+    public static class Insert extends Base {
+        @Benchmark
+        public void slang_persistent(Blackhole bh) {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                final Vector<Integer> values = slangPersistent.insert(i, 0);
+                assert values.size() == CONTAINER_SIZE + 1;
+                bh.consume(values);
+            }
+        }
     }
 
     public static class GroupBy extends Base {
         @Benchmark
-        public Object java_mutable() {
-            return javaMutable.stream().collect(Collectors.groupingBy(Integer::bitCount));
-        }
+        public Object java_mutable() { return javaMutable.stream().collect(groupingBy(Integer::bitCount)); }
 
         @Benchmark
-        public Object scala_persistent() {
-            return scalaPersistent.groupBy(func(Integer::bitCount));
-        }
+        public Object scala_persistent() { return scalaPersistent.groupBy(func(Integer::bitCount)); }
 
         @Benchmark
-        public Object slang_persistent() {
-            return slangPersistent.groupBy(Integer::bitCount);
-        }
+        public Object slang_persistent() { return slangPersistent.groupBy(Integer::bitCount); }
     }
 
     /** Consume the vector one-by-one, from the front and back */
@@ -733,30 +865,24 @@ public class VectorBenchmark {
                 bh.consume(values);
             }
         }
+
+        @Benchmark
+        public void slang_persistent_int(Blackhole bh) {
+            javaslang.collection.Vector<Integer> values = this.slangPersistentInt;
+            while (!values.isEmpty()) {
+                values = values.slice(1, values.size());
+                values = values.slice(0, values.size() - 1);
+                bh.consume(values);
+            }
+        }
     }
 
     /** Sequential access for all elements */
     public static class Iterate extends Base {
-        @State(Scope.Thread)
-        public static class Initialized {
-            final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
-
-            @Setup(Level.Invocation)
-            public void initializeMutable(Base state) {
-                java.util.Collections.addAll(javaMutable, state.ELEMENTS);
-                assert areEqual(javaMutable, asList(state.ELEMENTS));
-            }
-
-            @TearDown(Level.Invocation)
-            public void tearDown() {
-                javaMutable.clear();
-            }
-        }
-
         @Benchmark
-        public int java_mutable(Initialized state) {
+        public int java_mutable() {
             int aggregate = 0;
-            for (final java.util.Iterator<Integer> iterator = state.javaMutable.iterator(); iterator.hasNext(); ) {
+            for (final java.util.Iterator<Integer> iterator = javaMutable.iterator(); iterator.hasNext(); ) {
                 aggregate ^= iterator.next();
             }
             assert aggregate == EXPECTED_AGGREGATE;
@@ -821,6 +947,19 @@ public class VectorBenchmark {
             }
             assert aggregate == EXPECTED_AGGREGATE;
             return aggregate;
+        }
+
+        @Benchmark
+        public int slang_persistent_int() {
+            final int[] aggregate = { 0 };
+            slangPersistentInt.trie.<int[]> visit((ordinal, leaf, start, end) -> {
+                for (int i = start; i < end; i++) {
+                    aggregate[0] ^= leaf[i];
+                }
+                return -1;
+            });
+            assert aggregate[0] == EXPECTED_AGGREGATE;
+            return aggregate[0];
         }
     }
 }

--- a/javaslang/generator/Generator.scala
+++ b/javaslang/generator/Generator.scala
@@ -2299,20 +2299,18 @@ def generateMainClasses(): Unit = {
       genJavaslangFile("javaslang.collection", s"${arrayType.capitalize}ArrayType")(genArrayType(arrayType))
     }
 
-    /*
-     * Generates *ArrayType
-     */
     def genArrayType(arrayType: String)(im: ImportManager, packageName: String, className: String): String = {
       val wrapperType = types(arrayType)
-      val cast = if (wrapperType != "Object") s"($wrapperType)" else ""
+      val cast = if (wrapperType != "Object") s" ($wrapperType)" else ""
 
       xs"""
-         /**
+        /**
          * $arrayType[] helper to replace reflective array access.
+         *
          * @author Pap Lőrinc
          * @since 2.1.0
          */
-        final class $className extends ArrayType<$wrapperType> {
+        final class $className implements ArrayType<$wrapperType>, ${im.getType("java.io.Serializable")} {
             private static final long serialVersionUID = 1L;
             static final $className INSTANCE = new $className();
             static final $arrayType[] EMPTY = new $arrayType[0];
@@ -2320,22 +2318,22 @@ def generateMainClasses(): Unit = {
             private static $arrayType[] cast(Object array) { return ($arrayType[]) array; }
 
             @Override
-            Class<$wrapperType> type() { return $arrayType.class; }
+            public Class<$wrapperType> type() { return $arrayType.class; }
 
             @Override
-            $arrayType[] empty() { return EMPTY; }
+            public $arrayType[] empty() { return EMPTY; }
 
             @Override
-            int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+            public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
 
             @Override
-            $wrapperType getAt(Object array, int index) { return cast(array)[index]; }
+            public $wrapperType getAt(Object array, int index) { return cast(array)[index]; }
 
             @Override
-            void setAt(Object array, int index, Object value) { cast(array)[index] = $cast value; }
+            public void setAt(Object array, int index, Object value) { cast(array)[index] =$cast value; }
 
             @Override
-            Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+            public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
                 if (size == 0) {
                     return new $arrayType[arraySize];
                 } else {

--- a/javaslang/src-gen/main/java/javaslang/collection/BooleanArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/BooleanArrayType.java
@@ -1,0 +1,49 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2016 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*\
+   G E N E R A T O R   C R A F T E D
+\*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
+
+ /**
+ * boolean[] helper to replace reflective array access.
+ * @author Pap Lőrinc
+ * @since 2.1.0
+ */
+final class BooleanArrayType extends ArrayType<Boolean> {
+    private static final long serialVersionUID = 1L;
+    static final BooleanArrayType INSTANCE = new BooleanArrayType();
+    static final boolean[] EMPTY = new boolean[0];
+
+    private static boolean[] cast(Object array) { return (boolean[]) array; }
+
+    @Override
+    Class<Boolean> type() { return boolean.class; }
+
+    @Override
+    boolean[] empty() { return EMPTY; }
+
+    @Override
+    int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+
+    @Override
+    Boolean getAt(Object array, int index) { return cast(array)[index]; }
+
+    @Override
+    void setAt(Object array, int index, Object value) { cast(array)[index] = (Boolean) value; }
+
+    @Override
+    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+        if (size == 0) {
+            return new boolean[arraySize];
+        } else {
+            final boolean[] result = new boolean[arraySize];
+            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            return result;
+        }
+    }
+}

--- a/javaslang/src-gen/main/java/javaslang/collection/BooleanArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/BooleanArrayType.java
@@ -9,12 +9,15 @@ package javaslang.collection;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
- /**
+import java.io.Serializable;
+
+/**
  * boolean[] helper to replace reflective array access.
+ *
  * @author Pap Lőrinc
  * @since 2.1.0
  */
-final class BooleanArrayType extends ArrayType<Boolean> {
+final class BooleanArrayType implements ArrayType<Boolean>, Serializable {
     private static final long serialVersionUID = 1L;
     static final BooleanArrayType INSTANCE = new BooleanArrayType();
     static final boolean[] EMPTY = new boolean[0];
@@ -22,22 +25,22 @@ final class BooleanArrayType extends ArrayType<Boolean> {
     private static boolean[] cast(Object array) { return (boolean[]) array; }
 
     @Override
-    Class<Boolean> type() { return boolean.class; }
+    public Class<Boolean> type() { return boolean.class; }
 
     @Override
-    boolean[] empty() { return EMPTY; }
+    public boolean[] empty() { return EMPTY; }
 
     @Override
-    int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+    public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
 
     @Override
-    Boolean getAt(Object array, int index) { return cast(array)[index]; }
+    public Boolean getAt(Object array, int index) { return cast(array)[index]; }
 
     @Override
-    void setAt(Object array, int index, Object value) { cast(array)[index] = (Boolean) value; }
+    public void setAt(Object array, int index, Object value) { cast(array)[index] = (Boolean) value; }
 
     @Override
-    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+    public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
         if (size == 0) {
             return new boolean[arraySize];
         } else {

--- a/javaslang/src-gen/main/java/javaslang/collection/ByteArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/ByteArrayType.java
@@ -9,12 +9,15 @@ package javaslang.collection;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
- /**
+import java.io.Serializable;
+
+/**
  * byte[] helper to replace reflective array access.
+ *
  * @author Pap Lőrinc
  * @since 2.1.0
  */
-final class ByteArrayType extends ArrayType<Byte> {
+final class ByteArrayType implements ArrayType<Byte>, Serializable {
     private static final long serialVersionUID = 1L;
     static final ByteArrayType INSTANCE = new ByteArrayType();
     static final byte[] EMPTY = new byte[0];
@@ -22,22 +25,22 @@ final class ByteArrayType extends ArrayType<Byte> {
     private static byte[] cast(Object array) { return (byte[]) array; }
 
     @Override
-    Class<Byte> type() { return byte.class; }
+    public Class<Byte> type() { return byte.class; }
 
     @Override
-    byte[] empty() { return EMPTY; }
+    public byte[] empty() { return EMPTY; }
 
     @Override
-    int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+    public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
 
     @Override
-    Byte getAt(Object array, int index) { return cast(array)[index]; }
+    public Byte getAt(Object array, int index) { return cast(array)[index]; }
 
     @Override
-    void setAt(Object array, int index, Object value) { cast(array)[index] = (Byte) value; }
+    public void setAt(Object array, int index, Object value) { cast(array)[index] = (Byte) value; }
 
     @Override
-    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+    public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
         if (size == 0) {
             return new byte[arraySize];
         } else {

--- a/javaslang/src-gen/main/java/javaslang/collection/ByteArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/ByteArrayType.java
@@ -1,0 +1,49 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2016 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*\
+   G E N E R A T O R   C R A F T E D
+\*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
+
+ /**
+ * byte[] helper to replace reflective array access.
+ * @author Pap Lőrinc
+ * @since 2.1.0
+ */
+final class ByteArrayType extends ArrayType<Byte> {
+    private static final long serialVersionUID = 1L;
+    static final ByteArrayType INSTANCE = new ByteArrayType();
+    static final byte[] EMPTY = new byte[0];
+
+    private static byte[] cast(Object array) { return (byte[]) array; }
+
+    @Override
+    Class<Byte> type() { return byte.class; }
+
+    @Override
+    byte[] empty() { return EMPTY; }
+
+    @Override
+    int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+
+    @Override
+    Byte getAt(Object array, int index) { return cast(array)[index]; }
+
+    @Override
+    void setAt(Object array, int index, Object value) { cast(array)[index] = (Byte) value; }
+
+    @Override
+    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+        if (size == 0) {
+            return new byte[arraySize];
+        } else {
+            final byte[] result = new byte[arraySize];
+            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            return result;
+        }
+    }
+}

--- a/javaslang/src-gen/main/java/javaslang/collection/CharArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/CharArrayType.java
@@ -1,0 +1,49 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2016 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*\
+   G E N E R A T O R   C R A F T E D
+\*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
+
+ /**
+ * char[] helper to replace reflective array access.
+ * @author Pap Lőrinc
+ * @since 2.1.0
+ */
+final class CharArrayType extends ArrayType<Character> {
+    private static final long serialVersionUID = 1L;
+    static final CharArrayType INSTANCE = new CharArrayType();
+    static final char[] EMPTY = new char[0];
+
+    private static char[] cast(Object array) { return (char[]) array; }
+
+    @Override
+    Class<Character> type() { return char.class; }
+
+    @Override
+    char[] empty() { return EMPTY; }
+
+    @Override
+    int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+
+    @Override
+    Character getAt(Object array, int index) { return cast(array)[index]; }
+
+    @Override
+    void setAt(Object array, int index, Object value) { cast(array)[index] = (Character) value; }
+
+    @Override
+    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+        if (size == 0) {
+            return new char[arraySize];
+        } else {
+            final char[] result = new char[arraySize];
+            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            return result;
+        }
+    }
+}

--- a/javaslang/src-gen/main/java/javaslang/collection/CharArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/CharArrayType.java
@@ -9,12 +9,15 @@ package javaslang.collection;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
- /**
+import java.io.Serializable;
+
+/**
  * char[] helper to replace reflective array access.
+ *
  * @author Pap Lőrinc
  * @since 2.1.0
  */
-final class CharArrayType extends ArrayType<Character> {
+final class CharArrayType implements ArrayType<Character>, Serializable {
     private static final long serialVersionUID = 1L;
     static final CharArrayType INSTANCE = new CharArrayType();
     static final char[] EMPTY = new char[0];
@@ -22,22 +25,22 @@ final class CharArrayType extends ArrayType<Character> {
     private static char[] cast(Object array) { return (char[]) array; }
 
     @Override
-    Class<Character> type() { return char.class; }
+    public Class<Character> type() { return char.class; }
 
     @Override
-    char[] empty() { return EMPTY; }
+    public char[] empty() { return EMPTY; }
 
     @Override
-    int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+    public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
 
     @Override
-    Character getAt(Object array, int index) { return cast(array)[index]; }
+    public Character getAt(Object array, int index) { return cast(array)[index]; }
 
     @Override
-    void setAt(Object array, int index, Object value) { cast(array)[index] = (Character) value; }
+    public void setAt(Object array, int index, Object value) { cast(array)[index] = (Character) value; }
 
     @Override
-    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+    public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
         if (size == 0) {
             return new char[arraySize];
         } else {

--- a/javaslang/src-gen/main/java/javaslang/collection/DoubleArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/DoubleArrayType.java
@@ -1,0 +1,49 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2016 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*\
+   G E N E R A T O R   C R A F T E D
+\*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
+
+ /**
+ * double[] helper to replace reflective array access.
+ * @author Pap Lőrinc
+ * @since 2.1.0
+ */
+final class DoubleArrayType extends ArrayType<Double> {
+    private static final long serialVersionUID = 1L;
+    static final DoubleArrayType INSTANCE = new DoubleArrayType();
+    static final double[] EMPTY = new double[0];
+
+    private static double[] cast(Object array) { return (double[]) array; }
+
+    @Override
+    Class<Double> type() { return double.class; }
+
+    @Override
+    double[] empty() { return EMPTY; }
+
+    @Override
+    int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+
+    @Override
+    Double getAt(Object array, int index) { return cast(array)[index]; }
+
+    @Override
+    void setAt(Object array, int index, Object value) { cast(array)[index] = (Double) value; }
+
+    @Override
+    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+        if (size == 0) {
+            return new double[arraySize];
+        } else {
+            final double[] result = new double[arraySize];
+            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            return result;
+        }
+    }
+}

--- a/javaslang/src-gen/main/java/javaslang/collection/DoubleArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/DoubleArrayType.java
@@ -9,12 +9,15 @@ package javaslang.collection;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
- /**
+import java.io.Serializable;
+
+/**
  * double[] helper to replace reflective array access.
+ *
  * @author Pap Lőrinc
  * @since 2.1.0
  */
-final class DoubleArrayType extends ArrayType<Double> {
+final class DoubleArrayType implements ArrayType<Double>, Serializable {
     private static final long serialVersionUID = 1L;
     static final DoubleArrayType INSTANCE = new DoubleArrayType();
     static final double[] EMPTY = new double[0];
@@ -22,22 +25,22 @@ final class DoubleArrayType extends ArrayType<Double> {
     private static double[] cast(Object array) { return (double[]) array; }
 
     @Override
-    Class<Double> type() { return double.class; }
+    public Class<Double> type() { return double.class; }
 
     @Override
-    double[] empty() { return EMPTY; }
+    public double[] empty() { return EMPTY; }
 
     @Override
-    int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+    public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
 
     @Override
-    Double getAt(Object array, int index) { return cast(array)[index]; }
+    public Double getAt(Object array, int index) { return cast(array)[index]; }
 
     @Override
-    void setAt(Object array, int index, Object value) { cast(array)[index] = (Double) value; }
+    public void setAt(Object array, int index, Object value) { cast(array)[index] = (Double) value; }
 
     @Override
-    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+    public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
         if (size == 0) {
             return new double[arraySize];
         } else {

--- a/javaslang/src-gen/main/java/javaslang/collection/FloatArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/FloatArrayType.java
@@ -1,0 +1,49 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2016 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*\
+   G E N E R A T O R   C R A F T E D
+\*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
+
+ /**
+ * float[] helper to replace reflective array access.
+ * @author Pap Lőrinc
+ * @since 2.1.0
+ */
+final class FloatArrayType extends ArrayType<Float> {
+    private static final long serialVersionUID = 1L;
+    static final FloatArrayType INSTANCE = new FloatArrayType();
+    static final float[] EMPTY = new float[0];
+
+    private static float[] cast(Object array) { return (float[]) array; }
+
+    @Override
+    Class<Float> type() { return float.class; }
+
+    @Override
+    float[] empty() { return EMPTY; }
+
+    @Override
+    int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+
+    @Override
+    Float getAt(Object array, int index) { return cast(array)[index]; }
+
+    @Override
+    void setAt(Object array, int index, Object value) { cast(array)[index] = (Float) value; }
+
+    @Override
+    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+        if (size == 0) {
+            return new float[arraySize];
+        } else {
+            final float[] result = new float[arraySize];
+            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            return result;
+        }
+    }
+}

--- a/javaslang/src-gen/main/java/javaslang/collection/FloatArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/FloatArrayType.java
@@ -9,12 +9,15 @@ package javaslang.collection;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
- /**
+import java.io.Serializable;
+
+/**
  * float[] helper to replace reflective array access.
+ *
  * @author Pap Lőrinc
  * @since 2.1.0
  */
-final class FloatArrayType extends ArrayType<Float> {
+final class FloatArrayType implements ArrayType<Float>, Serializable {
     private static final long serialVersionUID = 1L;
     static final FloatArrayType INSTANCE = new FloatArrayType();
     static final float[] EMPTY = new float[0];
@@ -22,22 +25,22 @@ final class FloatArrayType extends ArrayType<Float> {
     private static float[] cast(Object array) { return (float[]) array; }
 
     @Override
-    Class<Float> type() { return float.class; }
+    public Class<Float> type() { return float.class; }
 
     @Override
-    float[] empty() { return EMPTY; }
+    public float[] empty() { return EMPTY; }
 
     @Override
-    int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+    public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
 
     @Override
-    Float getAt(Object array, int index) { return cast(array)[index]; }
+    public Float getAt(Object array, int index) { return cast(array)[index]; }
 
     @Override
-    void setAt(Object array, int index, Object value) { cast(array)[index] = (Float) value; }
+    public void setAt(Object array, int index, Object value) { cast(array)[index] = (Float) value; }
 
     @Override
-    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+    public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
         if (size == 0) {
             return new float[arraySize];
         } else {

--- a/javaslang/src-gen/main/java/javaslang/collection/IntArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/IntArrayType.java
@@ -1,0 +1,49 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2016 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*\
+   G E N E R A T O R   C R A F T E D
+\*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
+
+ /**
+ * int[] helper to replace reflective array access.
+ * @author Pap Lőrinc
+ * @since 2.1.0
+ */
+final class IntArrayType extends ArrayType<Integer> {
+    private static final long serialVersionUID = 1L;
+    static final IntArrayType INSTANCE = new IntArrayType();
+    static final int[] EMPTY = new int[0];
+
+    private static int[] cast(Object array) { return (int[]) array; }
+
+    @Override
+    Class<Integer> type() { return int.class; }
+
+    @Override
+    int[] empty() { return EMPTY; }
+
+    @Override
+    int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+
+    @Override
+    Integer getAt(Object array, int index) { return cast(array)[index]; }
+
+    @Override
+    void setAt(Object array, int index, Object value) { cast(array)[index] = (Integer) value; }
+
+    @Override
+    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+        if (size == 0) {
+            return new int[arraySize];
+        } else {
+            final int[] result = new int[arraySize];
+            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            return result;
+        }
+    }
+}

--- a/javaslang/src-gen/main/java/javaslang/collection/IntArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/IntArrayType.java
@@ -9,12 +9,15 @@ package javaslang.collection;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
- /**
+import java.io.Serializable;
+
+/**
  * int[] helper to replace reflective array access.
+ *
  * @author Pap Lőrinc
  * @since 2.1.0
  */
-final class IntArrayType extends ArrayType<Integer> {
+final class IntArrayType implements ArrayType<Integer>, Serializable {
     private static final long serialVersionUID = 1L;
     static final IntArrayType INSTANCE = new IntArrayType();
     static final int[] EMPTY = new int[0];
@@ -22,22 +25,22 @@ final class IntArrayType extends ArrayType<Integer> {
     private static int[] cast(Object array) { return (int[]) array; }
 
     @Override
-    Class<Integer> type() { return int.class; }
+    public Class<Integer> type() { return int.class; }
 
     @Override
-    int[] empty() { return EMPTY; }
+    public int[] empty() { return EMPTY; }
 
     @Override
-    int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+    public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
 
     @Override
-    Integer getAt(Object array, int index) { return cast(array)[index]; }
+    public Integer getAt(Object array, int index) { return cast(array)[index]; }
 
     @Override
-    void setAt(Object array, int index, Object value) { cast(array)[index] = (Integer) value; }
+    public void setAt(Object array, int index, Object value) { cast(array)[index] = (Integer) value; }
 
     @Override
-    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+    public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
         if (size == 0) {
             return new int[arraySize];
         } else {

--- a/javaslang/src-gen/main/java/javaslang/collection/LongArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/LongArrayType.java
@@ -9,12 +9,15 @@ package javaslang.collection;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
- /**
+import java.io.Serializable;
+
+/**
  * long[] helper to replace reflective array access.
+ *
  * @author Pap Lőrinc
  * @since 2.1.0
  */
-final class LongArrayType extends ArrayType<Long> {
+final class LongArrayType implements ArrayType<Long>, Serializable {
     private static final long serialVersionUID = 1L;
     static final LongArrayType INSTANCE = new LongArrayType();
     static final long[] EMPTY = new long[0];
@@ -22,22 +25,22 @@ final class LongArrayType extends ArrayType<Long> {
     private static long[] cast(Object array) { return (long[]) array; }
 
     @Override
-    Class<Long> type() { return long.class; }
+    public Class<Long> type() { return long.class; }
 
     @Override
-    long[] empty() { return EMPTY; }
+    public long[] empty() { return EMPTY; }
 
     @Override
-    int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+    public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
 
     @Override
-    Long getAt(Object array, int index) { return cast(array)[index]; }
+    public Long getAt(Object array, int index) { return cast(array)[index]; }
 
     @Override
-    void setAt(Object array, int index, Object value) { cast(array)[index] = (Long) value; }
+    public void setAt(Object array, int index, Object value) { cast(array)[index] = (Long) value; }
 
     @Override
-    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+    public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
         if (size == 0) {
             return new long[arraySize];
         } else {

--- a/javaslang/src-gen/main/java/javaslang/collection/LongArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/LongArrayType.java
@@ -1,0 +1,49 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2016 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*\
+   G E N E R A T O R   C R A F T E D
+\*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
+
+ /**
+ * long[] helper to replace reflective array access.
+ * @author Pap Lőrinc
+ * @since 2.1.0
+ */
+final class LongArrayType extends ArrayType<Long> {
+    private static final long serialVersionUID = 1L;
+    static final LongArrayType INSTANCE = new LongArrayType();
+    static final long[] EMPTY = new long[0];
+
+    private static long[] cast(Object array) { return (long[]) array; }
+
+    @Override
+    Class<Long> type() { return long.class; }
+
+    @Override
+    long[] empty() { return EMPTY; }
+
+    @Override
+    int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+
+    @Override
+    Long getAt(Object array, int index) { return cast(array)[index]; }
+
+    @Override
+    void setAt(Object array, int index, Object value) { cast(array)[index] = (Long) value; }
+
+    @Override
+    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+        if (size == 0) {
+            return new long[arraySize];
+        } else {
+            final long[] result = new long[arraySize];
+            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            return result;
+        }
+    }
+}

--- a/javaslang/src-gen/main/java/javaslang/collection/ObjectArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/ObjectArrayType.java
@@ -1,0 +1,49 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2016 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*\
+   G E N E R A T O R   C R A F T E D
+\*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
+
+ /**
+ * Object[] helper to replace reflective array access.
+ * @author Pap Lőrinc
+ * @since 2.1.0
+ */
+final class ObjectArrayType extends ArrayType<Object> {
+    private static final long serialVersionUID = 1L;
+    static final ObjectArrayType INSTANCE = new ObjectArrayType();
+    static final Object[] EMPTY = new Object[0];
+
+    private static Object[] cast(Object array) { return (Object[]) array; }
+
+    @Override
+    Class<Object> type() { return Object.class; }
+
+    @Override
+    Object[] empty() { return EMPTY; }
+
+    @Override
+    int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+
+    @Override
+    Object getAt(Object array, int index) { return cast(array)[index]; }
+
+    @Override
+    void setAt(Object array, int index, Object value) { cast(array)[index] =  value; }
+
+    @Override
+    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+        if (size == 0) {
+            return new Object[arraySize];
+        } else {
+            final Object[] result = new Object[arraySize];
+            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            return result;
+        }
+    }
+}

--- a/javaslang/src-gen/main/java/javaslang/collection/ObjectArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/ObjectArrayType.java
@@ -9,12 +9,15 @@ package javaslang.collection;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
- /**
+import java.io.Serializable;
+
+/**
  * Object[] helper to replace reflective array access.
+ *
  * @author Pap Lőrinc
  * @since 2.1.0
  */
-final class ObjectArrayType extends ArrayType<Object> {
+final class ObjectArrayType implements ArrayType<Object>, Serializable {
     private static final long serialVersionUID = 1L;
     static final ObjectArrayType INSTANCE = new ObjectArrayType();
     static final Object[] EMPTY = new Object[0];
@@ -22,22 +25,22 @@ final class ObjectArrayType extends ArrayType<Object> {
     private static Object[] cast(Object array) { return (Object[]) array; }
 
     @Override
-    Class<Object> type() { return Object.class; }
+    public Class<Object> type() { return Object.class; }
 
     @Override
-    Object[] empty() { return EMPTY; }
+    public Object[] empty() { return EMPTY; }
 
     @Override
-    int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+    public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
 
     @Override
-    Object getAt(Object array, int index) { return cast(array)[index]; }
+    public Object getAt(Object array, int index) { return cast(array)[index]; }
 
     @Override
-    void setAt(Object array, int index, Object value) { cast(array)[index] =  value; }
+    public void setAt(Object array, int index, Object value) { cast(array)[index] = value; }
 
     @Override
-    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+    public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
         if (size == 0) {
             return new Object[arraySize];
         } else {

--- a/javaslang/src-gen/main/java/javaslang/collection/ShortArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/ShortArrayType.java
@@ -9,12 +9,15 @@ package javaslang.collection;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
- /**
+import java.io.Serializable;
+
+/**
  * short[] helper to replace reflective array access.
+ *
  * @author Pap Lőrinc
  * @since 2.1.0
  */
-final class ShortArrayType extends ArrayType<Short> {
+final class ShortArrayType implements ArrayType<Short>, Serializable {
     private static final long serialVersionUID = 1L;
     static final ShortArrayType INSTANCE = new ShortArrayType();
     static final short[] EMPTY = new short[0];
@@ -22,22 +25,22 @@ final class ShortArrayType extends ArrayType<Short> {
     private static short[] cast(Object array) { return (short[]) array; }
 
     @Override
-    Class<Short> type() { return short.class; }
+    public Class<Short> type() { return short.class; }
 
     @Override
-    short[] empty() { return EMPTY; }
+    public short[] empty() { return EMPTY; }
 
     @Override
-    int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+    public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
 
     @Override
-    Short getAt(Object array, int index) { return cast(array)[index]; }
+    public Short getAt(Object array, int index) { return cast(array)[index]; }
 
     @Override
-    void setAt(Object array, int index, Object value) { cast(array)[index] = (Short) value; }
+    public void setAt(Object array, int index, Object value) { cast(array)[index] = (Short) value; }
 
     @Override
-    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+    public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
         if (size == 0) {
             return new short[arraySize];
         } else {

--- a/javaslang/src-gen/main/java/javaslang/collection/ShortArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/ShortArrayType.java
@@ -1,0 +1,49 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2016 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*\
+   G E N E R A T O R   C R A F T E D
+\*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
+
+ /**
+ * short[] helper to replace reflective array access.
+ * @author Pap Lőrinc
+ * @since 2.1.0
+ */
+final class ShortArrayType extends ArrayType<Short> {
+    private static final long serialVersionUID = 1L;
+    static final ShortArrayType INSTANCE = new ShortArrayType();
+    static final short[] EMPTY = new short[0];
+
+    private static short[] cast(Object array) { return (short[]) array; }
+
+    @Override
+    Class<Short> type() { return short.class; }
+
+    @Override
+    short[] empty() { return EMPTY; }
+
+    @Override
+    int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+
+    @Override
+    Short getAt(Object array, int index) { return cast(array)[index]; }
+
+    @Override
+    void setAt(Object array, int index, Object value) { cast(array)[index] = (Short) value; }
+
+    @Override
+    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+        if (size == 0) {
+            return new short[arraySize];
+        } else {
+            final short[] result = new short[arraySize];
+            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            return result;
+        }
+    }
+}

--- a/javaslang/src/main/java/javaslang/collection/ArrayType.java
+++ b/javaslang/src/main/java/javaslang/collection/ArrayType.java
@@ -5,52 +5,69 @@
  */
 package javaslang.collection;
 
-/**
- * Internal class, containing Java array manipulation helpers.
- * Many arrays are represented as simple Objects, to avoid casts at the client site, and to work with all types of arrays, including primitive ones.
- *
- * @author Pap Lőrinc
- * @since 2.1.0
- */
-final class ArrayType {
-    private static final Object[] EMPTY = {};
-    static Object empty() { return EMPTY; }
+import java.io.Serializable;
+
+abstract class ArrayType<T> implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     @SuppressWarnings("unchecked")
-    static <T> T newInstance(int length) { return (T) copy(empty(), length); }
+    static <T> ArrayType<T> obj() { return (ArrayType<T>) ObjectArrayType.INSTANCE; }
 
-    /** Create a single element array */
-    static Object asArray(Object element) {
-        final Object copy = newInstance(1);
-        setAt(copy, 0, element);
-        return copy;
-    }
+    abstract Class<T> type();
+    abstract int lengthOf(Object array);
+    abstract T getAt(Object array, int index);
 
-    /** Store the content of an iterable in an array */
-    static Object asArray(java.util.Iterator<?> it, int length) {
-        final Object array = newInstance(length);
-        for (int i = 0; i < length; i++) {
-            setAt(array, i, it.next());
+    abstract Object empty();
+    abstract void setAt(Object array, int index, Object value);
+    abstract Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size);
+
+    @SuppressWarnings("unchecked")
+    static <T> ArrayType<T> of(Object array) { return of((Class<T>) array.getClass().getComponentType()); }
+    @SuppressWarnings("unchecked")
+    private static <T> ArrayType<T> of(Class<T> type) {
+        if (!type.isPrimitive()) {
+            return (ArrayType<T>) obj();
+        } else {
+            if (boolean.class == type) {
+                return (ArrayType<T>) BooleanArrayType.INSTANCE;
+            } else if (byte.class == type) {
+                return (ArrayType<T>) ByteArrayType.INSTANCE;
+            } else if (char.class == type) {
+                return (ArrayType<T>) CharArrayType.INSTANCE;
+            } else if (double.class == type) {
+                return (ArrayType<T>) DoubleArrayType.INSTANCE;
+            } else if (float.class == type) {
+                return (ArrayType<T>) FloatArrayType.INSTANCE;
+            } else if (int.class == type) {
+                return (ArrayType<T>) IntArrayType.INSTANCE;
+            } else if (long.class == type) {
+                return (ArrayType<T>) LongArrayType.INSTANCE;
+            } else if (short.class == type) {
+                return (ArrayType<T>) ShortArrayType.INSTANCE;
+            } else {
+                throw new IllegalArgumentException("Unknown type: " + type);
+            }
         }
-        return array;
     }
+
+    Object newInstance(int length) { return copy(empty(), length); }
 
     /** System.arrayCopy with same source and destination */
-    static Object copyRange(Object array, int from, int to) {
+    Object copyRange(Object array, int from, int to) {
         final int length = to - from;
-        return arrayCopy(length, array, from, 0, length);
+        return copy(array, length, from, 0, length);
     }
 
     /** Repeatedly group an array into equal sized sub-trees */
-    static Object grouped(Object array, int groupSize) {
+    Object grouped(Object array, int groupSize) {
         final int arrayLength = lengthOf(array);
         assert arrayLength > groupSize;
-        final Object results = newInstance(1 + ((arrayLength - 1) / groupSize));
-        setAt(results, 0, copyRange(array, 0, groupSize));
+        final Object results = obj().newInstance(1 + ((arrayLength - 1) / groupSize));
+        obj().setAt(results, 0, copyRange(array, 0, groupSize));
 
         for (int start = groupSize, i = 1; start < arrayLength; i++) {
             final int nextLength = Math.min(groupSize, arrayLength - (i * groupSize));
-            setAt(results, i, copyRange(array, start, start + nextLength));
+            obj().setAt(results, i, copyRange(array, start, start + nextLength));
             start += nextLength;
         }
 
@@ -58,46 +75,73 @@ final class ArrayType {
     }
 
     /** clone the source and set the value at the given position */
-    static Object copyUpdate(Object array, int index, Object element) {
+    Object copyUpdate(Object array, int index, T element) {
         final Object copy = copy(array, index + 1);
         setAt(copy, index, element);
         return copy;
     }
 
-    static Object copy(Object array, int minLength) {
-        final int arrayLength = (array == null) ? 0 : lengthOf(array);
+    Object copy(Object array, int minLength) {
+        final int arrayLength = lengthOf(array);
         final int length = Math.max(arrayLength, minLength);
-        return arrayCopy(length, array, 0, 0, arrayLength);
+        return copy(array, length, 0, 0, arrayLength);
     }
 
     /** clone the source and keep everything after the index (pre-padding the values with null) */
-    static Object copyDrop(Object array, int index) {
+    Object copyDrop(Object array, int index) {
         final int length = lengthOf(array);
-        return arrayCopy(length, array, index, index, length - index);
+        return copy(array, length, index, index, length - index);
     }
 
     /** clone the source and keep everything before and including the index */
-    static Object copyTake(Object array, int lastIndex) {
+    Object copyTake(Object array, int lastIndex) {
         return copyRange(array, 0, lastIndex + 1);
     }
 
-    /** for performance reasons the array allocation and the System.arraycopy must be next to each other */
-    static Object arrayCopy(int arraySize, Object source, int sourceFrom, int destinationFrom, int size) {
-        if (size == 0) {
-            return new Object[arraySize];
-        } else {
-            final Object[] result = new Object[arraySize];
-            System.arraycopy(source, sourceFrom, result, destinationFrom, size);
-            return result;
-        }
+    /** Create a single element array */
+    Object asArray(T element) {
+        final Object result = newInstance(1);
+        setAt(result, 0, element);
+        return result;
     }
 
-    /** array access, avoiding call-site casts */
+    /** Store the content of an iterable in an array */
+    static Object[] asArray(java.util.Iterator<?> it, int length) {
+        final Object[] array = new Object[length];
+        for (int i = 0; i < length; i++) {
+            array[i] = it.next();
+        }
+        return array;
+    }
+
     @SuppressWarnings("unchecked")
-    static <T> T getAt(Object array, int index) { return (T) ((Object[]) array)[index]; }
-    @SuppressWarnings("unchecked")
-    static void setAt(Object array, int index, Object value) { ((Object[]) array)[index] = value; }
-    static int lengthOf(Object array) {
-        return ((Object[]) array).length;
+    static <T> T asPrimitives(Class<?> primitiveClass, Iterable<?> values) {
+        final Object[] array = Array.ofAll(values).toJavaArray();
+        assert (array.length == 0) || (primitiveClass == asPrimitive(array[0].getClass())) && !primitiveClass.isArray();
+        final ArrayType<T> type = of((Class<T>) primitiveClass);
+        final Object results = type.newInstance(array.length);
+        for (int i = 0; i < array.length; i++) {
+            type.setAt(results, i, array[i]);
+        }
+        return (T) results;
+    }
+
+    /* convert to primitive */
+    private static final Class<?>[] WRAPPERS = { Boolean.class, Byte.class, Character.class, Double.class, Float.class, Integer.class, Long.class, Short.class, Void.class };
+    private static final Class<?>[] PRIMITIVES = { boolean.class, byte.class, char.class, double.class, float.class, int.class, long.class, short.class, void.class };
+
+    static Class<?> asPrimitive(Class<?> wrapper) {
+        final int i = primitiveIndex(wrapper);
+        return (i < 0) ? wrapper
+                       : PRIMITIVES[i];
+    }
+
+    private static int primitiveIndex(Class<?> wrapper) { /* linear search is faster than binary search here */
+        for (int j = 0; j < WRAPPERS.length; j++) {
+            if (wrapper == WRAPPERS[j]) {
+                return j;
+            }
+        }
+        return -1;
     }
 }

--- a/javaslang/src/main/java/javaslang/collection/ArrayType.java
+++ b/javaslang/src/main/java/javaslang/collection/ArrayType.java
@@ -14,42 +14,43 @@ package javaslang.collection;
  */
 final class ArrayType {
     private static final Object[] EMPTY = {};
-    static Object[] empty() { return EMPTY; }
+    static Object empty() { return EMPTY; }
 
     @SuppressWarnings("unchecked")
     static <T> T newInstance(int length) { return (T) copy(empty(), length); }
 
     /** Create a single element array */
-    static Object[] asArray(Object element) {
-        final Object[] copy = newInstance(1);
-        copy[0] = element;
+    static Object asArray(Object element) {
+        final Object copy = newInstance(1);
+        setAt(copy, 0, element);
         return copy;
     }
 
     /** Store the content of an iterable in an array */
-    static Object[] asArray(java.util.Iterator<?> it, int length) {
-        final Object[] array = newInstance(length);
+    static Object asArray(java.util.Iterator<?> it, int length) {
+        final Object array = newInstance(length);
         for (int i = 0; i < length; i++) {
-            array[i] = it.next();
+            setAt(array, i, it.next());
         }
         return array;
     }
 
     /** System.arrayCopy with same source and destination */
-    static Object[] copyRange(Object array, int from, int to) {
+    static Object copyRange(Object array, int from, int to) {
         final int length = to - from;
         return arrayCopy(length, array, from, 0, length);
     }
 
     /** Repeatedly group an array into equal sized sub-trees */
-    static Object[] grouped(Object[] array, int groupSize) {
-        assert array.length > groupSize;
-        final Object[] results = newInstance(1 + ((array.length - 1) / groupSize));
-        results[0] = copyRange(array, 0, groupSize);
+    static Object grouped(Object array, int groupSize) {
+        final int arrayLength = lengthOf(array);
+        assert arrayLength > groupSize;
+        final Object results = newInstance(1 + ((arrayLength - 1) / groupSize));
+        setAt(results, 0, copyRange(array, 0, groupSize));
 
-        for (int start = groupSize, i = 1; start < array.length; i++) {
-            final int nextLength = Math.min(groupSize, array.length - (i * groupSize));
-            results[i] = copyRange(array, start, start + nextLength);
+        for (int start = groupSize, i = 1; start < arrayLength; i++) {
+            final int nextLength = Math.min(groupSize, arrayLength - (i * groupSize));
+            setAt(results, i, copyRange(array, start, start + nextLength));
             start += nextLength;
         }
 
@@ -57,35 +58,31 @@ final class ArrayType {
     }
 
     /** clone the source and set the value at the given position */
-    static Object[] copyUpdate(Object arrayObject, int index, Object element) {
-        final Object[] array = (Object[]) arrayObject;
-        final Object[] copy = copy(array, index + 1);
-        copy[index] = element;
+    static Object copyUpdate(Object array, int index, Object element) {
+        final Object copy = copy(array, index + 1);
+        setAt(copy, index, element);
         return copy;
     }
 
-    static Object[] copy(Object arrayObject, int minLength) {
-        final Object[] array = (Object[]) arrayObject;
-        final int arrayLength = (array == null) ? 0 : array.length;
+    static Object copy(Object array, int minLength) {
+        final int arrayLength = (array == null) ? 0 : lengthOf(array);
         final int length = Math.max(arrayLength, minLength);
         return arrayCopy(length, array, 0, 0, arrayLength);
     }
 
     /** clone the source and keep everything after the index (pre-padding the values with null) */
-    static Object[] copyDrop(Object arrayObject, int index) {
-        final Object[] array = (Object[]) arrayObject;
-        final int length = array.length;
+    static Object copyDrop(Object array, int index) {
+        final int length = lengthOf(array);
         return arrayCopy(length, array, index, index, length - index);
     }
 
     /** clone the source and keep everything before and including the index */
-    static Object[] copyTake(Object arrayObject, int lastIndex) {
-        final Object[] array = (Object[]) arrayObject;
+    static Object copyTake(Object array, int lastIndex) {
         return copyRange(array, 0, lastIndex + 1);
     }
 
     /** for performance reasons the array allocation and the System.arraycopy must be next to each other */
-    static Object[] arrayCopy(int arraySize, Object source, int sourceFrom, int destinationFrom, int size) {
+    static Object arrayCopy(int arraySize, Object source, int sourceFrom, int destinationFrom, int size) {
         if (size == 0) {
             return new Object[arraySize];
         } else {
@@ -97,8 +94,10 @@ final class ArrayType {
 
     /** array access, avoiding call-site casts */
     @SuppressWarnings("unchecked")
-    static <T> T getAt(Object arrayObject, int index) {
-        final Object[] array = (Object[]) arrayObject;
-        return (T) array[index];
+    static <T> T getAt(Object array, int index) { return (T) ((Object[]) array)[index]; }
+    @SuppressWarnings("unchecked")
+    static void setAt(Object array, int index, Object value) { ((Object[]) array)[index] = value; }
+    static int lengthOf(Object array) {
+        return ((Object[]) array).length;
     }
 }

--- a/javaslang/src/main/java/javaslang/collection/ArrayType.java
+++ b/javaslang/src/main/java/javaslang/collection/ArrayType.java
@@ -5,61 +5,55 @@
  */
 package javaslang.collection;
 
-import java.io.Serializable;
-
-abstract class ArrayType<T> implements Serializable {
-    private static final long serialVersionUID = 1L;
-
+interface ArrayType<T> {
     @SuppressWarnings("unchecked")
     static <T> ArrayType<T> obj() { return (ArrayType<T>) ObjectArrayType.INSTANCE; }
 
-    abstract Class<T> type();
-    abstract int lengthOf(Object array);
-    abstract T getAt(Object array, int index);
+    Class<T> type();
+    int lengthOf(Object array);
+    T getAt(Object array, int index);
 
-    abstract Object empty();
-    abstract void setAt(Object array, int index, Object value);
-    abstract Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size);
+    Object empty();
+    void setAt(Object array, int index, Object value);
+    Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size);
 
     @SuppressWarnings("unchecked")
     static <T> ArrayType<T> of(Object array) { return of((Class<T>) array.getClass().getComponentType()); }
     @SuppressWarnings("unchecked")
-    private static <T> ArrayType<T> of(Class<T> type) {
+    static <T> ArrayType<T> of(Class<T> type) {
         if (!type.isPrimitive()) {
             return (ArrayType<T>) obj();
+        } else if (boolean.class == type) {
+            return (ArrayType<T>) BooleanArrayType.INSTANCE;
+        } else if (byte.class == type) {
+            return (ArrayType<T>) ByteArrayType.INSTANCE;
+        } else if (char.class == type) {
+            return (ArrayType<T>) CharArrayType.INSTANCE;
+        } else if (double.class == type) {
+            return (ArrayType<T>) DoubleArrayType.INSTANCE;
+        } else if (float.class == type) {
+            return (ArrayType<T>) FloatArrayType.INSTANCE;
+        } else if (int.class == type) {
+            return (ArrayType<T>) IntArrayType.INSTANCE;
+        } else if (long.class == type) {
+            return (ArrayType<T>) LongArrayType.INSTANCE;
+        } else if (short.class == type) {
+            return (ArrayType<T>) ShortArrayType.INSTANCE;
         } else {
-            if (boolean.class == type) {
-                return (ArrayType<T>) BooleanArrayType.INSTANCE;
-            } else if (byte.class == type) {
-                return (ArrayType<T>) ByteArrayType.INSTANCE;
-            } else if (char.class == type) {
-                return (ArrayType<T>) CharArrayType.INSTANCE;
-            } else if (double.class == type) {
-                return (ArrayType<T>) DoubleArrayType.INSTANCE;
-            } else if (float.class == type) {
-                return (ArrayType<T>) FloatArrayType.INSTANCE;
-            } else if (int.class == type) {
-                return (ArrayType<T>) IntArrayType.INSTANCE;
-            } else if (long.class == type) {
-                return (ArrayType<T>) LongArrayType.INSTANCE;
-            } else if (short.class == type) {
-                return (ArrayType<T>) ShortArrayType.INSTANCE;
-            } else {
-                throw new IllegalArgumentException("Unknown type: " + type);
-            }
+            throw new IllegalArgumentException("Unknown type: " + type);
         }
     }
 
-    Object newInstance(int length) { return copy(empty(), length); }
+    default Object newInstance(int length) { return copy(empty(), length); }
 
     /** System.arrayCopy with same source and destination */
-    Object copyRange(Object array, int from, int to) {
+    default Object copyRange(Object array, int from, int to) {
         final int length = to - from;
         return copy(array, length, from, 0, length);
     }
 
     /** Repeatedly group an array into equal sized sub-trees */
-    Object grouped(Object array, int groupSize) {
+    default Object grouped(Object array, int groupSize) {
         final int arrayLength = lengthOf(array);
         assert arrayLength > groupSize;
         final Object results = obj().newInstance(1 + ((arrayLength - 1) / groupSize));
@@ -75,31 +69,31 @@ abstract class ArrayType<T> implements Serializable {
     }
 
     /** clone the source and set the value at the given position */
-    Object copyUpdate(Object array, int index, T element) {
+    default Object copyUpdate(Object array, int index, T element) {
         final Object copy = copy(array, index + 1);
         setAt(copy, index, element);
         return copy;
     }
 
-    Object copy(Object array, int minLength) {
+    default Object copy(Object array, int minLength) {
         final int arrayLength = lengthOf(array);
         final int length = Math.max(arrayLength, minLength);
         return copy(array, length, 0, 0, arrayLength);
     }
 
     /** clone the source and keep everything after the index (pre-padding the values with null) */
-    Object copyDrop(Object array, int index) {
+    default Object copyDrop(Object array, int index) {
         final int length = lengthOf(array);
         return copy(array, length, index, index, length - index);
     }
 
     /** clone the source and keep everything before and including the index */
-    Object copyTake(Object array, int lastIndex) {
+    default Object copyTake(Object array, int lastIndex) {
         return copyRange(array, 0, lastIndex + 1);
     }
 
     /** Create a single element array */
-    Object asArray(T element) {
+    default Object asArray(T element) {
         final Object result = newInstance(1);
         setAt(result, 0, element);
         return result;
@@ -117,7 +111,7 @@ abstract class ArrayType<T> implements Serializable {
     @SuppressWarnings("unchecked")
     static <T> T asPrimitives(Class<?> primitiveClass, Iterable<?> values) {
         final Object[] array = Array.ofAll(values).toJavaArray();
-        assert (array.length == 0) || (primitiveClass == asPrimitive(array[0].getClass())) && !primitiveClass.isArray();
+        assert (array.length == 0) || (primitiveClass == primitiveType(array[0])) && !primitiveClass.isArray();
         final ArrayType<T> type = of((Class<T>) primitiveClass);
         final Object results = type.newInstance(array.length);
         for (int i = 0; i < array.length; i++) {
@@ -126,22 +120,26 @@ abstract class ArrayType<T> implements Serializable {
         return (T) results;
     }
 
-    /* convert to primitive */
-    private static final Class<?>[] WRAPPERS = { Boolean.class, Byte.class, Character.class, Double.class, Float.class, Integer.class, Long.class, Short.class, Void.class };
-    private static final Class<?>[] PRIMITIVES = { boolean.class, byte.class, char.class, double.class, float.class, int.class, long.class, short.class, void.class };
-
-    static Class<?> asPrimitive(Class<?> wrapper) {
-        final int i = primitiveIndex(wrapper);
-        return (i < 0) ? wrapper
-                       : PRIMITIVES[i];
-    }
-
-    private static int primitiveIndex(Class<?> wrapper) { /* linear search is faster than binary search here */
-        for (int j = 0; j < WRAPPERS.length; j++) {
-            if (wrapper == WRAPPERS[j]) {
-                return j;
-            }
+    static <T> Class<?> primitiveType(T element) {
+        final Class<?> wrapper = (element == null) ? Object.class : element.getClass();
+        if (wrapper == Boolean.class) {
+            return boolean.class;
+        } else if (wrapper == Byte.class) {
+            return byte.class;
+        } else if (wrapper == Character.class) {
+            return char.class;
+        } else if (wrapper == Double.class) {
+            return double.class;
+        } else if (wrapper == Float.class) {
+            return float.class;
+        } else if (wrapper == Integer.class) {
+            return int.class;
+        } else if (wrapper == Long.class) {
+            return long.class;
+        } else if (wrapper == Short.class) {
+            return short.class;
+        } else {
+            return wrapper;
         }
-        return -1;
     }
 }

--- a/javaslang/src/main/java/javaslang/collection/ArrayType.java
+++ b/javaslang/src/main/java/javaslang/collection/ArrayType.java
@@ -12,7 +12,7 @@ package javaslang.collection;
  * @author Pap Lőrinc
  * @since 2.1.0
  */
-final class Arrays {
+final class ArrayType {
     private static final Object[] EMPTY = {};
     static Object[] empty() { return EMPTY; }
 

--- a/javaslang/src/main/java/javaslang/collection/BitMappedTrie.java
+++ b/javaslang/src/main/java/javaslang/collection/BitMappedTrie.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static javaslang.collection.Arrays.*;
+import static javaslang.collection.ArrayType.*;
 import static javaslang.collection.NodeModifier.*;
 
 /**
@@ -37,7 +37,7 @@ final class BitMappedTrie<T> implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static final BitMappedTrie<?> EMPTY = new BitMappedTrie<>(Arrays.empty(), 0, 0, 0);
+    private static final BitMappedTrie<?> EMPTY = new BitMappedTrie<>(ArrayType.empty(), 0, 0, 0);
     @SuppressWarnings("unchecked")
     static <T> BitMappedTrie<T> empty() { return (BitMappedTrie<T>) EMPTY; }
 
@@ -81,7 +81,7 @@ final class BitMappedTrie<T> implements Serializable {
             Object[] array = this.array;
             int shift = depthShift, offset = this.offset;
             if (isFullLeft()) {
-                array = copyUpdate(Arrays.empty(), BRANCHING_FACTOR - 1, array);
+                array = copyUpdate(ArrayType.empty(), BRANCHING_FACTOR - 1, array);
                 shift += BRANCHING_BASE;
                 offset = treeSize(BRANCHING_FACTOR - 1, shift);
             }
@@ -125,7 +125,7 @@ final class BitMappedTrie<T> implements Serializable {
             final int index = offset + n;
             final Object[] root = arePointingToSameLeaf(0, n)
                                   ? array
-                                  : modifyLeaf(array, depthShift, index, Arrays::copyDrop, IDENTITY);
+                                  : modifyLeaf(array, depthShift, index, ArrayType::copyDrop, IDENTITY);
             return collapsed(root, index, length() - n, depthShift);
         }
     }
@@ -139,7 +139,7 @@ final class BitMappedTrie<T> implements Serializable {
             final int index = n - 1;
             final Object[] root = arePointingToSameLeaf(index, length() - 1)
                                   ? array
-                                  : modifyLeaf(array, depthShift, offset + index, Arrays::copyTake, IDENTITY);
+                                  : modifyLeaf(array, depthShift, offset + index, ArrayType::copyTake, IDENTITY);
             return collapsed(root, offset, n, depthShift);
         }
     }

--- a/javaslang/src/main/java/javaslang/collection/BitMappedTrie.java
+++ b/javaslang/src/main/java/javaslang/collection/BitMappedTrie.java
@@ -10,9 +10,9 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static javaslang.Function1.identity;
-import static javaslang.collection.ArrayType.asPrimitive;
+import static java.util.function.Function.identity;
 import static javaslang.collection.ArrayType.obj;
+import static javaslang.collection.ArrayType.primitiveType;
 import static javaslang.collection.NodeModifier.*;
 
 /**
@@ -79,9 +79,11 @@ final class BitMappedTrie<T> implements Serializable {
         }
     }
 
+    private BitMappedTrie<T> boxed() { return map(identity()); }
+
     BitMappedTrie<T> prepend(T leading) {
         if (cannotAdd(leading)) {
-            return map(identity()).prepend(leading);
+            return boxed().prepend(leading);
         } else {
             final int newSize = length() + 1;
             if (length() == 0) {
@@ -105,7 +107,7 @@ final class BitMappedTrie<T> implements Serializable {
 
     BitMappedTrie<T> append(T trailing) {
         if (cannotAdd(trailing)) {
-            return map(identity()).append(trailing);
+            return boxed().append(trailing);
         } else {
             final int newSize = length() + 1;
             if (length() == 0) {
@@ -127,7 +129,7 @@ final class BitMappedTrie<T> implements Serializable {
 
     BitMappedTrie<T> update(int index, T element) {
         if (cannotAdd(element)) {
-            return map(identity()).update(index, element);
+            return boxed().update(index, element);
         } else {
             final Object root = modifyLeaf(array, depthShift, offset + index, COPY_NODE, updateLeafWith(type, element));
             return new BitMappedTrie<>(type, root, offset, length(), depthShift);
@@ -314,7 +316,7 @@ final class BitMappedTrie<T> implements Serializable {
     }
 
     int length()                         { return length; }
-    private boolean cannotAdd(T element) { return type != obj() && ((element == null) || (type.type() != asPrimitive(element.getClass()))); }
+    private boolean cannotAdd(T element) { return (type != obj()) && (type.type() != primitiveType(element)); }
 }
 
 @FunctionalInterface

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -18,7 +18,6 @@ import static javaslang.collection.ArrayType.asArray;
 import static javaslang.collection.Collections.areEqual;
 import static javaslang.collection.Collections.seq;
 import static javaslang.collection.ArrayType.asArray;
-import static javaslang.collection.ArrayType.lengthOf;
 
 /**
  * Vector is the default Seq implementation that provides effectively constant time access to any element.
@@ -193,7 +192,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      */
     public static Vector<Boolean> ofAll(boolean... array) {
         Objects.requireNonNull(array, "array is null");
-        return ofAll(Iterator.ofAll(array));
+        return ofAll(BitMappedTrie.ofAll(array));
     }
 
     /**
@@ -204,7 +203,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      */
     public static Vector<Byte> ofAll(byte... array) {
         Objects.requireNonNull(array, "array is null");
-        return ofAll(Iterator.ofAll(array));
+        return ofAll(BitMappedTrie.ofAll(array));
     }
 
     /**
@@ -215,7 +214,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      */
     public static Vector<Character> ofAll(char... array) {
         Objects.requireNonNull(array, "array is null");
-        return ofAll(Iterator.ofAll(array));
+        return ofAll(BitMappedTrie.ofAll(array));
     }
 
     /**
@@ -226,7 +225,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      */
     public static Vector<Double> ofAll(double... array) {
         Objects.requireNonNull(array, "array is null");
-        return ofAll(Iterator.ofAll(array));
+        return ofAll(BitMappedTrie.ofAll(array));
     }
 
     /**
@@ -237,7 +236,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      */
     public static Vector<Float> ofAll(float... array) {
         Objects.requireNonNull(array, "array is null");
-        return ofAll(Iterator.ofAll(array));
+        return ofAll(BitMappedTrie.ofAll(array));
     }
 
     /**
@@ -248,7 +247,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      */
     public static Vector<Integer> ofAll(int... array) {
         Objects.requireNonNull(array, "array is null");
-        return ofAll(Iterator.ofAll(array));
+        return ofAll(BitMappedTrie.ofAll(array));
     }
 
     /**
@@ -259,7 +258,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      */
     public static Vector<Long> ofAll(long... array) {
         Objects.requireNonNull(array, "array is null");
-        return ofAll(Iterator.ofAll(array));
+        return ofAll(BitMappedTrie.ofAll(array));
     }
 
     /**
@@ -270,20 +269,20 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      */
     public static Vector<Short> ofAll(short... array) {
         Objects.requireNonNull(array, "array is null");
-        return ofAll(Iterator.ofAll(array));
+        return ofAll(BitMappedTrie.ofAll(array));
     }
 
     public static Vector<Character> range(char from, char toExclusive) {
-        return ofAll(Iterator.range(from, toExclusive));
+        return ofAll(ArrayType.<char[]> asPrimitives(char.class, Iterator.range(from, toExclusive)));
     }
 
     public static Vector<Character> rangeBy(char from, char toExclusive, int step) {
-        return ofAll(Iterator.rangeBy(from, toExclusive, step));
+        return ofAll(ArrayType.<char[]> asPrimitives(char.class, Iterator.rangeBy(from, toExclusive, step)));
     }
 
     @GwtIncompatible
     public static Vector<Double> rangeBy(double from, double toExclusive, double step) {
-        return ofAll(Iterator.rangeBy(from, toExclusive, step));
+        return ofAll(ArrayType.<double[]> asPrimitives(double.class, Iterator.rangeBy(from, toExclusive, step)));
     }
 
     /**
@@ -303,7 +302,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @return a range of int values as specified or the empty range if {@code from >= toExclusive}
      */
     public static Vector<Integer> range(int from, int toExclusive) {
-        return ofAll(Iterator.range(from, toExclusive));
+        return ofAll(ArrayType.<int[]> asPrimitives(int.class, Iterator.range(from, toExclusive)));
     }
 
     /**
@@ -329,7 +328,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @throws IllegalArgumentException if {@code step} is zero
      */
     public static Vector<Integer> rangeBy(int from, int toExclusive, int step) {
-        return ofAll(Iterator.rangeBy(from, toExclusive, step));
+        return ofAll(ArrayType.<int[]> asPrimitives(int.class, Iterator.rangeBy(from, toExclusive, step)));
     }
 
     /**
@@ -349,7 +348,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @return a range of long values as specified or the empty range if {@code from >= toExclusive}
      */
     public static Vector<Long> range(long from, long toExclusive) {
-        return ofAll(Iterator.range(from, toExclusive));
+        return ofAll(ArrayType.<long[]> asPrimitives(long.class, Iterator.range(from, toExclusive)));
     }
 
     /**
@@ -375,20 +374,20 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @throws IllegalArgumentException if {@code step} is zero
      */
     public static Vector<Long> rangeBy(long from, long toExclusive, long step) {
-        return ofAll(Iterator.rangeBy(from, toExclusive, step));
+        return ofAll(ArrayType.<long[]> asPrimitives(long.class, Iterator.rangeBy(from, toExclusive, step)));
     }
 
     public static Vector<Character> rangeClosed(char from, char toInclusive) {
-        return ofAll(Iterator.rangeClosed(from, toInclusive));
+        return ofAll(ArrayType.<char[]> asPrimitives(char.class, Iterator.rangeClosed(from, toInclusive)));
     }
 
     public static Vector<Character> rangeClosedBy(char from, char toInclusive, int step) {
-        return ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
+        return ofAll(ArrayType.<char[]> asPrimitives(char.class, Iterator.rangeClosedBy(from, toInclusive, step)));
     }
 
     @GwtIncompatible
     public static Vector<Double> rangeClosedBy(double from, double toInclusive, double step) {
-        return ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
+        return ofAll(ArrayType.<double[]> asPrimitives(double.class, Iterator.rangeClosedBy(from, toInclusive, step)));
     }
 
     /**
@@ -408,7 +407,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @return a range of int values as specified or the empty range if {@code from > toInclusive}
      */
     public static Vector<Integer> rangeClosed(int from, int toInclusive) {
-        return ofAll(Iterator.rangeClosed(from, toInclusive));
+        return ofAll(ArrayType.<int[]> asPrimitives(int.class, Iterator.rangeClosed(from, toInclusive)));
     }
 
     /**
@@ -434,7 +433,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @throws IllegalArgumentException if {@code step} is zero
      */
     public static Vector<Integer> rangeClosedBy(int from, int toInclusive, int step) {
-        return ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
+        return ofAll(ArrayType.<int[]> asPrimitives(int.class, Iterator.rangeClosedBy(from, toInclusive, step)));
     }
 
     /**
@@ -454,7 +453,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @return a range of long values as specified or the empty range if {@code from > toInclusive}
      */
     public static Vector<Long> rangeClosed(long from, long toInclusive) {
-        return ofAll(Iterator.rangeClosed(from, toInclusive));
+        return ofAll(ArrayType.<long[]> asPrimitives(long.class, Iterator.rangeClosed(from, toInclusive)));
     }
 
     /**
@@ -480,7 +479,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
      * @throws IllegalArgumentException if {@code step} is zero
      */
     public static Vector<Long> rangeClosedBy(long from, long toInclusive, long step) {
-        return ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
+        return ofAll(ArrayType.<long[]> asPrimitives(long.class, Iterator.rangeClosedBy(from, toInclusive, step)));
     }
 
     /**

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -17,6 +17,8 @@ import java.util.stream.Collector;
 import static javaslang.collection.ArrayType.asArray;
 import static javaslang.collection.Collections.areEqual;
 import static javaslang.collection.Collections.seq;
+import static javaslang.collection.ArrayType.asArray;
+import static javaslang.collection.ArrayType.lengthOf;
 
 /**
  * Vector is the default Seq implementation that provides effectively constant time access to any element.
@@ -162,11 +164,11 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
         if (iterable instanceof Vector) {
             return (Vector<T>) iterable;
         } else if (iterable instanceof Collection<?>) {
-            final Object[] array = ((Collection<? extends T>) iterable).toArray();
+            final Object array = ((Collection<? extends T>) iterable).toArray();
             return ofAll(BitMappedTrie.ofAll(array));
         } else {
             final Seq<? extends T> elems = seq(iterable);
-            final Object[] array = asArray(elems.iterator(), elems.size());
+            final Object array = asArray(elems.iterator(), elems.size());
             return ofAll(BitMappedTrie.ofAll(array));
         }
     }

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -14,7 +14,7 @@ import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;
 
-import static javaslang.collection.Arrays.asArray;
+import static javaslang.collection.ArrayType.asArray;
 import static javaslang.collection.Collections.areEqual;
 import static javaslang.collection.Collections.seq;
 

--- a/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
@@ -29,6 +29,53 @@ public class VectorPropertyTest {
             for (int j = 0; j < actual.size(); j++) {
                 assertThat(expected.get(j)).isEqualTo(actual.get(j));
             }
+
+            /* boolean */
+            final Seq<Boolean> expectedBoolean = expected.map(v -> v > 0);
+            final Vector<Boolean> actualBoolean = Vector.ofAll(ArrayType.<boolean[]> asPrimitives(boolean.class, expectedBoolean));
+            assert (i == 0) || (actualBoolean.trie.type.type() == boolean.class);
+            assertAreEqual(expectedBoolean, actualBoolean);
+
+            /* byte */
+            final Seq<Byte> expectedByte = expected.map(Integer::byteValue);
+            final Vector<Byte> actualByte = Vector.ofAll(ArrayType.<byte[]> asPrimitives(byte.class, expectedByte));
+            assert (i == 0) || (actualByte.trie.type.type() == byte.class);
+            assertAreEqual(expectedByte, actualByte);
+
+            /* char */
+            final Seq<Character> expectedChar = expected.map(v -> (char) v.intValue());
+            final Vector<Character> actualChar = Vector.ofAll(ArrayType.<char[]> asPrimitives(char.class, expectedChar));
+            assert (i == 0) || (actualChar.trie.type.type() == char.class);
+            assertAreEqual(expectedChar, actualChar);
+
+            /* double */
+            final Seq<Double> expectedDouble = expected.map(Integer::doubleValue);
+            final Vector<Double> actualDouble = Vector.ofAll(ArrayType.<double[]> asPrimitives(double.class, expectedDouble));
+            assert (i == 0) || (actualDouble.trie.type.type() == double.class);
+            assertAreEqual(expectedDouble, actualDouble);
+
+            /* float */
+            final Seq<Float> expectedFloat = expected.map(Integer::floatValue);
+            final Vector<Float> actualFloat = Vector.ofAll(ArrayType.<float[]> asPrimitives(float.class, expectedFloat));
+            assert (i == 0) || (actualFloat.trie.type.type() == float.class);
+            assertAreEqual(expectedFloat, actualFloat);
+
+            /* int */
+            final Vector<Integer> actualInt = Vector.ofAll(ArrayType.<int[]> asPrimitives(int.class, expected));
+            assert (i == 0) || (actualInt.trie.type.type() == int.class);
+            assertAreEqual(expected, actualInt);
+
+            /* long */
+            final Seq<Long> expectedLong = expected.map(Integer::longValue);
+            final Vector<Long> actualLog = Vector.ofAll(ArrayType.<long[]> asPrimitives(long.class, expectedLong));
+            assert (i == 0) || (actualLog.trie.type.type() == long.class);
+            assertAreEqual(expectedLong, actualLog);
+
+            /* short */
+            final Seq<Short> expectedShort = expected.map(Integer::shortValue);
+            final Vector<Short> actualShort = Vector.ofAll(ArrayType.<short[]> asPrimitives(short.class, expectedShort));
+            assert (i == 0) || (actualShort.trie.type.type() == short.class);
+            assertAreEqual(expectedShort, actualShort);
         }
     }
 
@@ -43,10 +90,10 @@ public class VectorPropertyTest {
         }
 
         Seq<Integer> expected = Array.range(0, 1000);
-        Vector<Integer> actual = Vector.ofAll(expected);
+        Vector<Integer> actual = Vector.ofAll(ArrayType.<int[]> asPrimitives(int.class, expected));
         for (int drop = 0; drop <= (BRANCHING_FACTOR + 1); drop++) {
             final Iterator<Integer> expectedIterator = expected.iterator();
-            actual.trie.<Object[]> visit((index, leaf, start, end) -> {
+            actual.trie.<int[]> visit((index, leaf, start, end) -> {
                 for (int i = start; i < end; i++) {
                     assertThat(leaf[i]).isEqualTo(expectedIterator.next());
                 }
@@ -181,7 +228,8 @@ public class VectorPropertyTest {
                         values.add(random.nextInt());
                     }
                     expected = Array.ofAll(values);
-                    actual = Vector.ofAll(values);
+                    final boolean isPrimitive = percent(random) < 30;
+                    actual = isPrimitive ? Vector.narrow(Vector.ofAll(ArrayType.<int[]> asPrimitives(int.class, values))) : Vector.ofAll(values);
                     assertAreEqual(expected, actual);
                     history = history.append(Tuple.of(expected, actual));
                 }

--- a/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
@@ -46,7 +46,7 @@ public class VectorPropertyTest {
         Vector<Integer> actual = Vector.ofAll(expected);
         for (int drop = 0; drop <= (BRANCHING_FACTOR + 1); drop++) {
             final Iterator<Integer> expectedIterator = expected.iterator();
-            actual.trie.<Object> visit((index, leaf, start, end) -> {
+            actual.trie.<Object[]> visit((index, leaf, start, end) -> {
                 for (int i = start; i < end; i++) {
                     assertThat(leaf[i]).isEqualTo(expectedIterator.next());
                 }

--- a/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class VectorPropertyTest {
     @Test
     public void shouldCreateAndGet() {
-        for (int i = 0; i < 2000; i++) {
+        for (int i = 0; i < 500; i++) {
             final Seq<Integer> expected = Array.range(0, i);
             final Vector<Integer> actual = Vector.ofAll(expected);
             for (int j = 0; j < actual.size(); j++) {
@@ -81,8 +81,8 @@ public class VectorPropertyTest {
 
     @Test
     public void shouldIterate() {
-        for (byte depth = 0; depth <= 4; depth++) {
-            for (int i = 0; i < getMaxSizeForDepth(depth); i++) {
+        for (byte depth = 0; depth <= 2; depth++) {
+            for (int i = 0; i < 5000; i++) {
                 final Seq<Integer> expected = Array.range(0, i);
                 final Vector<Integer> actual = Vector.ofAll(expected);
                 assertAreEqual(actual, expected);
@@ -111,7 +111,7 @@ public class VectorPropertyTest {
         Vector<Integer> actual = Vector.empty();
 
         for (int drop = 0; drop <= (BRANCHING_FACTOR + 1); drop++) {
-            for (Integer value : Iterator.range(0, getMaxSizeForDepth(3) + BRANCHING_FACTOR)) {
+            for (Integer value : Iterator.range(0, 1000)) {
                 expected = expected.drop(drop);
                 actual = assertAreEqual(actual, drop, Vector::drop, expected);
 
@@ -127,7 +127,7 @@ public class VectorPropertyTest {
         Vector<Integer> actual = Vector.empty();
 
         for (int drop = 0; drop <= (BRANCHING_FACTOR + 1); drop++) {
-            for (Integer value : Iterator.range(0, getMaxSizeForDepth(2) + BRANCHING_FACTOR)) {
+            for (Integer value : Iterator.range(0, 500)) {
                 expected = expected.drop(drop);
                 actual = assertAreEqual(actual, drop, Vector::drop, expected);
 
@@ -141,8 +141,8 @@ public class VectorPropertyTest {
     public void shouldUpdate() {
         final Function<Integer, Integer> mapper = i -> i + 1;
 
-        for (byte depth = 0; depth <= 6; depth++) {
-            final int length = getMaxSizeForDepth(depth) + BRANCHING_FACTOR;
+        for (byte depth = 0; depth <= 2; depth++) {
+            final int length = 10_000;
 
             for (int drop = 0; drop <= (BRANCHING_FACTOR + 1); drop++) {
                 Seq<Integer> expected = Array.range(0, length);
@@ -163,13 +163,11 @@ public class VectorPropertyTest {
 
     @Test
     public void shouldDrop() {
-        final int length = getMaxSizeForDepth(6) + BRANCHING_FACTOR;
-
-        final Seq<Integer> expected = Array.range(0, length);
+        final Seq<Integer> expected = Array.range(0, 2_000);
         final Vector<Integer> actual = Vector.ofAll(expected);
 
         Vector<Integer> actualSingleDrop = actual;
-        for (int i = 0; i <= length; i++) {
+        for (int i = 0; i <= expected.length(); i++) {
             final Seq<Integer> expectedDrop = expected.drop(i);
 
             assertAreEqual(actual, i, Vector::drop, expectedDrop);
@@ -181,13 +179,11 @@ public class VectorPropertyTest {
 
     @Test
     public void shouldDropRight() {
-        final int length = getMaxSizeForDepth(4) + BRANCHING_FACTOR;
-
-        final Seq<Integer> expected = Array.range(0, length);
+        final Seq<Integer> expected = Array.range(0, 2_000);
         final Vector<Integer> actual = Vector.ofAll(expected);
 
         Vector<Integer> actualSingleDrop = actual;
-        for (int i = 0; i <= length; i++) {
+        for (int i = 0; i <= expected.length(); i++) {
             final Seq<Integer> expectedDrop = expected.dropRight(i);
 
             assertAreEqual(actual, i, Vector::dropRight, expectedDrop);
@@ -199,7 +195,7 @@ public class VectorPropertyTest {
 
     @Test
     public void shouldSlice() {
-        for (int length = 1, end = getMaxSizeForDepth(2) + BRANCHING_FACTOR; length <= end; length++) {
+        for (int length = 1, end = 500; length <= end; length++) {
             Seq<Integer> expected = Array.range(0, length);
             Vector<Integer> actual = Vector.ofAll(expected);
 
@@ -219,7 +215,7 @@ public class VectorPropertyTest {
         for (int i = 1; i < 10; i++) {
             Seq<Object> expected = Array.empty();
             Vector<Object> actual = Vector.empty();
-            for (int j = 0; j < 50_000; j++) {
+            for (int j = 0; j < 20_000; j++) {
                 Seq<Tuple2<Seq<Object>, Vector<Object>>> history = Array.empty();
 
                 if (percent(random) < 20) {
@@ -338,10 +334,5 @@ public class VectorPropertyTest {
         final List<?> actualList = actual.toJavaList();
         final List<?> expectedList = expected.toJavaList();
         assertThat(actualList).isEqualTo(expectedList); // a lot faster than `hasSameElementsAs`
-    }
-
-    private static int getMaxSizeForDepth(int depth) {
-        final int max = BRANCHING_FACTOR + (int) Math.pow(BRANCHING_FACTOR, depth) + BRANCHING_FACTOR;
-        return Math.min(max, 10_000);
     }
 }

--- a/javaslang/src/test/java/javaslang/collection/VectorTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorTest.java
@@ -289,7 +289,7 @@ public class VectorTest extends AbstractIndexedSeqTest {
 
     @Test
     public void shouldReturnSelfOnConvertToVector() {
-        Value<Integer> value = of(1, 2, 3);
+        final Value<Integer> value = of(1, 2, 3);
         assertThat(value.toVector()).isSameAs(value);
     }
 }

--- a/javaslang/src/test/java/javaslang/collection/VectorTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorTest.java
@@ -192,6 +192,13 @@ public class VectorTest extends AbstractIndexedSeqTest {
         assertThat(actual).isEqualTo(3);
     }
 
+    @Test
+    public void shouldNarrowPrimitives() {
+        final Vector<Object> object = Vector.narrow(range(0, 2));
+        Vector<Object> actual = object.append("String");
+        assertThat(actual).isEqualTo(of(0, 1, "String"));
+    }
+
     // -- transform()
 
     @Test


### PR DESCRIPTION
This PR modifies the optimized `Vector` to store its data internally in the format it was created from, i.e. 

``` java
Vector.ofAll(3, 1, 4, 1, 5); // stored internally as `int[]`
```

will create a `Vector` that has an `int[]` internally and

``` java
Vector.ofAll(Arrays.asList(3, 1, 4, 1, 5)); // boxed to `Integer[]` by `asList`
```

will have an `Object[]` inside.

The user doesn't have to know how it's stored internally (e.g. adding a `null` will automatically box everything in amortized constant time).

Internally many operations can work with primitive arrays without boxing (e.g. `slice`, `iterate`, `filter`, `distinct`), but others have to wrap them to make sense (e.g. `flatMap`).

Memory-wise storing primitives can be up to `~12×` more memory efficient (e.g. `53,968 bytes` for Vector<Byte> compared to `653,672 bytes` for `ArrayList<Byte>` (or `3,408,624 bytes` for Functional Java's `Seq<Byte>`)).
Interestingly many operations are faster also (e.g. `create` and `iterate`), sometimes even faster than the `Java` counterpart - e.g. `filter` or `map`.

The [benchmarks](https://github.com/paplorinc/javaslang/blob/Primitivization/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java) are as follows:

``` java
Operation Ratio                                                32     1024    32768
Create    slang_persistent/java_mutable                     1.51×    0.92×    1.17×
Create    slang_persistent/java_mutable_boxed              11.10×    8.64×    6.17×
Create    slang_persistent/java_mutable_boxed_stream       16.68×   10.77×    9.57×
Create    slang_persistent/fjava_persistent               229.91×  216.16×  192.30×
Create    slang_persistent/pcollections_persistent        126.90×  253.86×  375.34×
Create    slang_persistent/ecollections_persistent          2.05×    0.95×    1.18×
Create    slang_persistent/clojure_persistent               0.95×   15.40×   12.79×
Create    slang_persistent/scala_persistent                13.96×    9.32×    6.43×

Head      slang_persistent/java_mutable                     0.71×    0.53×    0.40×
Head      slang_persistent/fjava_persistent                 0.85×    0.66×    0.51×
Head      slang_persistent/pcollections_persistent          2.18×    3.75×    4.68×
Head      slang_persistent/ecollections_persistent          0.77×    0.61×    0.47×
Head      slang_persistent/clojure_persistent               0.70×    0.83×    0.90×
Head      slang_persistent/scala_persistent                 0.78×    0.63×    0.49×

Tail      slang_persistent/java_mutable                     0.71×    0.56×    0.39×
Tail      slang_persistent/fjava_persistent                52.84×   50.26×   52.36×
Tail      slang_persistent/pcollections_persistent          5.85×    9.15×   12.06×
Tail      slang_persistent/ecollections_persistent         16.88×  156.82× 4301.60×
Tail      slang_persistent/clojure_persistent               0.93×    0.69×    0.60×
Tail      slang_persistent/scala_persistent                 2.98×    4.87×    5.97×

Get       slang_persistent/java_mutable                     0.71×    0.12×    0.36×
Get       slang_persistent/fjava_persistent                55.92×   28.12×   79.81×
Get       slang_persistent/pcollections_persistent          8.32×    4.20×   17.46×
Get       slang_persistent/ecollections_persistent          0.71×    0.10×    0.34×
Get       slang_persistent/clojure_persistent               0.93×    0.37×    1.45×
Get       slang_persistent/scala_persistent                 1.13×    0.30×    0.95×

Update    slang_persistent/java_mutable                     0.11×    0.05×    0.03×
Update    slang_persistent/fjava_persistent               133.11×  262.66×  222.09×
Update    slang_persistent/pcollections_persistent          2.45×    4.30×    4.97×
Update    slang_persistent/ecollections_persistent         13.88×  162.43× 2589.05×
Update    slang_persistent/clojure_persistent               0.85×    1.23×    1.10×
Update    slang_persistent/scala_persistent                 1.03×    1.07×    1.14×

Map       slang_persistent/java_mutable                     2.19×    2.27×    2.00×
Map       slang_persistent/java_mutable_loop                0.53×    0.67×    0.54×
Map       slang_persistent/ecollections_persistent          1.16×    1.15×    1.06×
Map       slang_persistent/scala_persistent                 1.03×    1.43×    1.73×

Filter    slang_persistent/java_mutable                     1.97×    1.64×    1.15×
Filter    slang_persistent/ecollections_persistent          1.67×    1.14×    0.92×
Filter    slang_persistent/scala_persistent                 1.45×    1.44×    1.42×

Prepend   slang_persistent/java_mutable                     0.38×    0.71×   11.80×
Prepend   slang_persistent/fjava_persistent                 1.43×    1.62×    1.17×
Prepend   slang_persistent/pcollections_persistent          0.94×    2.47×    2.95×
Prepend   slang_persistent/ecollections_persistent          2.53×   27.04×  569.17×
Prepend   slang_persistent/clojure_persistent               5.90×  124.95× 3177.65×
Prepend   slang_persistent/scala_persistent                 0.22×    0.23×    0.15×

Append    slang_persistent/java_mutable                     0.25×    0.05×    0.03×
Append    slang_persistent/fjava_persistent                 5.18×    1.54×    1.02×
Append    slang_persistent/pcollections_persistent          2.71×    1.87×    2.22×
Append    slang_persistent/ecollections_persistent          7.93×   24.56×  560.25×
Append    slang_persistent/clojure_persistent               0.99×    0.23×    0.18×
Append    slang_persistent/scala_persistent                 0.81×    0.22×    0.16×

GroupBy   slang_persistent/java_mutable                     0.43×    0.65×    0.83×
GroupBy   slang_persistent/scala_persistent                 1.44×    1.05×    1.21×

Slice     slang_persistent/java_mutable                     0.54×    0.49×    0.45×
Slice     slang_persistent/pcollections_persistent          0.51×    0.42×    0.40×
Slice     slang_persistent/clojure_persistent               0.54×    0.45×    0.43×
Slice     slang_persistent/scala_persistent                 2.43×    5.61×    8.61×

Iterate   slang_persistent/java_mutable                     0.88×    0.45×    0.39×
Iterate   slang_persistent/fjava_persistent               368.25×  442.89×  289.54×
Iterate   slang_persistent/pcollections_persistent         14.61×   13.76×    9.42×
Iterate   slang_persistent/ecollections_persistent          2.35×    1.72×    1.52×
Iterate   slang_persistent/clojure_persistent               0.79×    1.03×    0.85×
Iterate   slang_persistent/scala_persistent                 1.53×    1.49×    0.90×
```

Note: Apparently `Java 9`  made some array copying optimizations (that made `append` slower than `prepend` in the first place), making `update`, `append` and `groupBy` slightly faster.

primitive:

``` java
Operation Ratio                                                32     1024    32768
Create    slang_persistent_int/java_mutable                 3.55×    1.71×    1.35×
Create    slang_persistent_int/java_mutable_boxed          26.16×   16.01×    7.09×
Create    slang_persistent_int/java_mutable_boxed_stream   39.31×   19.96×   11.01×
Create    slang_persistent_int/fjava_persistent           542.00×  400.65×  221.11×
Create    slang_persistent_int/pcollections_persistent    299.17×  470.54×  431.57×
Create    slang_persistent_int/ecollections_persistent      4.84×    1.76×    1.36×
Create    slang_persistent_int/clojure_persistent           2.23×   28.55×   14.71×
Create    slang_persistent_int/scala_persistent            32.91×   17.27×    7.39×

Tail      slang_persistent_int/java_mutable                 0.71×    0.56×    0.45×
Tail      slang_persistent_int/fjava_persistent            52.55×   50.20×   59.62×
Tail      slang_persistent_int/pcollections_persistent      5.82×    9.14×   13.73×
Tail      slang_persistent_int/ecollections_persistent     16.79×  156.62× 4898.01×
Tail      slang_persistent_int/clojure_persistent           0.92×    0.69×    0.68×
Tail      slang_persistent_int/scala_persistent             2.97×    4.87×    6.80×

Update    slang_persistent_int/java_mutable                 0.11×    0.05×    0.03×
Update    slang_persistent_int/fjava_persistent           124.86×  254.21×  215.66×
Update    slang_persistent_int/pcollections_persistent      2.30×    4.16×    4.83×
Update    slang_persistent_int/ecollections_persistent     13.02×  157.21× 2514.05×
Update    slang_persistent_int/clojure_persistent           0.80×    1.19×    1.07×
Update    slang_persistent_int/scala_persistent             0.97×    1.04×    1.11×

Map       slang_persistent_int/java_mutable                 2.01×    1.85×    1.58×
Map       slang_persistent_int/java_mutable_loop            0.48×    0.54×    0.43×
Map       slang_persistent_int/ecollections_persistent      1.07×    0.93×    0.84×
Map       slang_persistent_int/scala_persistent             0.94×    1.16×    1.37×

Filter    slang_persistent_int/java_mutable                 2.35×    1.63×    0.87×
Filter    slang_persistent_int/ecollections_persistent      2.00×    1.13×    0.70×
Filter    slang_persistent_int/scala_persistent             1.73×    1.43×    1.07×

Prepend   slang_persistent_int/java_mutable                 0.84×    0.78×   12.69×
Prepend   slang_persistent_int/fjava_persistent             3.12×    1.78×    1.25×
Prepend   slang_persistent_int/pcollections_persistent      2.05×    2.72×    3.18×
Prepend   slang_persistent_int/ecollections_persistent      5.50×   29.76×  612.04×
Prepend   slang_persistent_int/clojure_persistent          12.83×  137.53× 3416.94×
Prepend   slang_persistent_int/scala_persistent             0.49×    0.26×    0.17×

Append    slang_persistent_int/java_mutable                 0.23×    0.11×    0.03×
Append    slang_persistent_int/fjava_persistent             4.66×    3.00×    1.15×
Append    slang_persistent_int/pcollections_persistent      2.43×    3.64×    2.50×
Append    slang_persistent_int/ecollections_persistent      7.13×   47.83×  631.27×
Append    slang_persistent_int/clojure_persistent           0.89×    0.46×    0.20×
Append    slang_persistent_int/scala_persistent             0.73×    0.42×    0.18×

Slice     slang_persistent_int/java_mutable                 0.56×    0.47×    0.38×
Slice     slang_persistent_int/pcollections_persistent      0.52×    0.40×    0.34×
Slice     slang_persistent_int/clojure_persistent           0.55×    0.44×    0.37×
Slice     slang_persistent_int/scala_persistent             2.50×    5.42×    7.28×

Iterate   slang_persistent_int/java_mutable                 1.76×    0.88×    1.38×
Iterate   slang_persistent_int/fjava_persistent           737.64×  858.07× 1036.08×
Iterate   slang_persistent_int/pcollections_persistent     29.26×   26.65×   33.69×
Iterate   slang_persistent_int/ecollections_persistent      4.71×    3.33×    5.44×
Iterate   slang_persistent_int/clojure_persistent           1.58×    2.01×    3.05×
Iterate   slang_persistent_int/scala_persistent             3.06×    2.89×    3.23×
```

![screenshot from 2016-09-10 14 20 50](https://cloud.githubusercontent.com/assets/1841944/18410161/e09fbfe4-7762-11e6-9524-3eb7e46bd530.png)

and memory usages:

``` java
for `32` elements
  Java mutable @ ArrayList                            →   504 bytes
  Functional Java persistent @ Seq                    → 3,064 bytes
  PCollections persistent @ TreePVector               → 1,712 bytes
  Eclipse Collections persistent @ ImmutableArrayList →   496 bytes
  Clojure persistent @ PersistentVector               →   704 bytes
  Scala persistent @ Vector                           →   536 bytes
  Javaslang persistent @ Vector (Integer[])           →   544 bytes
  Javaslang persistent @ Vector (int[])               →   208 bytes
  Javaslang persistent @ Vector (byte[])              →   112 bytes

for `1024` elements
  Java mutable @ ArrayList                            →  19,064 bytes
  Functional Java persistent @ Seq                    → 104,760 bytes
  PCollections persistent @ TreePVector               →  55,984 bytes
  Eclipse Collections persistent @ ImmutableArrayList →  19,056 bytes
  Clojure persistent @ PersistentVector               →  20,504 bytes
  Scala persistent @ Vector                           →  19,736 bytes
  Javaslang persistent @ Vector (Integer[])           →  19,744 bytes
  Javaslang persistent @ Vector (int[])               →   4,816 bytes
  Javaslang persistent @ Vector (byte[])              →   1,744 bytes

for `32768` elements
  Java mutable @ ArrayList                            →   653,672 bytes
  Functional Java persistent @ Seq                    → 3,408,624 bytes
  PCollections persistent @ TreePVector               → 1,833,376 bytes
  Eclipse Collections persistent @ ImmutableArrayList →   653,664 bytes
  Clojure persistent @ PersistentVector               →   700,168 bytes
  Scala persistent @ Vector                           →   674,824 bytes
  Javaslang persistent @ Vector (Integer[])           →   674,832 bytes
  Javaslang persistent @ Vector (int[])               →   152,272 bytes
  Javaslang persistent @ Vector (byte[])              →    53,968 bytes
```

i.e. storing `byte`s in `functional java` would require `~63×` more storage.
