### PR TITLE
Changed memory usage display for benchmarks

### DIFF
--- a/javaslang-benchmark/src/test/java/javaslang/BenchmarkPerformanceReporter.java
+++ b/javaslang-benchmark/src/test/java/javaslang/BenchmarkPerformanceReporter.java
@@ -22,10 +22,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class BenchmarkPerformanceReporter {
-    static final Comparator<String> TO_STRING_COMPARATOR = Comparator.comparing(String::length).thenComparing(Function.identity());
-    static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("#,##0.000");
-    static final DecimalFormat PERFORMANCE_FORMAT = new DecimalFormat("#0.00");
-    static final DecimalFormat PCT_FORMAT = new DecimalFormat("0.00%");
+    private static final Comparator<String> TO_STRING_COMPARATOR = Comparator.comparing(String::length).thenComparing(Function.identity());
+    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("#,##0.00");
+    private static final DecimalFormat PERFORMANCE_FORMAT = new DecimalFormat("#0.00");
+    private static final DecimalFormat PCT_FORMAT = new DecimalFormat("0.00%");
 
     private final Array<String> includeNames;
     private final Array<String> benchmarkClasses;

--- a/javaslang-benchmark/src/test/java/javaslang/MemoryUsage.java
+++ b/javaslang-benchmark/src/test/java/javaslang/MemoryUsage.java
@@ -1,37 +1,64 @@
 package javaslang;
 
-import javaslang.collection.CharSeq;
-import javaslang.collection.LinkedHashMultimap;
-import javaslang.collection.List;
-import javaslang.collection.Multimap;
+import javaslang.collection.*;
+
+import java.text.DecimalFormat;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 import static com.carrotsearch.sizeof.RamUsageEstimator.humanReadableUnits;
 import static com.carrotsearch.sizeof.RamUsageEstimator.sizeOf;
-import static javaslang.BenchmarkPerformanceReporter.DECIMAL_FORMAT;
+import static java.lang.Math.max;
 
 public class MemoryUsage {
-    private static Multimap<Integer, String> memoryUsages = LinkedHashMultimap.withSeq().empty(); // if forked, this will be reset every time
+    private static final DecimalFormat FORMAT = new DecimalFormat("#,##0");
+    private static Map<Integer, LinkedHashSet<Seq<CharSeq>>> memoryUsages = TreeMap.empty(); // if forked, this will be reset every time
 
     /** Calculate the occupied memory of different internals */
     static void printAndReset() {
-        for (int size : memoryUsages.keySet()) {
-            System.out.println(String.format("\nfor `%d` elements", size));
-            for (String usages : memoryUsages.get(size).get()) {
-                System.out.println(usages);
+        for (Tuple2<Integer, LinkedHashSet<Seq<CharSeq>>> entry : memoryUsages) {
+            final Seq<Integer> columnSizes = columnSizes(entry._1);
+            System.out.println(String.format("\nfor `%d` elements", entry._1));
+            for (Seq<CharSeq> stats : entry._2) {
+                final String format = String.format("  %s → %s bytes - %s",
+                        stats.get(0).padTo(columnSizes.get(0), ' '),
+                        stats.get(1).leftPadTo(columnSizes.get(1), ' '),
+                        stats.get(2).leftPadTo(columnSizes.get(2), ' ')
+                );
+                System.out.println(format);
             }
         }
 
         memoryUsages = memoryUsages.take(0); // reset
     }
-
-    public static void storeMemoryUsages(int elementCount, Object target) {
-        final CharSeq name = CharSeq.of(target.getClass().getPackage().getName()).splitSeq("\\.").map(CharSeq::head).mkCharSeq("", ".", "." + target.getClass().getSimpleName());
-        final String usage = String.format("%s  → %s bytes (%s)",
-                name.padTo(32, ' '),
-                CharSeq.of(DECIMAL_FORMAT.format(sizeOf(target))).leftPadTo(15, ' '),
-                humanReadableUnits(sizeOf(target)));
-        if (!memoryUsages.get(elementCount).getOrElse(List::empty).contains(usage)) {
-            memoryUsages = memoryUsages.put(elementCount, usage);
-        }
+    private static Seq<Integer> columnSizes(int size) {
+        return memoryUsages.get(size)
+                .map(rows -> rows.map(row -> row.map(CharSeq::length))).get()
+                .reduce((row1, row2) -> row1.zip(row2).map(ts -> max(ts._1, ts._2)));
     }
+
+    static void storeMemoryUsages(int elementCount, Object target) {
+        memoryUsages = memoryUsages.put(elementCount, memoryUsages.get(elementCount).getOrElse(LinkedHashSet.empty()).add(Array.of(
+                toHumanReadableName(target),
+                FORMAT.format(sizeOf(target)),
+                humanReadableUnits(sizeOf(target))
+        ).map(CharSeq::of)));
+    }
+
+    private static HashMap<Predicate<String>, String> names = HashMap.ofEntries(
+            Tuple.of("^java\\.", "Java mutable @ "),
+            Tuple.of("^fj\\.", "Functional Java persistent @ "),
+            Tuple.of("^org\\.pcollections", "PCollections persistent @ "),
+            Tuple.of("^org\\.eclipse\\.collections", "Eclipse Collections persistent @ "),
+            Tuple.of("^clojure\\.", "Clojure persistent @ "),
+            Tuple.of("^scalaz\\.Heap", "Scalaz persistent @ "),
+            Tuple.of("^scala\\.collection.immutable", "Scala persistent @ "),
+            Tuple.of("^scala\\.collection.mutable", "Scala mutable @ "),
+            Tuple.of("^javaslang\\.", "Javaslang persistent @ ")
+    ).mapKeys(r -> Pattern.compile(r).asPredicate());
+    private static String toHumanReadableName(Object target) {
+        final Class<?> type = target.getClass();
+        return prefix(type) + type.getSimpleName();
+    }
+    private static String prefix(Class<?> type) { return names.find(p -> p._1.test(type.getName())).get()._2; }
 }


### PR DESCRIPTION
```java
for `32` elements
  Java mutable @ ArrayList                            →   504 bytes - 504 bytes
  Functional Java persistent @ Seq                    → 3,064 bytes -      3 KB
  PCollections persistent @ TreePVector               → 1,744 bytes -    1.7 KB
  Eclipse Collections persistent @ ImmutableArrayList →   496 bytes - 496 bytes
  Clojure persistent @ PersistentVector               →   704 bytes - 704 bytes
  Scala persistent @ Vector                           →   536 bytes - 536 bytes
  Javaslang persistent @ Vector                       →   528 bytes - 528 bytes

for `1024` elements
  Java mutable @ ArrayList                            →  19,064 bytes -  18.6 KB
  Functional Java persistent @ Seq                    → 104,760 bytes - 102.3 KB
  PCollections persistent @ TreePVector               →  56,016 bytes -  54.7 KB
  Eclipse Collections persistent @ ImmutableArrayList →  19,056 bytes -  18.6 KB
  Clojure persistent @ PersistentVector               →  20,504 bytes -    20 KB
  Scala persistent @ Vector                           →  19,736 bytes -  19.3 KB
  Javaslang persistent @ Vector                       →  19,728 bytes -  19.3 KB

for `32768` elements
  Java mutable @ ArrayList                            →   653,672 bytes - 638.4 KB
  Functional Java persistent @ Seq                    → 3,408,624 bytes -   3.3 MB
  PCollections persistent @ TreePVector               → 1,833,408 bytes -   1.7 MB
  Eclipse Collections persistent @ ImmutableArrayList →   653,664 bytes - 638.3 KB
  Clojure persistent @ PersistentVector               →   700,168 bytes - 683.8 KB
  Scala persistent @ Vector                           →   674,824 bytes -   659 KB
  Javaslang persistent @ Vector                       →   674,816 bytes -   659 KB
```

```java
for `10` elements
  Java mutable @ String                   →    64 bytes - 64 bytes
  Functional Java persistent @ LazyString → 2,480 bytes -   2.4 KB
  Javaslang persistent @ CharSeq          →    80 bytes - 80 bytes

for `100` elements
  Java mutable @ String                   →    240 bytes - 240 bytes
  Functional Java persistent @ LazyString → 23,536 bytes -     23 KB
  Javaslang persistent @ CharSeq          →    256 bytes - 256 bytes

for `1000` elements
  Java mutable @ String                   →   2,040 bytes -     2 KB
  Functional Java persistent @ LazyString → 234,136 bytes - 228.6 KB
  Javaslang persistent @ CharSeq          →   2,056 bytes -     2 KB
```

```java
for `10` elements
  Scalaz persistent @ anon$4                 → 1,568 bytes -    1.5 KB
  Functional Java persistent @ PriorityQueue → 1,280 bytes -    1.2 KB
  Javaslang persistent @ PriorityQueue       →   664 bytes - 664 bytes

for `100` elements
  Scalaz persistent @ anon$4                 → 14,528 bytes - 14.2 KB
  Functional Java persistent @ PriorityQueue → 12,000 bytes - 11.7 KB
  Javaslang persistent @ PriorityQueue       →  5,848 bytes -  5.7 KB

for `1000` elements
  Scalaz persistent @ anon$4                 → 150,208 bytes - 146.7 KB
  Functional Java persistent @ PriorityQueue → 125,904 bytes -   123 KB
  Javaslang persistent @ PriorityQueue       →  62,328 bytes -  60.9 KB
```

```java
for `8` elements
  Scala persistent @ BitSet1 → 24 bytes - 24 bytes

for `10` elements
  Javaslang persistent @ BitSet1 → 64 bytes - 64 bytes

for `62` elements
  Scala persistent @ BitSet2 → 32 bytes - 32 bytes

for `100` elements
  Javaslang persistent @ BitSet2 → 72 bytes - 72 bytes

for `613` elements
  Scala persistent @ BitSetN → 160 bytes - 160 bytes

for `1000` elements
  Javaslang persistent @ BitSetN → 208 bytes - 208 bytes
```

```java
for `10` elements
  Java mutable @ ArrayList             → 208 bytes - 208 bytes
  Java mutable @ LinkedList            → 400 bytes - 400 bytes
  Scala mutable @ MutableList          → 416 bytes - 416 bytes
  Scala persistent @ $colon$colon      → 384 bytes - 384 bytes
  Clojure persistent @ PersistentList  → 528 bytes - 528 bytes
  Functional Java persistent @ Cons    → 384 bytes - 384 bytes
  PCollections persistent @ ConsPStack → 480 bytes - 480 bytes
  Javaslang persistent @ Cons          → 384 bytes - 384 bytes

for `100` elements
  Java mutable @ ArrayList             → 1,432 bytes - 1.4 KB
  Java mutable @ LinkedList            → 3,424 bytes - 3.3 KB
  Scala mutable @ MutableList          → 3,440 bytes - 3.4 KB
  Scala persistent @ $colon$colon      → 3,408 bytes - 3.3 KB
  Clojure persistent @ PersistentList  → 4,992 bytes - 4.9 KB
  Functional Java persistent @ Cons    → 3,408 bytes - 3.3 KB
  PCollections persistent @ ConsPStack → 4,224 bytes - 4.1 KB
  Javaslang persistent @ Cons          → 3,408 bytes - 3.3 KB

for `1000` elements
  Java mutable @ ArrayList             → 18,312 bytes - 17.9 KB
  Java mutable @ LinkedList            → 38,304 bytes - 37.4 KB
  Scala mutable @ MutableList          → 38,320 bytes - 37.4 KB
  Scala persistent @ $colon$colon      → 38,288 bytes - 37.4 KB
  Clojure persistent @ PersistentList  → 54,272 bytes -   53 KB
  Functional Java persistent @ Cons    → 38,288 bytes - 37.4 KB
  PCollections persistent @ ConsPStack → 46,304 bytes - 45.2 KB
  Javaslang persistent @ Cons          → 38,288 bytes - 37.4 KB
```

```java
for `10` elements
  Java mutable @ ArrayList           → 208 bytes - 208 bytes
  Functional Java persistent @ Array → 200 bytes - 200 bytes
  Javaslang persistent @ Array       → 200 bytes - 200 bytes

for `100` elements
  Java mutable @ ArrayList           → 1,432 bytes - 1.4 KB
  Functional Java persistent @ Array → 1,424 bytes - 1.4 KB
  Javaslang persistent @ Array       → 1,424 bytes - 1.4 KB

for `1000` elements
  Java mutable @ ArrayList           → 18,312 bytes - 17.9 KB
  Functional Java persistent @ Array → 18,304 bytes - 17.9 KB
  Javaslang persistent @ Array       → 18,304 bytes - 17.9 KB
```

```java
for `8` elements
  Scala persistent @ HashTrieSet    →   440 bytes - 440 bytes
  PCollections persistent @ MapPSet → 1,120 bytes -    1.1 KB
  Javaslang persistent @ HashSet    →   408 bytes - 408 bytes

for `62` elements
  Scala persistent @ HashTrieSet    → 3,536 bytes - 3.5 KB
  PCollections persistent @ MapPSet → 7,168 bytes -   7 KB
  Javaslang persistent @ HashSet    → 3,928 bytes - 3.8 KB

for `613` elements
  Scala persistent @ HashTrieSet    → 33,976 bytes - 33.2 KB
  PCollections persistent @ MapPSet → 68,880 bytes - 67.3 KB
  Javaslang persistent @ HashSet    → 29,648 bytes -   29 KB
```