### PR TITLE
Added Value.toTree conversion methods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,6 +195,16 @@ release v2.1.0 - - - - - - + - - - X - - - + 2.1.1-SNAPSHOT
                           ...             ...
 ```
 
+### Backward compatibility
+
+We check backward compatibility by running the baseline goal of the maven-bundle-plugin:
+
+**Example:** Comparing API changes of current branch with version 2.0.0
+
+```bash
+mvn org.apache.felix:maven-bundle-plugin:baseline -DcomparisonVersion=2.0.0 -DskipTests
+```
+
 ### Major release
 
 #### Performing a release

--- a/javaslang/src/main/java/javaslang/Value.java
+++ b/javaslang/src/main/java/javaslang/Value.java
@@ -113,6 +113,8 @@ import java.util.stream.StreamSupport;
  * <li>{@link #toStream()}</li>
  * <li>{@link #toString()}</li>
  * <li>{@link #toTree()}</li>
+ * <li>{@link #toTree(Comparator)}</li>
+ * <li>{@link #toTree(ToIntFunction)}</li>
  * <li>{@link #toTry()}</li>
  * <li>{@link #toTry(Supplier)}</li>
  * <li>{@link #toVector()}</li>
@@ -955,6 +957,35 @@ public interface Value<T> extends Iterable<T> {
     }
 
     /**
+     * Converts this to a {@link Tree}.
+     *
+     * @return A new {@link Tree}.
+     */
+    default Tree<T> toTree() {
+        return ValueModule.toTraversable(this, Tree.empty(), Tree::of, Tree::ofAll);
+    }
+
+    /**
+     * Converts this to a {@link Tree} using a {@code Comparator}
+     *
+     * @param comparator An element comparator that computes the tree level difference of two elements {@code e1}, {@code e2}.
+     * @return The result of {@code Tree.ofAll(this, comparator)}.
+     */
+    default Tree<T> toTree(Comparator<? super T> comparator) {
+        return Tree.ofAll(this, comparator);
+    }
+
+    /**
+     * Converts this to a {@link Tree} using a {@code Comparator}
+     *
+     * @param treeLevel A function that computes the tree level of an element.
+     * @return The result of {@code Tree.ofAll(this, treeLevel)}.
+     */
+    default Tree<T> toTree(ToIntFunction<? super T> treeLevel) {
+        return Tree.ofAll(this, treeLevel);
+    }
+
+    /**
      * Converts this to a {@link Try}.
      * <p>
      * If this value is undefined, i.e. empty, then a new {@code Failure(NoSuchElementException)} is returned,
@@ -982,15 +1013,6 @@ public interface Value<T> extends Iterable<T> {
     default Try<T> toTry(Supplier<? extends Throwable> ifEmpty) {
         Objects.requireNonNull(ifEmpty, "ifEmpty is null");
         return isEmpty() ? Try.failure(ifEmpty.get()) : toTry();
-    }
-
-    /**
-     * Converts this to a {@link Tree}.
-     *
-     * @return A new {@link Tree}.
-     */
-    default Tree<T> toTree() {
-        return ValueModule.toTraversable(this, Tree.empty(), Tree::of, Tree::ofAll);
     }
 
     /**


### PR DESCRIPTION
I prepare the next releases 2.0.4 and 2.1.0. To get sure that we stay backward compatible I write a tool that parses the output of the maven-bundle-plugin.

The 'parser' will be based on our collection API. First we will filter the console output, then convert the relevant lines to a tree (using this conversion methods) and then semantically enrich the parse tree and interpret the resulting tree of information.

We can define our own rules then what is backward compatible and what is not. E.g. these are backward compatible:
- widening of generic type arguments
- changing collection indexing from long to int (because java will convert ints to long at the call site)
- ...
