### PR TITLE
RFC: Migrate codebase to Java 9 compatibility

### DIFF
--- a/javaslang-match/src/main/java/javaslang/match/generator/ImportManager.java
+++ b/javaslang-match/src/main/java/javaslang/match/generator/ImportManager.java
@@ -114,7 +114,7 @@ class ImportManager {
     private static List<String> reverseSort(String[] strings) {
         final String[] copy = new String[strings.length];
         System.arraycopy(strings, 0, copy, 0, strings.length);
-        Arrays.sort(copy, (s1, s2) -> s2.compareTo(s1));
+        Arrays.sort(copy, Comparator.reverseOrder());
         return Arrays.asList(copy);
     }
 

--- a/javaslang/src/main/java/javaslang/Value.java
+++ b/javaslang/src/main/java/javaslang/Value.java
@@ -860,7 +860,7 @@ public interface Value<T> extends Iterable<T> {
      */
     default <K extends Comparable<? super K>, V> SortedMap<K, V> toSortedMap(Function<? super T, ? extends Tuple2<? extends K, ? extends V>> f) {
         Objects.requireNonNull(f, "f is null");
-        return toSortedMap((Comparator<? super K> & Serializable) K::compareTo, f);
+        return toSortedMap(Comparator.naturalOrder(), f);
     }
 
     /**
@@ -992,8 +992,8 @@ public interface Value<T> extends Iterable<T> {
             return (PriorityQueue<T>) this;
         } else {
             final Comparator<T> comparator = (this instanceof Ordered<?>)
-                                             ? ((Ordered<T>) this).comparator()
-                                             : (Comparator<T> & Serializable) (o1, o2) -> ((Comparable<T>) o1).compareTo(o2);
+                    ? ((Ordered<T>) this).comparator()
+                    : (Comparator<T>) Comparator.naturalOrder();
             return toPriorityQueue(comparator);
         }
     }
@@ -1069,8 +1069,8 @@ public interface Value<T> extends Iterable<T> {
             return (TreeSet<T>) this;
         } else {
             final Comparator<T> comparator = (this instanceof Ordered<?>)
-                                             ? ((Ordered<T>) this).comparator()
-                                             : (Comparator<T> & Serializable) (o1, o2) -> ((Comparable<T>) o1).compareTo(o2);
+                    ? ((Ordered<T>) this).comparator()
+                    : (Comparator<T>) Comparator.naturalOrder();
             return toSortedSet(comparator);
         }
     }

--- a/javaslang/src/main/java/javaslang/collection/BitSet.java
+++ b/javaslang/src/main/java/javaslang/collection/BitSet.java
@@ -744,7 +744,7 @@ interface BitSetModule {
 
         @Override
         public Comparator<T> comparator() {
-            return (Comparator<T> & Serializable) (t1, t2) -> Integer.compare(toInt.apply(t1), toInt.apply(t2));
+            return Comparator.comparing(toInt);
         }
 
         @Override

--- a/javaslang/src/test/java/javaslang/TupleTest.java
+++ b/javaslang/src/test/java/javaslang/TupleTest.java
@@ -399,14 +399,14 @@ public class TupleTest {
 
     @Test
     public void shouldNarrowTuple6() {
-        final Tuple6<String, Double, Float, Integer, Long, Byte> wideTuple = Tuple.of("zero", 1.0D, 2.0F, 3, 4L, new Byte("5"));
+        final Tuple6<String, Double, Float, Integer, Long, Byte> wideTuple = Tuple.of("zero", 1.0D, 2.0F, 3, 4L, (byte) 5);
         final Tuple6<CharSequence, Number, Number, Number, Number, Number> narrowTuple = Tuple.narrow(wideTuple);
         assertThat(narrowTuple._1()).isEqualTo("zero");
         assertThat(narrowTuple._2()).isEqualTo(1.0D);
         assertThat(narrowTuple._3()).isEqualTo(2.0F);
         assertThat(narrowTuple._4()).isEqualTo(3);
         assertThat(narrowTuple._5()).isEqualTo(4L);
-        assertThat(narrowTuple._6()).isEqualTo(new Byte("5"));
+        assertThat(narrowTuple._6()).isEqualTo((byte) 5);
     }
 
     // -- Tuple7
@@ -452,15 +452,15 @@ public class TupleTest {
 
     @Test
     public void shouldNarrowTuple7() {
-        final Tuple7<String, Double, Float, Integer, Long, Byte, Short> wideTuple = Tuple.of("zero", 1.0D, 2.0F, 3, 4L, new Byte("5"), new Short("6"));
+        final Tuple7<String, Double, Float, Integer, Long, Byte, Short> wideTuple = Tuple.of("zero", 1.0D, 2.0F, 3, 4L, (byte) 5, (short) 6);
         final Tuple7<CharSequence, Number, Number, Number, Number, Number, Number> narrowTuple = Tuple.narrow(wideTuple);
         assertThat(narrowTuple._1()).isEqualTo("zero");
         assertThat(narrowTuple._2()).isEqualTo(1.0D);
         assertThat(narrowTuple._3()).isEqualTo(2.0F);
         assertThat(narrowTuple._4()).isEqualTo(3);
         assertThat(narrowTuple._5()).isEqualTo(4L);
-        assertThat(narrowTuple._6()).isEqualTo(new Byte("5"));
-        assertThat(narrowTuple._7()).isEqualTo(new Short("6"));
+        assertThat(narrowTuple._6()).isEqualTo((byte) 5);
+        assertThat(narrowTuple._7()).isEqualTo((short) 6);
     }
 
     // -- Tuple8
@@ -506,15 +506,15 @@ public class TupleTest {
 
     @Test
     public void shouldNarrowTuple8() {
-        final Tuple8<String, Double, Float, Integer, Long, Byte, Short, BigDecimal> wideTuple = Tuple.of("zero", 1.0D, 2.0F, 3, 4L, new Byte("5"), new Short("6"), new BigDecimal(7));
+        final Tuple8<String, Double, Float, Integer, Long, Byte, Short, BigDecimal> wideTuple = Tuple.of("zero", 1.0D, 2.0F, 3, 4L, (byte) 5, (short) 6, new BigDecimal(7));
         final Tuple8<CharSequence, Number, Number, Number, Number, Number, Number, Number> narrowTuple = Tuple.narrow(wideTuple);
         assertThat(narrowTuple._1()).isEqualTo("zero");
         assertThat(narrowTuple._2()).isEqualTo(1.0D);
         assertThat(narrowTuple._3()).isEqualTo(2.0F);
         assertThat(narrowTuple._4()).isEqualTo(3);
         assertThat(narrowTuple._5()).isEqualTo(4L);
-        assertThat(narrowTuple._6()).isEqualTo(new Byte("5"));
-        assertThat(narrowTuple._7()).isEqualTo(new Short("6"));
+        assertThat(narrowTuple._6()).isEqualTo((byte) 5);
+        assertThat(narrowTuple._7()).isEqualTo((short) 6);
         assertThat(narrowTuple._8()).isEqualTo(new BigDecimal(7));
     }
 

--- a/javaslang/src/test/java/javaslang/collection/CharSeqTest.java
+++ b/javaslang/src/test/java/javaslang/collection/CharSeqTest.java
@@ -451,7 +451,7 @@ public class CharSeqTest {
 
     @Test
     public void shouldComputeDistinctByOfEmptyTraversableUsingComparator() {
-        final Comparator<Character> comparator = (i1, i2) -> i1 - i2;
+        final Comparator<Character> comparator = Comparator.comparingInt(i -> i);
         assertThat(empty().distinctBy(comparator)).isSameAs(empty());
     }
 
@@ -1004,7 +1004,7 @@ public class CharSeqTest {
 
     @Test
     public void shouldCalculateMaxByOfInts() {
-        assertThat(of('1', '2', '3').maxBy((i1, i2) -> i1 - i2)).isEqualTo(Option.some('3'));
+        assertThat(of('1', '2', '3').maxBy(Comparator.comparingInt(i -> i))).isEqualTo(Option.some('3'));
     }
 
     @Test
@@ -1060,7 +1060,7 @@ public class CharSeqTest {
 
     @Test
     public void shouldCalculateMinByOfInts() {
-        assertThat(of('1', '2', '3').minBy((i1, i2) -> i1 - i2)).isEqualTo(Option.some('1'));
+        assertThat(of('1', '2', '3').minBy(Comparator.comparingInt(i -> i))).isEqualTo(Option.some('1'));
     }
 
     @Test
@@ -3139,7 +3139,7 @@ public class CharSeqTest {
         assertThat(
                 CharSeq.unfoldRight('j', x -> x == 'a'
                                               ? Option.none()
-                                              : Option.of(new Tuple2<>(new Character(x), (char) (x - 1)))))
+                                              : Option.of(new Tuple2<>(x, (char) (x - 1)))))
                 .isEqualTo(of("jihgfedcb"));
     }
 
@@ -3153,7 +3153,7 @@ public class CharSeqTest {
         assertThat(
                 CharSeq.unfoldLeft('j', x -> x == 'a'
                                              ? Option.none()
-                                             : Option.of(new Tuple2<>((char) (x - 1), new Character(x)))))
+                                             : Option.of(new Tuple2<>((char) (x - 1), x))))
                 .isEqualTo(of("bcdefghij"));
     }
 
@@ -3167,7 +3167,7 @@ public class CharSeqTest {
         assertThat(
                 CharSeq.unfold('j', x -> x == 'a'
                                          ? Option.none()
-                                         : Option.of(new Tuple2<>((char) (x - 1), new Character(x)))))
+                                         : Option.of(new Tuple2<>((char) (x - 1), x))))
                 .isEqualTo(of("bcdefghij"));
     }
 

--- a/javaslang/src/test/java/javaslang/control/TryTest.java
+++ b/javaslang/src/test/java/javaslang/control/TryTest.java
@@ -956,10 +956,10 @@ public class TryTest extends AbstractValueTest {
 
     private static <T, X extends Throwable> Try<T> failure(Class<X> exceptionType) {
         try {
-            final X exception = exceptionType.newInstance();
+            final X exception = exceptionType.getConstructor().newInstance();
             return Try.failure(exception);
-        } catch (InstantiationException | IllegalAccessException x) {
-            throw new IllegalStateException("Error instantiating " + exceptionType);
+        } catch (Throwable e) {
+            throw new IllegalStateException("Error instantiating " + exceptionType, e);
         }
     }
 


### PR DESCRIPTION
WIP, feedback needed.
Addresses: #1465.

The code compiles but the `Scala` based code generation fails.
Running the tests without the generator reveals (unrelated?) bugs.

Still needs some love, but e.g. benchmarks are already functional.
Luckily some measurable speed improvements were implemented, i.e. `Vector`'s `append` is now almost as fast as it's `prepend` (#1557)
