### PR TITLE
Benchmark framework updates

### DIFF
--- a/javaslang-benchmark/pom.xml
+++ b/javaslang-benchmark/pom.xml
@@ -49,6 +49,11 @@
             <version>4.6</version>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+            <version>8.0.0-M1</version>
+        </dependency>
+        <dependency>
             <groupId>com.carrotsearch</groupId>
             <artifactId>java-sizeof</artifactId>
             <version>0.0.5</version>

--- a/javaslang-benchmark/src/test/java/javaslang/MemoryUsage.java
+++ b/javaslang-benchmark/src/test/java/javaslang/MemoryUsage.java
@@ -1,37 +1,35 @@
 package javaslang;
 
+import javaslang.collection.CharSeq;
+import javaslang.collection.LinkedHashMultimap;
 import javaslang.collection.List;
-import javaslang.collection.TreeMultimap;
+import javaslang.collection.Multimap;
 
-import java.text.DecimalFormat;
-import java.util.Comparator;
-
-import static com.carrotsearch.sizeof.RamUsageEstimator.*;
+import static com.carrotsearch.sizeof.RamUsageEstimator.humanReadableUnits;
+import static com.carrotsearch.sizeof.RamUsageEstimator.sizeOf;
+import static javaslang.BenchmarkPerformanceReporter.DECIMAL_FORMAT;
 
 public class MemoryUsage {
-    private static final DecimalFormat RATIO_FORMAT = new DecimalFormat("#0.0");
-    private static TreeMultimap<Integer, String> memoryUsages = TreeMultimap.withSeq().empty(Comparator.reverseOrder()); // if forked, this will be reset every time
+    private static Multimap<Integer, String> memoryUsages = LinkedHashMultimap.withSeq().empty(); // if forked, this will be reset every time
 
     /** Calculate the occupied memory of different internals */
     static void printAndReset() {
         for (int size : memoryUsages.keySet()) {
-            System.out.println(String.format("\nfor %d elements", size));
+            System.out.println(String.format("\nfor `%d` elements", size));
             for (String usages : memoryUsages.get(size).get()) {
-                System.out.println("\t" + usages);
+                System.out.println(usages);
             }
         }
 
         memoryUsages = memoryUsages.take(0); // reset
     }
 
-    public static void storeMemoryUsages(Object source, int elementCount, Object target) {
-        final long overhead = sizeOf(target) - sizeOf(source);
-        final double overheadPerElement = overhead / (double) elementCount;
-        final String usage = String.format("`%s` uses `%s` (`%s` overhead, `%s` bytes overhead per element)",
-                                           target.getClass().getName(),
-                                           humanSizeOf(target),
-                                           humanReadableUnits(overhead),
-                                           RATIO_FORMAT.format(overheadPerElement));
+    public static void storeMemoryUsages(int elementCount, Object target) {
+        final CharSeq name = CharSeq.of(target.getClass().getPackage().getName()).splitSeq("\\.").map(CharSeq::head).mkCharSeq("", ".", "." + target.getClass().getSimpleName());
+        final String usage = String.format("%s  → %s bytes (%s)",
+                name.padTo(32, ' '),
+                CharSeq.of(DECIMAL_FORMAT.format(sizeOf(target))).leftPadTo(15, ' '),
+                humanReadableUnits(sizeOf(target)));
         if (!memoryUsages.get(elementCount).getOrElse(List::empty).contains(usage)) {
             memoryUsages = memoryUsages.put(elementCount, usage);
         }

--- a/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java
@@ -1,26 +1,32 @@
 package javaslang.collection;
 
 import javaslang.JmhRunner;
+import org.eclipse.collections.api.list.MutableList;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
-import scala.compat.java8.JFunction;
+import scala.collection.generic.CanBuildFrom;
+import scala.compat.java8.functionConverterImpls.FromJavaFunction;
+import scala.compat.java8.functionConverterImpls.FromJavaPredicate;
 
-import java.util.ArrayList;
 import java.util.Objects;
 import java.util.Random;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.carrotsearch.sizeof.RamUsageEstimator.sizeOf;
 import static java.util.Arrays.asList;
+import static javaslang.JmhRunner.Includes.*;
 import static javaslang.JmhRunner.*;
 import static javaslang.collection.Arrays.copyRange;
 import static javaslang.collection.BitMappedTrie.branchingFactor;
 import static javaslang.collection.Collections.areEqual;
 import static scala.collection.JavaConversions.asJavaCollection;
 import static scala.collection.JavaConversions.asScalaBuffer;
+import static scala.compat.java8.JFunction.func;
 
-@SuppressWarnings({ "ALL", "unchecked" })
+@SuppressWarnings({ "ALL", "unchecked", "rawtypes" })
 public class VectorBenchmark {
     static final Array<Class<?>> CLASSES = Array.of(
             Create.class,
@@ -28,6 +34,8 @@ public class VectorBenchmark {
             Tail.class,
             Get.class,
             Update.class,
+            Map.class,
+            Filter.class,
             Prepend.class,
             Append.class,
             GroupBy.class,
@@ -36,13 +44,11 @@ public class VectorBenchmark {
     );
 
     @Test
-    public void testAsserts() {
-        JmhRunner.runDebugWithAsserts(CLASSES);
-    }
+    public void testAsserts() { JmhRunner.runDebugWithAsserts(CLASSES); }
 
     public static void main(String... args) {
         JmhRunner.runDebugWithAsserts(CLASSES);
-        JmhRunner.runNormalNoAsserts(CLASSES);
+        JmhRunner.runNormalNoAsserts(CLASSES, JAVA, FUNCTIONAL_JAVA, PCOLLECTIONS, ECOLLECTIONS, CLOJURE, SCALA, JAVASLANG);
     }
 
     @State(Scope.Benchmark)
@@ -57,10 +63,11 @@ public class VectorBenchmark {
         /* Only use this for non-mutating operations */
         java.util.ArrayList<Integer> javaMutable;
 
-        scala.collection.immutable.Vector<Integer> scalaPersistent;
-        clojure.lang.PersistentVector clojurePersistent;
         fj.data.Seq<Integer> fjavaPersistent;
-        org.pcollections.PVector<Integer> pcollectionsPersistent;
+        org.pcollections.PVector<Integer> pCollectionsPersistent;
+        org.eclipse.collections.api.list.ImmutableList<Integer> eCollectionsPersistent;
+        clojure.lang.PersistentVector clojurePersistent;
+        scala.collection.immutable.Vector<Integer> scalaPersistent;
         javaslang.collection.Vector<Integer> slangPersistent;
 
         @Setup
@@ -72,10 +79,11 @@ public class VectorBenchmark {
             EXPECTED_AGGREGATE = Array.of(ELEMENTS).reduce(JmhRunner::aggregate);
 
             javaMutable = create(java.util.ArrayList::new, asList(ELEMENTS), v -> areEqual(v, asList(ELEMENTS)));
-            scalaPersistent = create(v -> (scala.collection.immutable.Vector<Integer>) scala.collection.immutable.Vector$.MODULE$.apply(asScalaBuffer(v)), javaMutable, v -> areEqual(asJavaCollection(v), javaMutable));
-            clojurePersistent = create(clojure.lang.PersistentVector::create, javaMutable, v -> areEqual(v, javaMutable));
-            pcollectionsPersistent = create(org.pcollections.TreePVector::from, javaMutable, v -> areEqual(v, javaMutable));
             fjavaPersistent = create(fj.data.Seq::fromJavaList, javaMutable, v -> areEqual(v, javaMutable));
+            pCollectionsPersistent = create(org.pcollections.TreePVector::from, javaMutable, v -> areEqual(v, javaMutable));
+            eCollectionsPersistent = create(org.eclipse.collections.impl.factory.Lists.immutable::ofAll, javaMutable, v -> areEqual(v, javaMutable));
+            clojurePersistent = create(clojure.lang.PersistentVector::create, javaMutable, v -> areEqual(v, javaMutable));
+            scalaPersistent = create(v -> (scala.collection.immutable.Vector<Integer>) scala.collection.immutable.Vector$.MODULE$.apply(asScalaBuffer(v)), javaMutable, v -> areEqual(asJavaCollection(v), javaMutable));
             slangPersistent = create(javaslang.collection.Vector::ofAll, javaMutable, v -> areEqual(v, javaMutable));
         }
     }
@@ -84,21 +92,7 @@ public class VectorBenchmark {
     public static class Create extends Base {
         @Benchmark
         public Object java_mutable() {
-            final ArrayList<Integer> values = new ArrayList<>(javaMutable);
-            assert areEqual(values, javaMutable);
-            return values;
-        }
-
-        @Benchmark
-        public Object scala_persistent() {
-            final scala.collection.immutable.Vector<?> values = scala.collection.immutable.Vector$.MODULE$.apply(scalaPersistent);
-            assert Objects.equals(values, scalaPersistent);
-            return values;
-        }
-
-        @Benchmark
-        public Object clojure_persistent() {
-            final clojure.lang.PersistentVector values = clojure.lang.PersistentVector.create(javaMutable);
+            final java.util.List<Integer> values = new java.util.ArrayList<>(java.util.Arrays.asList(ELEMENTS));
             assert areEqual(values, javaMutable);
             return values;
         }
@@ -114,6 +108,27 @@ public class VectorBenchmark {
         public Object pcollections_persistent() {
             final org.pcollections.PVector<Integer> values = org.pcollections.TreePVector.from(javaMutable);
             assert areEqual(values, javaMutable);
+            return values;
+        }
+
+        @Benchmark
+        public Object ecollections_persistent() {
+            final org.eclipse.collections.api.list.ImmutableList<Integer> values = org.eclipse.collections.impl.factory.Lists.immutable.ofAll(javaMutable);
+            assert areEqual(values, javaMutable);
+            return values;
+        }
+
+        @Benchmark
+        public Object clojure_persistent() {
+            final clojure.lang.PersistentVector values = clojure.lang.PersistentVector.create(javaMutable);
+            assert areEqual(values, javaMutable);
+            return values;
+        }
+
+        @Benchmark
+        public Object scala_persistent() {
+            final scala.collection.immutable.Vector<?> values = scala.collection.immutable.Vector$.MODULE$.apply(scalaPersistent);
+            assert Objects.equals(values, scalaPersistent);
             return values;
         }
 
@@ -134,8 +149,22 @@ public class VectorBenchmark {
         }
 
         @Benchmark
-        public Object scala_persistent() {
-            final Object head = scalaPersistent.head();
+        public Object fjava_persistent() {
+            final Object head = fjavaPersistent.head();
+            assert Objects.equals(head, javaMutable.get(0));
+            return head;
+        }
+
+        @Benchmark
+        public Object pcollections_persistent() {
+            final Object head = pCollectionsPersistent.get(0);
+            assert Objects.equals(head, javaMutable.get(0));
+            return head;
+        }
+
+        @Benchmark
+        public Object ecollections_persistent() {
+            final Object head = eCollectionsPersistent.getFirst();
             assert Objects.equals(head, javaMutable.get(0));
             return head;
         }
@@ -148,15 +177,8 @@ public class VectorBenchmark {
         }
 
         @Benchmark
-        public Object fjava_persistent() {
-            final Object head = fjavaPersistent.head();
-            assert Objects.equals(head, javaMutable.get(0));
-            return head;
-        }
-
-        @Benchmark
-        public Object pcollections_persistent() {
-            final Object head = pcollectionsPersistent.get(0);
+        public Object scala_persistent() {
+            final Object head = scalaPersistent.head();
             assert Objects.equals(head, javaMutable.get(0));
             return head;
         }
@@ -197,12 +219,32 @@ public class VectorBenchmark {
         }
 
         @Benchmark
-        public Object scala_persistent() {
-            scala.collection.immutable.Vector<Integer> values = scalaPersistent;
+        public Object fjava_persistent() {
+            fj.data.Seq<Integer> values = fjavaPersistent;
             for (int i = 0; i < CONTAINER_SIZE; i++) {
                 values = values.tail();
             }
             assert values.isEmpty();
+            return values;
+        }
+
+        @Benchmark
+        public Object pcollections_persistent() {
+            org.pcollections.PVector<Integer> values = pCollectionsPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.minus(0);
+            }
+            assert values.isEmpty();
+            return values;
+        }
+
+        @Benchmark
+        public Object ecollections_persistent() {
+            org.eclipse.collections.api.list.ImmutableList<Integer> values = eCollectionsPersistent;
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values = values.drop(1);
+            }
+            assert values.isEmpty() && (values != eCollectionsPersistent);
             return values;
         }
 
@@ -216,20 +258,10 @@ public class VectorBenchmark {
         }
 
         @Benchmark
-        public Object fjava_persistent() {
-            fj.data.Seq<Integer> values = fjavaPersistent;
+        public Object scala_persistent() {
+            scala.collection.immutable.Vector<Integer> values = scalaPersistent;
             for (int i = 0; i < CONTAINER_SIZE; i++) {
                 values = values.tail();
-            }
-            assert values.isEmpty();
-            return values;
-        }
-
-        @Benchmark
-        public Object pcollections_persistent() {
-            org.pcollections.PVector<Integer> values = pcollectionsPersistent;
-            for (int i = 0; i < CONTAINER_SIZE; i++) {
-                values = values.minus(0);
             }
             assert values.isEmpty();
             return values;
@@ -259,10 +291,30 @@ public class VectorBenchmark {
         }
 
         @Benchmark
-        public int scala_persistent() {
+        public int fjava_persistent() {
             int aggregate = 0;
             for (int i : RANDOMIZED_INDICES) {
-                aggregate ^= scalaPersistent.apply(i);
+                aggregate ^= fjavaPersistent.index(i);
+            }
+            assert aggregate == EXPECTED_AGGREGATE;
+            return aggregate;
+        }
+
+        @Benchmark
+        public int pcollections_persistent() {
+            int aggregate = 0;
+            for (int i : RANDOMIZED_INDICES) {
+                aggregate ^= pCollectionsPersistent.get(i);
+            }
+            assert aggregate == EXPECTED_AGGREGATE;
+            return aggregate;
+        }
+
+        @Benchmark
+        public int ecollections_persistent() {
+            int aggregate = 0;
+            for (int i : RANDOMIZED_INDICES) {
+                aggregate ^= eCollectionsPersistent.get(i);
             }
             assert aggregate == EXPECTED_AGGREGATE;
             return aggregate;
@@ -279,20 +331,10 @@ public class VectorBenchmark {
         }
 
         @Benchmark
-        public int fjava_persistent() {
+        public int scala_persistent() {
             int aggregate = 0;
             for (int i : RANDOMIZED_INDICES) {
-                aggregate ^= fjavaPersistent.index(i);
-            }
-            assert aggregate == EXPECTED_AGGREGATE;
-            return aggregate;
-        }
-
-        @Benchmark
-        public int pcollections_persistent() {
-            int aggregate = 0;
-            for (int i : RANDOMIZED_INDICES) {
-                aggregate ^= pcollectionsPersistent.get(i);
+                aggregate ^= scalaPersistent.apply(i);
             }
             assert aggregate == EXPECTED_AGGREGATE;
             return aggregate;
@@ -338,12 +380,34 @@ public class VectorBenchmark {
         }
 
         @Benchmark
-        public Object scala_persistent() {
-            scala.collection.immutable.Vector<Integer> values = scalaPersistent;
+        public Object fjava_persistent() {
+            fj.data.Seq<Integer> values = fjavaPersistent;
             for (int i : RANDOMIZED_INDICES) {
-                values = values.updateAt(i, 0);
+                values = values.update(i, 0);
             }
-            assert Array.ofAll(asJavaCollection(values)).forAll(e -> e == 0);
+            assert Array.ofAll(values).forAll(e -> e == 0);
+            return values;
+        }
+
+        @Benchmark
+        public Object pcollections_persistent() {
+            org.pcollections.PVector<Integer> values = pCollectionsPersistent;
+            for (int i : RANDOMIZED_INDICES) {
+                values = values.with(i, 0);
+            }
+            assert Array.ofAll(values).forAll(e -> e == 0);
+            return values;
+        }
+
+        @Benchmark
+        public Object ecollections_persistent() {
+            org.eclipse.collections.api.list.ImmutableList<Integer> values = eCollectionsPersistent;
+            for (int i : RANDOMIZED_INDICES) {
+                final MutableList<Integer> copy = values.toList();
+                copy.set(i, 0);
+                values = copy.toImmutable();
+            }
+            assert Array.ofAll(values).forAll(e -> e == 0) && (values != eCollectionsPersistent);
             return values;
         }
 
@@ -358,22 +422,12 @@ public class VectorBenchmark {
         }
 
         @Benchmark
-        public Object fjava_persistent() {
-            fj.data.Seq<Integer> values = fjavaPersistent;
+        public Object scala_persistent() {
+            scala.collection.immutable.Vector<Integer> values = scalaPersistent;
             for (int i : RANDOMIZED_INDICES) {
-                values = values.update(i, 0);
+                values = values.updateAt(i, 0);
             }
-            assert Array.ofAll(values).forAll(e -> e == 0);
-            return values;
-        }
-
-        @Benchmark
-        public Object pcollections_persistent() {
-            org.pcollections.PVector<Integer> values = pcollectionsPersistent;
-            for (int i : RANDOMIZED_INDICES) {
-                values = values.with(i, 0);
-            }
-            assert Array.ofAll(values).forAll(e -> e == 0);
+            assert Array.ofAll(asJavaCollection(values)).forAll(e -> e == 0);
             return values;
         }
 
@@ -388,36 +442,121 @@ public class VectorBenchmark {
         }
     }
 
+    public static class Map extends Base {
+        private final Function<Integer, Integer> MAPPER = i -> i + 1;
+
+        @Benchmark
+        public Object java_mutable_loop() {
+            final Integer[] values = ELEMENTS.clone();
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                values[i] = MAPPER.apply(values[i]);
+            }
+            assert areEqual(Array.of(values), Array.of(ELEMENTS).map(MAPPER));
+            return values;
+        }
+
+        @Benchmark
+        public Object java_mutable() {
+            final java.util.List<Integer> values = javaMutable.stream().map(MAPPER).collect(Collectors.toList());
+            assert areEqual(values, Array.of(ELEMENTS).map(MAPPER));
+            return values;
+        }
+
+        @Benchmark
+        public Object ecollections_persistent() {
+            org.eclipse.collections.api.list.ImmutableList<Integer> values = eCollectionsPersistent.collect(MAPPER::apply);
+            assert areEqual(values, Array.of(ELEMENTS).map(MAPPER));
+            return values;
+        }
+
+        @Benchmark
+        public Object scala_persistent() {
+            final CanBuildFrom canBuildFrom = scala.collection.immutable.Vector.canBuildFrom();
+            final scala.collection.immutable.Vector<Integer> values = (scala.collection.immutable.Vector<Integer>) scalaPersistent.map(new FromJavaFunction<>(MAPPER), canBuildFrom);
+            assert areEqual(asJavaCollection(values), Array.of(ELEMENTS).map(MAPPER));
+            return values;
+        }
+
+        @Benchmark
+        public Object slang_persistent() {
+            final javaslang.collection.Vector<Integer> values = slangPersistent.map(MAPPER);
+            assert areEqual(values, Array.of(ELEMENTS).map(MAPPER));
+            return values;
+        }
+    }
+
+    public static class Filter extends Base {
+        private final Predicate<Integer> ALL = i -> true;
+        private final Predicate<Integer> SOME = i -> (i & 1) == 1;
+        private final Predicate<Integer> NONE = i -> false;
+
+        @Benchmark
+        public void java_mutable(Blackhole bh) {
+            final java.util.List<Integer> allValues = javaMutable.stream().filter(ALL).collect(Collectors.toList());
+            assert areEqual(allValues, Array.of(ELEMENTS).filter(ALL));
+            bh.consume(allValues);
+
+            final java.util.List<Integer> someValues = javaMutable.stream().filter(SOME).collect(Collectors.toList());
+            assert areEqual(someValues, Array.of(ELEMENTS).filter(SOME));
+            bh.consume(someValues);
+
+            final java.util.List<Integer> noValues = javaMutable.stream().filter(NONE).collect(Collectors.toList());
+            assert areEqual(noValues, Array.of(ELEMENTS).filter(NONE));
+            bh.consume(noValues);
+        }
+
+        @Benchmark
+        public void ecollections_persistent(Blackhole bh) {
+            org.eclipse.collections.api.list.ImmutableList<Integer> allValues = eCollectionsPersistent.select(ALL::test);
+            assert areEqual(allValues, Array.of(ELEMENTS).filter(ALL));
+            bh.consume(allValues);
+
+            org.eclipse.collections.api.list.ImmutableList<Integer> someValues = eCollectionsPersistent.select(SOME::test);
+            assert areEqual(someValues, Array.of(ELEMENTS).filter(SOME));
+            bh.consume(someValues);
+
+            org.eclipse.collections.api.list.ImmutableList<Integer> noValues = eCollectionsPersistent.select(NONE::test);
+            assert areEqual(noValues, Array.of(ELEMENTS).filter(NONE));
+            bh.consume(noValues);
+        }
+
+        @Benchmark
+        public void scala_persistent(Blackhole bh) {
+            final scala.collection.immutable.Vector<Integer> allValues = (scala.collection.immutable.Vector<Integer>) scalaPersistent.filter(new FromJavaPredicate(ALL));
+            assert areEqual(asJavaCollection(allValues), Array.of(ELEMENTS).filter(ALL));
+            bh.consume(allValues);
+
+            final scala.collection.immutable.Vector<Integer> someValues = (scala.collection.immutable.Vector<Integer>) scalaPersistent.filter(new FromJavaPredicate(SOME));
+            assert areEqual(asJavaCollection(someValues), Array.of(ELEMENTS).filter(SOME));
+            bh.consume(someValues);
+
+            final scala.collection.immutable.Vector<Integer> noValues = (scala.collection.immutable.Vector<Integer>) scalaPersistent.filter(new FromJavaPredicate(NONE));
+            assert areEqual(asJavaCollection(noValues), Array.of(ELEMENTS).filter(NONE));
+            bh.consume(noValues);
+        }
+
+        @Benchmark
+        public void slang_persistent(Blackhole bh) {
+            final javaslang.collection.Vector<Integer> allValues = slangPersistent.filter(ALL);
+            assert areEqual(allValues, Array.of(ELEMENTS).filter(ALL));
+            bh.consume(allValues);
+
+            final javaslang.collection.Vector<Integer> someValues = slangPersistent.filter(SOME);
+            assert areEqual(someValues, Array.of(ELEMENTS).filter(SOME));
+            bh.consume(someValues);
+
+            final javaslang.collection.Vector<Integer> noValues = slangPersistent.filter(NONE);
+            assert areEqual(noValues, Array.of(ELEMENTS).filter(NONE));
+            bh.consume(noValues);
+        }
+    }
+
     public static class Prepend extends Base {
         @Benchmark
         public Object java_mutable() {
             final java.util.ArrayList<Integer> values = new java.util.ArrayList<>(); /* no initial value, as we're simulating dynamic usage */
             for (Integer element : ELEMENTS) {
                 values.add(0, element);
-            }
-            assert areEqual(Array.ofAll(values).reverse(), javaMutable);
-            return values;
-        }
-
-        @Benchmark
-        public Object scala_persistent() {
-            scala.collection.immutable.Vector<Integer> values = scala.collection.immutable.Vector$.MODULE$.empty();
-            for (Integer element : ELEMENTS) {
-                values = values.appendFront(element);
-            }
-            assert areEqual(Array.ofAll(asJavaCollection(values)).reverse(), javaMutable);
-            return values;
-        }
-
-        @Benchmark
-        public Object clojure_persistent() {
-            clojure.lang.PersistentVector values = clojure.lang.PersistentVector.EMPTY;
-            for (int i = 0; i < ELEMENTS.length; i++) {
-                clojure.lang.PersistentVector prepended = clojure.lang.PersistentVector.create(ELEMENTS[i]);
-                for (Object value : values) {
-                    prepended = prepended.cons(value);  /* rebuild everything via append */
-                }
-                values = prepended;
             }
             assert areEqual(Array.ofAll(values).reverse(), javaMutable);
             return values;
@@ -444,6 +583,42 @@ public class VectorBenchmark {
         }
 
         @Benchmark
+        public Object ecollections_persistent() {
+            org.eclipse.collections.api.list.ImmutableList<Integer> values = org.eclipse.collections.impl.factory.Lists.immutable.empty();
+            for (Integer element : ELEMENTS) {
+                final org.eclipse.collections.api.list.MutableList<Integer> copy = values.toList();
+                copy.add(0, element);
+                values = copy.toImmutable();
+            }
+            assert areEqual(values.toReversed(), javaMutable) && (values != eCollectionsPersistent);
+            return values;
+        }
+
+        @Benchmark
+        public Object clojure_persistent() {
+            clojure.lang.PersistentVector values = clojure.lang.PersistentVector.EMPTY;
+            for (int i = 0; i < ELEMENTS.length; i++) {
+                clojure.lang.PersistentVector prepended = clojure.lang.PersistentVector.create(ELEMENTS[i]);
+                for (Object value : values) {
+                    prepended = prepended.cons(value);  /* rebuild everything via append */
+                }
+                values = prepended;
+            }
+            assert areEqual(Array.ofAll(values).reverse(), javaMutable);
+            return values;
+        }
+
+        @Benchmark
+        public Object scala_persistent() {
+            scala.collection.immutable.Vector<Integer> values = scala.collection.immutable.Vector$.MODULE$.empty();
+            for (Integer element : ELEMENTS) {
+                values = values.appendFront(element);
+            }
+            assert areEqual(Array.ofAll(asJavaCollection(values)).reverse(), javaMutable);
+            return values;
+        }
+
+        @Benchmark
         public Object slang_persistent() {
             javaslang.collection.Vector<Integer> values = javaslang.collection.Vector.empty();
             for (Integer element : ELEMENTS) {
@@ -466,30 +641,6 @@ public class VectorBenchmark {
         }
 
         @Benchmark
-        public Object scala_persistent() {
-            scala.collection.immutable.Vector<Integer> values = scala.collection.immutable.Vector$.MODULE$.empty();
-            for (Integer element : ELEMENTS) {
-                final scala.collection.immutable.Vector<Integer> newValues = values.appendBack(element);
-                assert values != newValues;
-                values = newValues;
-            }
-            assert areEqual(asJavaCollection(values), javaMutable);
-            return values;
-        }
-
-        @Benchmark
-        public Object clojure_persistent() {
-            clojure.lang.PersistentVector values = clojure.lang.PersistentVector.EMPTY;
-            for (Integer element : ELEMENTS) {
-                final clojure.lang.PersistentVector newValues = values.cons(element);
-                assert values != newValues;
-                values = newValues;
-            }
-            assert areEqual(values, javaMutable);
-            return values;
-        }
-
-        @Benchmark
         public Object fjava_persistent() {
             fj.data.Seq<Integer> values = fj.data.Seq.empty();
             for (Integer element : ELEMENTS) {
@@ -498,6 +649,18 @@ public class VectorBenchmark {
                 values = newValues;
             }
             assert areEqual(values, javaMutable);
+            return values;
+        }
+
+        @Benchmark
+        public Object ecollections_persistent() {
+            org.eclipse.collections.api.list.ImmutableList<Integer> values = org.eclipse.collections.impl.factory.Lists.immutable.empty();
+            for (Integer element : ELEMENTS) {
+                final org.eclipse.collections.api.list.MutableList<Integer> copy = values.toList();
+                copy.add(element);
+                values = copy.toImmutable();
+            }
+            assert areEqual(values, javaMutable) && (values != eCollectionsPersistent);
             return values;
         }
 
@@ -514,10 +677,34 @@ public class VectorBenchmark {
         }
 
         @Benchmark
+        public Object clojure_persistent() {
+            clojure.lang.PersistentVector values = clojure.lang.PersistentVector.EMPTY;
+            for (Integer element : ELEMENTS) {
+                final clojure.lang.PersistentVector newValues = values.cons(element);
+                assert values != newValues;
+                values = newValues;
+            }
+            assert areEqual(values, javaMutable);
+            return values;
+        }
+
+        @Benchmark
+        public Object scala_persistent() {
+            scala.collection.immutable.Vector<Integer> values = scala.collection.immutable.Vector$.MODULE$.empty();
+            for (Integer element : ELEMENTS) {
+                final scala.collection.immutable.Vector<Integer> newValues = values.appendBack(element);
+                assert values != newValues;
+                values = newValues;
+            }
+            assert areEqual(asJavaCollection(values), javaMutable);
+            return values;
+        }
+
+        @Benchmark
         public Object slang_persistent() {
             javaslang.collection.Vector<Integer> values = javaslang.collection.Vector.empty();
             for (Integer element : ELEMENTS) {
-                final Vector<Integer> newValues = values.append(element);
+                final javaslang.collection.Vector<Integer> newValues = values.append(element);
                 assert values != newValues;
                 values = newValues;
             }
@@ -534,7 +721,7 @@ public class VectorBenchmark {
 
         @Benchmark
         public Object scala_persistent() {
-            return scalaPersistent.groupBy(JFunction.func(Integer::bitCount));
+            return scalaPersistent.groupBy(func(Integer::bitCount));
         }
 
         @Benchmark
@@ -549,6 +736,16 @@ public class VectorBenchmark {
         public void java_mutable(Blackhole bh) { /* stores the whole collection underneath */
             java.util.List<Integer> values = javaMutable;
             while (!values.isEmpty()) {
+                values = values.subList(1, values.size());
+                values = values.subList(0, values.size() - 1);
+                bh.consume(values);
+            }
+        }
+
+        @Benchmark
+        public void pcollections_persistent(Blackhole bh) {
+            org.eclipse.collections.api.list.ImmutableList<Integer> values = eCollectionsPersistent;
+            for (int i = 1; !values.isEmpty(); i++) {
                 values = values.subList(1, values.size());
                 values = values.subList(0, values.size() - 1);
                 bh.consume(values);
@@ -587,7 +784,7 @@ public class VectorBenchmark {
         }
     }
 
-    /* Sequential access for all elements */
+    /** Sequential access for all elements */
     public static class Iterate extends Base {
         @State(Scope.Thread)
         public static class Initialized {
@@ -616,9 +813,29 @@ public class VectorBenchmark {
         }
 
         @Benchmark
-        public int scala_persistent() {
+        public int fjava_persistent() {
             int aggregate = 0;
-            for (final scala.collection.Iterator<Integer> iterator = scalaPersistent.iterator(); iterator.hasNext(); ) {
+            for (final java.util.Iterator<Integer> iterator = fjavaPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assert aggregate == EXPECTED_AGGREGATE;
+            return aggregate;
+        }
+
+        @Benchmark
+        public int ecollections_persistent() {
+            int aggregate = 0;
+            for (final java.util.Iterator<Integer> iterator = eCollectionsPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assert aggregate == EXPECTED_AGGREGATE;
+            return aggregate;
+        }
+
+        @Benchmark
+        public int pcollections_persistent() {
+            int aggregate = 0;
+            for (final java.util.Iterator<Integer> iterator = pCollectionsPersistent.iterator(); iterator.hasNext(); ) {
                 aggregate ^= iterator.next();
             }
             assert aggregate == EXPECTED_AGGREGATE;
@@ -636,19 +853,9 @@ public class VectorBenchmark {
         }
 
         @Benchmark
-        public int fjava_persistent() {
+        public int scala_persistent() {
             int aggregate = 0;
-            for (final java.util.Iterator<Integer> iterator = fjavaPersistent.iterator(); iterator.hasNext(); ) {
-                aggregate ^= iterator.next();
-            }
-            assert aggregate == EXPECTED_AGGREGATE;
-            return aggregate;
-        }
-
-        @Benchmark
-        public int pcollections_persistent() {
-            int aggregate = 0;
-            for (final java.util.Iterator<Integer> iterator = pcollectionsPersistent.iterator(); iterator.hasNext(); ) {
+            for (final scala.collection.Iterator<Integer> iterator = scalaPersistent.iterator(); iterator.hasNext(); ) {
                 aggregate ^= iterator.next();
             }
             assert aggregate == EXPECTED_AGGREGATE;


### PR DESCRIPTION
* Added `Eclipse Collections`
* Added option to selectively disable benchmarking alternatives
* Added proper sorting of end-results
* Added more compact memory consumption display
* Ordered methods in VectorBenchmarks (and added `map` and `filter` methods)