### PR TITLE
#1531: Implemented zipWith and transformResult

### DIFF
--- a/javaslang/src/main/java/javaslang/concurrent/Future.java
+++ b/javaslang/src/main/java/javaslang/concurrent/Future.java
@@ -933,7 +933,7 @@ public interface Future<T> extends Value<T> {
     @Override
     default <U> Future<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return mapTry(mapper::apply);
+        return transformResult(t -> t.map(mapper::apply));
     }
 
     default <U> Future<U> mapTry(CheckedFunction<? super T, ? extends U> mapper) {

--- a/javaslang/src/main/java/javaslang/concurrent/Future.java
+++ b/javaslang/src/main/java/javaslang/concurrent/Future.java
@@ -5,7 +5,6 @@
  */
 package javaslang.concurrent;
 
-import javaslang.Function2;
 import javaslang.Tuple;
 import javaslang.Tuple2;
 import javaslang.Value;
@@ -748,7 +747,7 @@ public interface Future<T> extends Value<T> {
      */
     default Future<T> recover(Function<? super Throwable, ? extends T> f) {
         Objects.requireNonNull(f, "f is null");
-        return transformResult(t -> t.recover(f::apply));
+        return transformValue(t -> t.recover(f::apply));
     }
 
     /**
@@ -791,14 +790,14 @@ public interface Future<T> extends Value<T> {
     }
 
     /**
-     * Transforms the result of this {@code Future}, whether it is a success or a failure.
+     * Transforms the value of this {@code Future}, whether it is a success or a failure.
      *
      * @param f   A transformation
      * @param <U> Generic type of transformation {@code Try} result
      * @return A {@code Future} of type {@code U}
      * @throws NullPointerException if {@code f} is null
      */
-    default <U> Future<U> transformResult(Function<? super Try<T>, ? extends Try<U>> f) {
+    default <U> Future<U> transformValue(Function<? super Try<T>, ? extends Try<? extends U>> f) {
         Objects.requireNonNull(f, "f is null");
         final Promise<U> promise = Promise.make(executorService());
         onComplete(t -> {
@@ -837,7 +836,7 @@ public interface Future<T> extends Value<T> {
      * @throws NullPointerException if {@code that} is null
      */
     @SuppressWarnings("unchecked")
-    default <U, R> Future<R> zipWith(Future<? extends U> that, Function2<T, U, R> combinator) {
+    default <U, R> Future<R> zipWith(Future<? extends U> that, BiFunction<? super T, ? super U, ? extends R> combinator) {
         Objects.requireNonNull(that, "that is null");
         Objects.requireNonNull(combinator, "combinator is null");
         final Promise<R> promise = Promise.make(executorService());
@@ -933,12 +932,12 @@ public interface Future<T> extends Value<T> {
     @Override
     default <U> Future<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return transformResult(t -> t.map(mapper::apply));
+        return transformValue(t -> t.map(mapper::apply));
     }
 
     default <U> Future<U> mapTry(CheckedFunction<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return transformResult(t -> t.mapTry(mapper::apply));
+        return transformValue(t -> t.mapTry(mapper::apply));
     }
 
     default Future<T> orElse(Future<? extends T> other) {

--- a/javaslang/src/test/java/javaslang/concurrent/FutureTest.java
+++ b/javaslang/src/test/java/javaslang/concurrent/FutureTest.java
@@ -711,7 +711,7 @@ public class FutureTest extends AbstractValueTest {
 
     @Test
     public void shouldTransformResultFromSuccessToFailureThroughError() {
-        Future<String> future = Future.of(zZz(42)).transformResult(t -> Try.of(() -> "zzz" + (12/0)));
+        Future<String> future = Future.of(zZz(42)).transformResult(t -> Try.of(() -> {throw new ArithmeticException();}));
         waitUntil(future::isCompleted);
         waitUntil(future::isFailure);
         assertThat(future.getCause().get().getClass()).isEqualTo(ArithmeticException.class);
@@ -727,7 +727,7 @@ public class FutureTest extends AbstractValueTest {
 
     @Test
     public void shouldTransformResultFromFailureToFailure() {
-        Future<String> future = Future.of(() -> "zzz" + (12/0)).transformResult(t -> Try.failure(new Error()));
+        Future<String> future = Future.of(() -> {throw new ArithmeticException();}).transformResult(t -> Try.failure(new Error()));
         waitUntil(future::isCompleted);
         waitUntil(future::isFailure);
         assertThat(future.getCause().get().getClass()).isEqualTo(Error.class);
@@ -735,7 +735,7 @@ public class FutureTest extends AbstractValueTest {
 
     @Test
     public void shouldTransformResultFromFailureToFailureThroughError() {
-        Future<String> future = Future.of(zZz(new Error())).transformResult(t -> Try.of(() -> "zzz" + (12/0)));
+        Future<String> future = Future.of(zZz(new Error())).transformResult(t -> Try.of(() -> {throw new ArithmeticException();}));
         waitUntil(future::isCompleted);
         waitUntil(future::isFailure);
         assertThat(future.getCause().get().getClass()).isEqualTo(ArithmeticException.class);

--- a/javaslang/src/test/java/javaslang/concurrent/FutureTest.java
+++ b/javaslang/src/test/java/javaslang/concurrent/FutureTest.java
@@ -691,6 +691,56 @@ public class FutureTest extends AbstractValueTest {
         assertThat(transformed).isEqualTo("42");
     }
 
+    // -- transformResult()
+
+    @Test
+    public void shouldTransformResultFromSuccessToSuccess() {
+        Future<String> future = Future.of(zZz(42)).transformResult(t -> Try.of(() -> "forty two"));
+        waitUntil(future::isCompleted);
+        waitUntil(future::isSuccess);
+        assertThat(future.get()).isEqualTo("forty two");
+    }
+
+    @Test
+    public void shouldTransformResultFromSuccessToFailure() {
+        Future<String> future = Future.of(zZz(42)).transformResult(t -> Try.failure(new Error()));
+        waitUntil(future::isCompleted);
+        waitUntil(future::isFailure);
+        assertThat(future.getCause().get().getClass()).isEqualTo(Error.class);
+    }
+
+    @Test
+    public void shouldTransformResultFromSuccessToFailureThroughError() {
+        Future<String> future = Future.of(zZz(42)).transformResult(t -> Try.of(() -> "zzz" + (12/0)));
+        waitUntil(future::isCompleted);
+        waitUntil(future::isFailure);
+        assertThat(future.getCause().get().getClass()).isEqualTo(ArithmeticException.class);
+    }
+
+    @Test
+    public void shouldTransformResultFromFailureToSuccess() {
+        Future<String> future = Future.of(zZz(new Error())).transformResult(t -> Try.of(() -> "forty two"));
+        waitUntil(future::isCompleted);
+        waitUntil(future::isSuccess);
+        assertThat(future.get()).isEqualTo("forty two");
+    }
+
+    @Test
+    public void shouldTransformResultFromFailureToFailure() {
+        Future<String> future = Future.of(() -> "zzz" + (12/0)).transformResult(t -> Try.failure(new Error()));
+        waitUntil(future::isCompleted);
+        waitUntil(future::isFailure);
+        assertThat(future.getCause().get().getClass()).isEqualTo(Error.class);
+    }
+
+    @Test
+    public void shouldTransformResultFromFailureToFailureThroughError() {
+        Future<String> future = Future.of(zZz(new Error())).transformResult(t -> Try.of(() -> "zzz" + (12/0)));
+        waitUntil(future::isCompleted);
+        waitUntil(future::isFailure);
+        assertThat(future.getCause().get().getClass()).isEqualTo(ArithmeticException.class);
+    }
+
     // -- zip()
 
     @Test
@@ -704,6 +754,24 @@ public class FutureTest extends AbstractValueTest {
     @Test
     public void shouldZipFailure() {
         Future<Tuple2<Integer, Integer>> future = Future.<Integer> of(zZz(new Error())).zip(Future.of(zZz(2)));
+        waitUntil(future::isCompleted);
+        waitUntil(future::isFailure);
+        assertThat(future.getCause().get().getClass()).isEqualTo(Error.class);
+    }
+
+    // -- zipWith()
+
+    @Test
+    public void shouldZipWithSuccess() {
+        Future<List<Integer>> future = Future.of(zZz(1)).zipWith(Future.of(zZz(2)), List::of);
+        waitUntil(future::isCompleted);
+        waitUntil(future::isSuccess);
+        assertThat(future.get()).isEqualTo(List.of(1, 2));
+    }
+
+    @Test
+    public void shouldZipWithFailure() {
+        Future<List<Integer>> future = Future.<Integer> of(zZz(new Error())).zipWith(Future.of(zZz(2)), List::of);
         waitUntil(future::isCompleted);
         waitUntil(future::isFailure);
         assertThat(future.getCause().get().getClass()).isEqualTo(Error.class);


### PR DESCRIPTION
I enjoyed playing with this library and I also implemented two of the methods listed in the linked issue.

I named `transformResult` the new transform function because of type erasure... this is still Java, even if you did a great work to improve it.

I wonder how you would implement `flatten` without implicits :)

See you!