### PR TITLE
`Lazy` access minor speedup

### DIFF
--- a/javaslang-benchmark/src/test/java/javaslang/control/LazyBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/control/LazyBenchmark.java
@@ -1,0 +1,83 @@
+package javaslang.control;
+
+import javaslang.JmhRunner;
+import javaslang.Lazy;
+import javaslang.collection.Array;
+import javaslang.collection.Iterator;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import static javaslang.JmhRunner.Includes.JAVA;
+import static javaslang.JmhRunner.Includes.JAVASLANG;
+
+public class LazyBenchmark {
+    static final Array<Class<?>> CLASSES = Array.of(
+            Get.class
+    );
+
+    @Test
+    public void testAsserts() { JmhRunner.runDebugWithAsserts(CLASSES); }
+
+    public static void main(String... args) {
+        JmhRunner.runDebugWithAsserts(CLASSES, JAVA, JAVASLANG);
+        JmhRunner.runSlowNoAsserts(CLASSES, JAVA, JAVASLANG);
+    }
+
+    @State(Scope.Benchmark)
+    public static class Base {
+        final int SIZE = 10;
+
+        Integer[] EAGERS;
+        javaslang.Lazy<Integer>[] INITED_LAZIES;
+
+        @Setup
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        public void setup() {
+            EAGERS = Iterator.range(0, SIZE).toJavaArray(Integer.class);
+            INITED_LAZIES = Iterator.of(EAGERS).map(i -> {
+                final Lazy<Integer> lazy = Lazy.of(() -> i);
+                lazy.get();
+                return lazy;
+            }).toJavaList().toArray(new Lazy[0]);
+        }
+    }
+
+    @Threads(4)
+    @SuppressWarnings({ "WeakerAccess", "rawtypes" })
+    public static class Get extends Base {
+        @State(Scope.Thread)
+        public static class Initialized {
+            javaslang.Lazy<Integer>[] LAZIES;
+
+            @Setup(Level.Invocation)
+            @SuppressWarnings("unchecked")
+            public void initializeMutable(Base state) {
+                LAZIES = Iterator.of(state.EAGERS).map(i -> Lazy.of(() -> i)).toJavaList().toArray(new Lazy[0]);
+            }
+        }
+
+        @Benchmark
+        public void java_eager(Blackhole bh) {
+            for (int i = 0; i < SIZE; i++) {
+                bh.consume(EAGERS[i]);
+            }
+        }
+
+        @Benchmark
+        public void slang_inited_lazy(Blackhole bh) {
+            for (int i = 0; i < SIZE; i++) {
+                assert INITED_LAZIES[i].isEvaluated();
+                bh.consume(INITED_LAZIES[i].get());
+            }
+        }
+
+        @Benchmark
+        public void slang_lazy(Initialized state, Blackhole bh) {
+            for (int i = 0; i < SIZE; i++) {
+                assert !state.LAZIES[i].isEvaluated();
+                bh.consume(state.LAZIES[i].get());
+            }
+        }
+    }
+}

--- a/javaslang/src/main/java/javaslang/Lazy.java
+++ b/javaslang/src/main/java/javaslang/Lazy.java
@@ -7,13 +7,20 @@ package javaslang;
 
 import javaslang.collection.Iterator;
 import javaslang.collection.List;
-import javaslang.collection.*;
+import javaslang.collection.Seq;
 import javaslang.control.Option;
 
-import java.io.*;
-import java.lang.reflect.*;
-import java.util.*;
-import java.util.function.*;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * Represents a lazy evaluated value. Compared to a Supplier, Lazy is memoizing, i.e. it evaluates only once and
@@ -44,9 +51,7 @@ public final class Lazy<T> implements Value<T>, Supplier<T>, Serializable {
 
     // read http://javarevisited.blogspot.de/2014/05/double-checked-locking-on-singleton-in-java.html
     private transient volatile Supplier<? extends T> supplier;
-
-    // does not need to be volatile, visibility piggy-backs on volatile read of `supplier`
-    private T value;
+    private T value; // will behave as a volatile in reality, because a supplier volatile read will update all fields (see https://www.cs.umd.edu/~pugh/java/memoryModel/jsr-133-faq.html#volatile)
 
     // should not be called directly
     private Lazy(Supplier<? extends T> supplier) {
@@ -135,16 +140,13 @@ public final class Lazy<T> implements Value<T>, Supplier<T>, Serializable {
      */
     @Override
     public T get() {
-        // using a local var speeds up the double-check idiom by 25%, see Effective Java, Item 71
-        Supplier<? extends T> tmp = supplier;
-        if (tmp != null) {
-            synchronized (this) {
-                tmp = supplier;
-                if (tmp != null) {
-                    value = tmp.get();
-                    supplier = null; // free mem
-                }
-            }
+        return (supplier == null) ? value : computeValue();
+    }
+    private synchronized T computeValue() {
+        final Supplier<? extends T> s = supplier;
+        if (s != null) {
+            value = s.get();
+            supplier = null;
         }
         return value;
     }


### PR DESCRIPTION
Alternative to #1576
Memoization (mutation / multi threading in general) performance is difficult to measure properly.

The benchmark compares simple eager access (`java_eager`) to `Lazy`'s first access (`slang_lazy`) and subsequent, initialized access (`slang_inited_lazy`):

Since running the same measurement multiple times would measure different things (the first access would memoize, the rest would return the result of the calculation), I created a small array of `Lazy` values (small enough [to fit in the cache](https://github.com/emilk/ram_bench#measuring-it) but big enough to make the array access cost dissolve), and measure consuming it - recreating it before every measurement to assure uninitialized `Lazy`.

These are the results (please run them on your PC also via `javaslang.control.LazyBenchmark#main`):
```java
Before:
  java_eager/slang_inited_lazy 1.11×
  java_eager/slang_lazy        6.79×

After:
  java_eager/slang_inited_lazy 1.06×
  java_eager/slang_lazy        6.78×
```

Note: a proper test is still missing, thanks for the comments.