### PR TITLE
Changed benchmark memory footprint computation to JOL

### DIFF
--- a/javaslang-benchmark/pom.xml
+++ b/javaslang-benchmark/pom.xml
@@ -54,9 +54,9 @@
             <version>8.0.0-M1</version>
         </dependency>
         <dependency>
-            <groupId>com.carrotsearch</groupId>
-            <artifactId>java-sizeof</artifactId>
-            <version>0.0.5</version>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <version>0.6</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>

--- a/javaslang-benchmark/src/test/java/javaslang/MemoryUsage.java
+++ b/javaslang-benchmark/src/test/java/javaslang/MemoryUsage.java
@@ -1,13 +1,12 @@
 package javaslang;
 
 import javaslang.collection.*;
+import org.openjdk.jol.info.GraphLayout;
 
 import java.text.DecimalFormat;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
-import static com.carrotsearch.sizeof.RamUsageEstimator.humanReadableUnits;
-import static com.carrotsearch.sizeof.RamUsageEstimator.sizeOf;
 import static java.lang.Math.max;
 
 public class MemoryUsage {
@@ -20,10 +19,9 @@ public class MemoryUsage {
             final Seq<Integer> columnSizes = columnSizes(entry._1);
             System.out.println(String.format("\nfor `%d` elements", entry._1));
             for (Seq<CharSeq> stats : entry._2) {
-                final String format = String.format("  %s → %s bytes - %s",
+                final String format = String.format("  %s → %s bytes",
                         stats.get(0).padTo(columnSizes.get(0), ' '),
-                        stats.get(1).leftPadTo(columnSizes.get(1), ' '),
-                        stats.get(2).leftPadTo(columnSizes.get(2), ' ')
+                        stats.get(1).leftPadTo(columnSizes.get(1), ' ')
                 );
                 System.out.println(format);
             }
@@ -40,10 +38,11 @@ public class MemoryUsage {
     static void storeMemoryUsages(int elementCount, Object target) {
         memoryUsages = memoryUsages.put(elementCount, memoryUsages.get(elementCount).getOrElse(LinkedHashSet.empty()).add(Array.of(
                 toHumanReadableName(target),
-                FORMAT.format(sizeOf(target)),
-                humanReadableUnits(sizeOf(target))
+                toHumanReadableByteSize(target)
         ).map(CharSeq::of)));
     }
+    private static String toHumanReadableByteSize(Object target) { return FORMAT.format(byteSize(target)); }
+    private static long byteSize(Object target)                  { return GraphLayout.parseInstance(target).totalSize(); }
 
     private static HashMap<Predicate<String>, String> names = HashMap.ofEntries(
             Tuple.of("^java\\.", "Java mutable @ "),

--- a/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java
@@ -15,12 +15,9 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static com.carrotsearch.sizeof.RamUsageEstimator.sizeOf;
 import static java.util.Arrays.asList;
 import static javaslang.JmhRunner.Includes.*;
 import static javaslang.JmhRunner.*;
-import static javaslang.collection.Arrays.copyRange;
-import static javaslang.collection.BitMappedTrie.branchingFactor;
 import static javaslang.collection.Collections.areEqual;
 import static scala.collection.JavaConversions.asJavaCollection;
 import static scala.collection.JavaConversions.asScalaBuffer;
@@ -778,7 +775,6 @@ public class VectorBenchmark {
             for (int i = 1; !values.isEmpty(); i++) {
                 values = values.slice(1, values.size());
                 values = values.slice(0, values.size() - 1);
-                assert sizeOf(values.trie) < (branchingFactor() * sizeOf(copyRange(ELEMENTS, i, javaMutable.size() - i))); /* detect memory leak */
                 bh.consume(values);
             }
         }


### PR DESCRIPTION
All previous measurements were correctly done via `com.carrotsearch#java-sizeof` also, but JOL is more mainstream and part of the OpenJDK.

Note: Unlike `java-sizeof`, `JOL` gives a runtime warning (even with `jol.tryWithSudo=true` on Linux):
```
# WARNING: Unable to attach Serviceability Agent. You can try again with escalated privileges. Two options: a) use -Djol.tryWithSudo=true to try with sudo; b) echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
```

Note2: you can find the memory measurements in: https://github.com/javaslang/javaslang/pull/1561