### PR TITLE
Optimized `prependAll`, `appendAll` and `insertAll` for `Vector`

### DIFF
--- a/javaslang-benchmark/pom.xml
+++ b/javaslang-benchmark/pom.xml
@@ -29,9 +29,9 @@
         </dependency>
         <dependency>
             <groupId>org.scalaz</groupId>
-            <artifactId>scalaz-core_2.12.0-RC2</artifactId>
+            <artifactId>scalaz-core_2.12</artifactId>
             <version>7.3.0-M6</version>
-            <!--contains scala-library 2.12.0-RC2-->
+            <!--contains scala-library 2.12.0-->
         </dependency>
         <dependency>
             <groupId>org.clojure</groupId>
@@ -66,11 +66,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/javaslang-benchmark/src/test/java/javaslang/JmhRunner.java
+++ b/javaslang-benchmark/src/test/java/javaslang/JmhRunner.java
@@ -110,7 +110,7 @@ public class JmhRunner {
                      Any GC during testing will destroy the iteration (i.e. introduce unreliable noise in the measurement), which should get ignored as an outlier */
                     .jvmArgsAppend("-XX:+UseG1GC", "-Xss100m", "-Xms4g", "-Xmx4g", "-XX:MaxGCPauseMillis=1000", "-XX:+UnlockExperimentalVMOptions", "-XX:G1NewSizePercent=100", "-XX:G1MaxNewSizePercent=100", assertions.vmArg);
 
-            final String includePattern = includeNames.mkString("\\..*?(", "|", ")_");
+            final String includePattern = includeNames.mkString("\\..*?\\b(", "|", ")_");
             classNames.forEach(name -> builder.include(name + includePattern));
 
             if (printInlining == PrintInlining.ENABLE) {

--- a/javaslang-pure/generator/Generator.scala
+++ b/javaslang-pure/generator/Generator.scala
@@ -454,16 +454,16 @@ object Generator {
   }
 
   /**
-    * Generates a String based on an Iterable of objects. Objects are converted to Strings via toString.
-    * {{{
-    * // val a = "A"
-    * // val b = "B"
-    * // val c = "C"
-    * Seq("a", "b", "c").gen(s => raw"""val $s = "${s.toUpperCase}"""")("\n")
-    * }}}
-    *
-    * @param iterable An Interable
-    */
+   * Generates a String based on an Iterable of objects. Objects are converted to Strings via toString.
+   * {{{
+   * // val a = "A"
+   * // val b = "B"
+   * // val c = "C"
+   * Seq("a", "b", "c").gen(s => raw"""val $s = "${s.toUpperCase}"""")("\n")
+   * }}}
+   *
+   * @param iterable An Interable
+   */
   implicit class IterableExtensions(iterable: Iterable[Any]) {
     def gen(f: String => String = identity)(implicit delimiter: String = ""): String =
       iterable.map(x => f.apply(x.toString)) mkString delimiter

--- a/javaslang-test/generator/Generator.scala
+++ b/javaslang-test/generator/Generator.scala
@@ -855,16 +855,16 @@ object Generator {
   }
 
   /**
-    * Generates a String based on an Iterable of objects. Objects are converted to Strings via toString.
-    * {{{
-    * // val a = "A"
-    * // val b = "B"
-    * // val c = "C"
-    * Seq("a", "b", "c").gen(s => raw"""val $s = "${s.toUpperCase}"""")("\n")
-    * }}}
-    *
-    * @param iterable An Interable
-    */
+   * Generates a String based on an Iterable of objects. Objects are converted to Strings via toString.
+   * {{{
+   * // val a = "A"
+   * // val b = "B"
+   * // val c = "C"
+   * Seq("a", "b", "c").gen(s => raw"""val $s = "${s.toUpperCase}"""")("\n")
+   * }}}
+   *
+   * @param iterable An Interable
+   */
   implicit class IterableExtensions(iterable: Iterable[Any]) {
     def gen(f: String => String = identity)(implicit delimiter: String = ""): String =
       iterable.map(x => f.apply(x.toString)) mkString delimiter

--- a/javaslang/src/test/java/javaslang/collection/AbstractSeqTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractSeqTest.java
@@ -5,7 +5,9 @@
  */
 package javaslang.collection;
 
-import javaslang.*;
+import javaslang.Function1;
+import javaslang.Tuple;
+import javaslang.Tuple2;
 import javaslang.control.Option;
 import org.junit.Test;
 
@@ -592,8 +594,8 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldInsertBehindOfElement() {
-        final Seq<Integer> actual = of(4).insert(1, 1);
-        final Seq<Integer> expected = of(4, 1);
+        final Seq<Integer> actual = of(4).insert(1, 5);
+        final Seq<Integer> expected = of(4, 5);
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -622,7 +624,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     // -- insertAll
 
     @Test
-    public void shouldInserAlltIntoNil() {
+    public void shouldInsertAllIntoNil() {
         final Seq<Integer> actual = this.<Integer> empty().insertAll(0, of(1, 2, 3));
         final Seq<Integer> expected = of(1, 2, 3);
         assertThat(actual).isEqualTo(expected);
@@ -701,7 +703,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldFullyIterateNonNilStartingAtIndex() {
         int actual = -1;
-        for (final Iterator<Integer> iter = of(1, 2, 3).iterator(1); iter.hasNext(); ) {
+        for (Iterator<Integer> iter = of(1, 2, 3).iterator(1); iter.hasNext(); ) {
             actual = iter.next();
         }
         assertThat(actual).isEqualTo(3);
@@ -922,9 +924,13 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldPrependAllNonNilToNonNil() {
-        final Seq<Integer> actual = of(4, 5, 6).prependAll(of(1, 2, 3));
-        final Seq<Integer> expected = of(1, 2, 3, 4, 5, 6);
-        assertThat(actual).isEqualTo(expected);
+        final Seq<Integer> expected = range(0, 100);
+
+        final Seq<Integer> actualFirstPartLarger = range(90, 100).prependAll(range(0, 90));
+        assertThat(actualFirstPartLarger).isEqualTo(expected);
+
+        final Seq<Integer> actualSecondPartLarger = range(10, 100).prependAll(range(0, 10));
+        assertThat(actualSecondPartLarger).isEqualTo(expected);
     }
 
     // -- remove
@@ -1081,7 +1087,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
             assertThat(of(1, 2, 3).removeAll(ignore -> true)).isEmpty();
             assertThat(of(1, 2, 3).removeAll(ignore -> false)).isEqualTo(of(1, 2, 3));
         } else {
-            Seq<Integer> seq = of(1, 2, 3);
+            final Seq<Integer> seq = of(1, 2, 3);
             assertThat(seq.removeAll(ignore -> false)).isSameAs(seq);
         }
     }

--- a/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorPropertyTest.java
@@ -6,17 +6,17 @@
 package javaslang.collection;
 
 import javaslang.Function2;
-import javaslang.Tuple;
 import javaslang.Tuple2;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import static javaslang.API.Tuple;
+import static javaslang.API.Vector;
 import static javaslang.collection.BitMappedTrie.BRANCHING_FACTOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,52 +30,62 @@ public class VectorPropertyTest {
                 assertThat(expected.get(j)).isEqualTo(actual.get(j));
             }
 
+            assert (i == 0) || !actual.trie.type.type().isPrimitive();
+
             /* boolean */
             final Seq<Boolean> expectedBoolean = expected.map(v -> v > 0);
             final Vector<Boolean> actualBoolean = Vector.ofAll(ArrayType.<boolean[]> asPrimitives(boolean.class, expectedBoolean));
             assert (i == 0) || (actualBoolean.trie.type.type() == boolean.class);
             assertAreEqual(expectedBoolean, actualBoolean);
+            assertAreEqual(expectedBoolean.append(null), actualBoolean.append(null));
 
             /* byte */
             final Seq<Byte> expectedByte = expected.map(Integer::byteValue);
             final Vector<Byte> actualByte = Vector.ofAll(ArrayType.<byte[]> asPrimitives(byte.class, expectedByte));
             assert (i == 0) || (actualByte.trie.type.type() == byte.class);
             assertAreEqual(expectedByte, actualByte);
+            assertAreEqual(expectedByte.append(null), actualByte.append(null));
 
             /* char */
             final Seq<Character> expectedChar = expected.map(v -> (char) v.intValue());
             final Vector<Character> actualChar = Vector.ofAll(ArrayType.<char[]> asPrimitives(char.class, expectedChar));
             assert (i == 0) || (actualChar.trie.type.type() == char.class);
             assertAreEqual(expectedChar, actualChar);
+            assertAreEqual(expectedChar.append(null), actualChar.append(null));
 
             /* double */
             final Seq<Double> expectedDouble = expected.map(Integer::doubleValue);
             final Vector<Double> actualDouble = Vector.ofAll(ArrayType.<double[]> asPrimitives(double.class, expectedDouble));
             assert (i == 0) || (actualDouble.trie.type.type() == double.class);
             assertAreEqual(expectedDouble, actualDouble);
+            assertAreEqual(expectedDouble.append(null), actualDouble.append(null));
 
             /* float */
             final Seq<Float> expectedFloat = expected.map(Integer::floatValue);
             final Vector<Float> actualFloat = Vector.ofAll(ArrayType.<float[]> asPrimitives(float.class, expectedFloat));
             assert (i == 0) || (actualFloat.trie.type.type() == float.class);
             assertAreEqual(expectedFloat, actualFloat);
+            assertAreEqual(expectedFloat.append(null), actualFloat.append(null));
 
             /* int */
             final Vector<Integer> actualInt = Vector.ofAll(ArrayType.<int[]> asPrimitives(int.class, expected));
             assert (i == 0) || (actualInt.trie.type.type() == int.class);
             assertAreEqual(expected, actualInt);
+            assertAreEqual(expected.append(null), actual.append(null));
 
             /* long */
             final Seq<Long> expectedLong = expected.map(Integer::longValue);
-            final Vector<Long> actualLog = Vector.ofAll(ArrayType.<long[]> asPrimitives(long.class, expectedLong));
-            assert (i == 0) || (actualLog.trie.type.type() == long.class);
-            assertAreEqual(expectedLong, actualLog);
+            final Vector<Long> actualLong = Vector.ofAll(ArrayType.<long[]> asPrimitives(long.class, expectedLong));
+            assert (i == 0) || (actualLong.trie.type.type() == long.class);
+            assertAreEqual(expectedLong, actualLong);
+            assertAreEqual(expectedLong.append(null), actualLong.append(null));
 
             /* short */
             final Seq<Short> expectedShort = expected.map(Integer::shortValue);
             final Vector<Short> actualShort = Vector.ofAll(ArrayType.<short[]> asPrimitives(short.class, expectedShort));
             assert (i == 0) || (actualShort.trie.type.type() == short.class);
             assertAreEqual(expectedShort, actualShort);
+            assertAreEqual(expectedShort.append(null), actualShort.append(null));
         }
     }
 
@@ -219,55 +229,76 @@ public class VectorPropertyTest {
                 Seq<Tuple2<Seq<Object>, Vector<Object>>> history = Array.empty();
 
                 if (percent(random) < 20) {
-                    final ArrayList<Object> values = new ArrayList<>();
-                    for (int k = 0; k < random.nextInt(j + 1); k++) {
-                        values.add(random.nextInt());
-                    }
-                    expected = Array.ofAll(values);
-                    final boolean isPrimitive = percent(random) < 30;
-                    actual = isPrimitive ? Vector.narrow(Vector.ofAll(ArrayType.<int[]> asPrimitives(int.class, values))) : Vector.ofAll(values);
+                    expected = Array.ofAll(Vector(randomValues(random, 100)).filter(v -> v instanceof Integer));
+                    actual = (percent(random) < 30) ? Vector.narrow(Vector.ofAll(ArrayType.<int[]> asPrimitives(int.class, expected))) : Vector.ofAll(expected);
                     assertAreEqual(expected, actual);
-                    history = history.append(Tuple.of(expected, actual));
+                    history = history.append(Tuple(expected, actual));
                 }
 
                 if (percent(random) < 50) {
                     final Object value = randomValue(random);
                     expected = expected.append(value);
                     actual = assertAreEqual(actual, value, Vector::append, expected);
-                    history = history.append(Tuple.of(expected, actual));
+                    history = history.append(Tuple(expected, actual));
+                }
+                if (percent(random) < 10) {
+                    Iterable<Object> values = randomValues(random, random.nextInt(2 * BRANCHING_FACTOR));
+                    expected = expected.appendAll(values);
+
+                    values = (percent(random) < 50) ? Iterator.ofAll(values.iterator()) : values;  /* not traversable again */
+                    actual = assertAreEqual(actual, values, Vector::appendAll, expected);
+                    history = history.append(Tuple(expected, actual));
                 }
 
                 if (percent(random) < 50) {
                     final Object value = randomValue(random);
                     expected = expected.prepend(value);
                     actual = assertAreEqual(actual, value, Vector::prepend, expected);
-                    history = history.append(Tuple.of(expected, actual));
+                    history = history.append(Tuple(expected, actual));
+                }
+                if (percent(random) < 10) {
+                    Iterable<Object> values = randomValues(random, random.nextInt(2 * BRANCHING_FACTOR));
+                    expected = expected.prependAll(values);
+
+                    values = (percent(random) < 50) ? Iterator.ofAll(values) : values;  /* not traversable again */
+                    actual = assertAreEqual(actual, values, Vector::prependAll, expected);
+                    history = history.append(Tuple(expected, actual));
                 }
 
                 if (percent(random) < 30) {
                     final int n = random.nextInt(expected.size() + 1);
                     expected = expected.drop(n);
                     actual = assertAreEqual(actual, n, Vector::drop, expected);
-                    history = history.append(Tuple.of(expected, actual));
+                    history = history.append(Tuple(expected, actual));
+                }
+
+                if (percent(random) < 10) {
+                    final int index = random.nextInt(expected.size() + 1);
+                    Iterable<Object> values = randomValues(random, random.nextInt(2 * BRANCHING_FACTOR));
+                    expected = expected.insertAll(index, values);
+
+                    values = (percent(random) < 50) ? Iterator.ofAll(values) : values;  /* not traversable again */
+                    actual = assertAreEqual(actual, values, (a, p) -> a.insertAll(index, p), expected);
+                    history = history.append(Tuple(expected, actual));
                 }
 
                 if (percent(random) < 30) {
                     final int n = random.nextInt(expected.size() + 1);
                     expected = expected.take(n);
                     actual = assertAreEqual(actual, n, Vector::take, expected);
-                    history = history.append(Tuple.of(expected, actual));
+                    history = history.append(Tuple(expected, actual));
                 }
 
                 if (!expected.isEmpty()) {
                     assertThat(actual.head()).isEqualTo(expected.head());
                     assertThat(actual.tail().toJavaList()).isEqualTo(expected.tail().toJavaList());
-                    history = history.append(Tuple.of(expected, actual));
+                    history = history.append(Tuple(expected, actual));
                 }
 
                 if (!expected.isEmpty()) {
                     final int index = random.nextInt(expected.size());
                     assertThat(actual.get(index)).isEqualTo(expected.get(index));
-                    history = history.append(Tuple.of(expected, actual));
+                    history = history.append(Tuple(expected, actual));
                 }
 
                 if (percent(random) < 50) {
@@ -276,7 +307,7 @@ public class VectorPropertyTest {
                         final Object value = randomValue(random);
                         expected = expected.update(index, value);
                         actual = assertAreEqual(actual, null, (a, p) -> a.update(index, value), expected);
-                        history = history.append(Tuple.of(expected, actual));
+                        history = history.append(Tuple(expected, actual));
                     }
                 }
 
@@ -284,14 +315,14 @@ public class VectorPropertyTest {
                     final Function<Object, Object> mapper = val -> (val instanceof Integer) ? ((Integer) val + 1) : val;
                     expected = expected.map(mapper);
                     actual = assertAreEqual(actual, null, (a, p) -> a.map(mapper), expected);
-                    history = history.append(Tuple.of(expected, actual));
+                    history = history.append(Tuple(expected, actual));
                 }
 
                 if (percent(random) < 30) {
                     final Predicate<Object> filter = val -> (String.valueOf(val).length() % 10) == 0;
                     expected = expected.filter(filter);
                     actual = assertAreEqual(actual, null, (a, p) -> a.filter(filter), expected);
-                    history = history.append(Tuple.of(expected, actual));
+                    history = history.append(Tuple(expected, actual));
                 }
 
                 if (percent(random) < 30) {
@@ -301,7 +332,7 @@ public class VectorPropertyTest {
                             final int from = random.nextInt(to + 1);
                             expected = expected.slice(from, to);
                             actual = assertAreEqual(actual, null, (a, p) -> a.slice(from, to), expected);
-                            history = history.append(Tuple.of(expected, actual));
+                            history = history.append(Tuple(expected, actual));
                         }
                     }
                 }
@@ -311,8 +342,16 @@ public class VectorPropertyTest {
         }
     }
 
-    private int percent(Random random) { return random.nextInt(100); }
-
+    private int percent(Random random) { return random.nextInt(101); }
+    private Iterable<Object> randomValues(Random random, int count) {
+        final Vector<Object> values = Vector.range(0, count).map(v -> randomValue(random));
+        final int percent = percent(random);
+        if (percent < 30) {
+            return values.toJavaList();  /* not Traversable */
+        } else {
+            return values;
+        }
+    }
     private Object randomValue(Random random) {
         final int percent = percent(random);
         if (percent < 5) {

--- a/javaslang/src/test/java/javaslang/collection/VectorTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorTest.java
@@ -192,11 +192,25 @@ public class VectorTest extends AbstractIndexedSeqTest {
         assertThat(actual).isEqualTo(3);
     }
 
+    // -- primitives
+
     @Test
-    public void shouldNarrowPrimitives() {
-        final Vector<Object> object = Vector.narrow(range(0, 2));
-        Vector<Object> actual = object.append("String");
-        assertThat(actual).isEqualTo(of(0, 1, "String"));
+    public void shouldAddNullToPrimitiveVector() {
+        final Vector<Integer> primitives = rangeClosed(0, 2);
+
+        assertThat(primitives.append(null)).isEqualTo(of(0, 1, 2, null));
+        assertThat(primitives.prepend(null)).isEqualTo(of(null, 0, 1, 2));
+        assertThat(primitives.update(1, null)).isEqualTo(of(0, null, 2));
+    }
+
+    @Test
+    public void shouldAddObjectToPrimitiveVector() {
+        final String object = "String";
+        final Vector<Object> primitives = Vector.narrow(rangeClosed(0, 2));
+
+        assertThat(primitives.append(object)).isEqualTo(of(0, 1, 2, object));
+        assertThat(primitives.prepend(object)).isEqualTo(of(object, 0, 1, 2));
+        assertThat(primitives.update(1, object)).isEqualTo(of(0, object, 2));
     }
 
     // -- transform()

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@ Note: The maven build currently needs to be started from the javaslang root dir
         <assertj.core.version>3.5.2</assertj.core.version>
         <eclipse.lifecycle.mapping.version>1.0.0</eclipse.lifecycle.mapping.version>
         <java.version>1.8</java.version>
-        <jmh.version>1.15</jmh.version>
+        <jmh.version>1.16</jmh.version>
         <junit.version>4.12</junit.version>
         <gwt.version>2.8.0</gwt.version>
         <maven.build-helper.version>1.12</maven.build-helper.version>
@@ -104,11 +104,6 @@ Note: The maven build currently needs to be started from the javaslang root dir
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.openjdk.jmh</groupId>
-                <artifactId>jmh-core</artifactId>
-                <version>${jmh.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.openjdk.jmh</groupId>


### PR DESCRIPTION
Since @danieldietrich requested the original `Vector` to be simplified (good call, the code is a lot simpler now!), I've been thinking how to keep the performance AND maintainable code.

The solution was the optimization of the bulk operations instead, i.e. `appendAll` and `prependAll`.
Though they are difficult to benchmarks, I ended up measuring all reasonable combinations of recreating the original array by splitting it and recombining via `prependAll` and `appendAll`, therefore including all corner cases that could differ in speed.

I couldn't really compare it against Java (I can't recreate everything after a modification) or Scala (doesn't have bulk `prepend`, just `append`), so I compared it against the previous implementation:

``` java
Operation  Ratio                   10      100    1026
PrependAll slang_new/slang_old   3.63×  12.93×  17.64×
AppendAll  slang_new/slang_old   1.28×   8.86×  16.82×
Insert     slang_new/slang_old   0.48×   6.65×  18.87×
```
Note: I optimized `insertAll` also, by always iterating over the smaller collection.

---
The benchmarks are as follows:
boxed:
```java
Operation  Ratio                                                10      100     1026 
Create     slang_persistent/java_mutable                     1.68×    1.31×    1.28×
Create     slang_persistent/java_mutable_boxed               3.93×    5.28×    7.80×
Create     slang_persistent/java_mutable_boxed_stream        7.84×    7.27×    8.90×
Create     slang_persistent/fjava_persistent                67.37×  165.32×  197.55×
Create     slang_persistent/pcollections_persistent         27.73×  107.59×  202.16×
Create     slang_persistent/ecollections_persistent          2.24×    1.12×    0.88×
Create     slang_persistent/clojure_persistent               1.00×   11.33×   10.11×
Create     slang_persistent/scala_persistent                 7.13×    7.92×    7.70×

Head       slang_persistent/java_mutable                     0.66×    0.49×    0.39×
Head       slang_persistent/fjava_persistent                 0.83×    0.64×    0.51×
Head       slang_persistent/pcollections_persistent          1.70×    2.31×    3.16×
Head       slang_persistent/ecollections_persistent          0.62×    0.60×    0.49×
Head       slang_persistent/clojure_persistent               0.71×    0.83×    0.69×
Head       slang_persistent/scala_persistent                 0.79×    0.59×    0.49×

Tail       slang_persistent/java_mutable                     0.88×    0.48×    0.49×
Tail       slang_persistent/fjava_persistent                30.80×   44.14×   40.51×
Tail       slang_persistent/pcollections_persistent          4.49×    5.65×    7.78×
Tail       slang_persistent/ecollections_persistent         19.18×   19.57×  128.28×
Tail       slang_persistent/clojure_persistent               0.94×    0.66×    0.63×
Tail       slang_persistent/scala_persistent                 2.64×    3.49×    4.55×

Get        slang_persistent/java_mutable                     0.80×    0.41×    0.27×
Get        slang_persistent/fjava_persistent                28.58×   51.36×   60.27×
Get        slang_persistent/pcollections_persistent          4.56×    6.10×    8.81×
Get        slang_persistent/ecollections_persistent          1.30×    0.39×    0.22×
Get        slang_persistent/clojure_persistent               0.88×    1.48×    0.74×
Get        slang_persistent/scala_persistent                 1.09×    1.03×    0.71×

Update     slang_persistent/java_mutable                     0.18×    0.06×    0.04×
Update     slang_persistent/fjava_persistent                62.71×  147.10×  175.57×
Update     slang_persistent/pcollections_persistent          1.62×    2.21×    2.82×
Update     slang_persistent/ecollections_persistent          4.97×   22.35×  112.51×
Update     slang_persistent/clojure_persistent               0.75×    1.41×    0.89×
Update     slang_persistent/scala_persistent                 1.21×    1.07×    0.76×

Map        slang_persistent/java_mutable                     2.16×    2.37×    2.30×
Map        slang_persistent/java_mutable_loop                0.48×    0.51×    0.72×
Map        slang_persistent/ecollections_persistent          1.39×    0.96×    1.13×
Map        slang_persistent/scala_persistent                 1.21×    1.18×    1.43×

Filter     slang_persistent/java_mutable                     1.88×    1.94×    1.53×
Filter     slang_persistent/ecollections_persistent          1.04×    1.49×    1.06×
Filter     slang_persistent/scala_persistent                 1.47×    1.55×    1.38×

Prepend    slang_persistent/java_mutable                     0.11×    0.12×    0.23×
Prepend    slang_persistent/fjava_persistent                 0.39×    0.56×    0.51×
Prepend    slang_persistent/pcollections_persistent          0.22×    0.49×    0.84×
Prepend    slang_persistent/ecollections_persistent          0.38×    1.50×    9.03×
Prepend    slang_persistent/clojure_persistent               0.91×    4.70×   42.84×
Prepend    slang_persistent/scala_persistent                 0.09×    0.08×    0.08×

Append     slang_persistent/java_mutable                     0.04×    0.03×    0.02×
Append     slang_persistent/fjava_persistent                 0.65×    0.66×    0.57×
Append     slang_persistent/pcollections_persistent          0.29×    0.44×    0.70×
Append     slang_persistent/ecollections_persistent          0.47×    1.57×    9.45×
Append     slang_persistent/clojure_persistent               0.15×    0.10×    0.10×
Append     slang_persistent/scala_persistent                 0.15×    0.10×    0.08×

AppendAll  slang_persistent/scala_persistent                 2.79×    1.52×    1.67×

GroupBy    slang_persistent/java_mutable                     0.35×    0.53×    0.89×
GroupBy    slang_persistent/scala_persistent                 1.25×    1.17×    0.92×

Slice      slang_persistent/java_mutable                     0.63×    0.43×    0.45×
Slice      slang_persistent/pcollections_persistent          0.56×    0.40×    0.37×
Slice      slang_persistent/clojure_persistent               0.60×    0.43×    0.41×
Slice      slang_persistent/scala_persistent                 2.45×    3.13×    4.87×

Iterate    slang_persistent/java_mutable                     0.75×    0.30×    0.40×
Iterate    slang_persistent/fjava_persistent               191.76×  259.16×  396.44×
Iterate    slang_persistent/pcollections_persistent         13.86×    6.54×   13.70×
Iterate    slang_persistent/ecollections_persistent          1.14×    1.21×    1.68×
Iterate    slang_persistent/clojure_persistent               0.95×    0.78×    1.33×
Iterate    slang_persistent/scala_persistent                 2.03×    0.88×    1.43×
```

primitives
```java
Create     slang_persistent_int/java_mutable                 2.61×    1.29×    1.22×
Create     slang_persistent_int/java_mutable_boxed           6.12×    5.20×    7.41×
Create     slang_persistent_int/java_mutable_boxed_stream   12.19×    7.16×    8.46×
Create     slang_persistent_int/fjava_persistent           104.79×  162.83×  187.87×
Create     slang_persistent_int/pcollections_persistent     43.12×  105.97×  192.25×
Create     slang_persistent_int/ecollections_persistent      3.49×    1.10×    0.83×
Create     slang_persistent_int/clojure_persistent           1.55×   11.16×    9.61×
Create     slang_persistent_int/scala_persistent            11.09×    7.80×    7.32×

Tail       slang_persistent_int/java_mutable                 0.83×    0.48×    0.50×
Tail       slang_persistent_int/fjava_persistent            29.10×   44.56×   40.75×
Tail       slang_persistent_int/pcollections_persistent      4.24×    5.71×    7.82×
Tail       slang_persistent_int/ecollections_persistent     18.13×   19.76×  129.03×
Tail       slang_persistent_int/clojure_persistent           0.89×    0.67×    0.64×
Tail       slang_persistent_int/scala_persistent             2.49×    3.52×    4.58×

Update     slang_persistent_int/java_mutable                 0.20×    0.06×    0.04×
Update     slang_persistent_int/fjava_persistent            68.52×  150.03×  178.25×
Update     slang_persistent_int/pcollections_persistent      1.77×    2.26×    2.86×
Update     slang_persistent_int/ecollections_persistent      5.43×   22.80×  114.22×
Update     slang_persistent_int/clojure_persistent           0.82×    1.44×    0.91×
Update     slang_persistent_int/scala_persistent             1.32×    1.09×    0.77×

Map        slang_persistent_int/java_mutable                 2.11×    2.08×    1.79×
Map        slang_persistent_int/java_mutable_loop            0.47×    0.45×    0.56×
Map        slang_persistent_int/ecollections_persistent      1.36×    0.85×    0.88×
Map        slang_persistent_int/scala_persistent             1.18×    1.04×    1.11×

Filter     slang_persistent_int/java_mutable                 2.09×    2.28×    1.13×
Filter     slang_persistent_int/ecollections_persistent      1.15×    1.76×    0.78×
Filter     slang_persistent_int/scala_persistent             1.63×    1.82×    1.02×

Prepend    slang_persistent_int/java_mutable                 0.13×    0.15×    0.24×
Prepend    slang_persistent_int/fjava_persistent             0.46×    0.69×    0.53×
Prepend    slang_persistent_int/pcollections_persistent      0.25×    0.59×    0.87×
Prepend    slang_persistent_int/ecollections_persistent      0.45×    1.84×    9.33×
Prepend    slang_persistent_int/clojure_persistent           1.08×    5.74×   44.25×
Prepend    slang_persistent_int/scala_persistent             0.10×    0.10×    0.08×

Append     slang_persistent_int/java_mutable                 0.04×    0.03×    0.02×
Append     slang_persistent_int/fjava_persistent             0.57×    0.70×    0.64×
Append     slang_persistent_int/pcollections_persistent      0.25×    0.46×    0.79×
Append     slang_persistent_int/ecollections_persistent      0.42×    1.66×   10.68×
Append     slang_persistent_int/clojure_persistent           0.14×    0.10×    0.11×
Append     slang_persistent_int/scala_persistent             0.14×    0.11×    0.10×

Slice      slang_persistent_int/java_mutable                 0.62×    0.41×    0.48×
Slice      slang_persistent_int/pcollections_persistent      0.55×    0.39×    0.40×
Slice      slang_persistent_int/clojure_persistent           0.58×    0.42×    0.44×
Slice      slang_persistent_int/scala_persistent             2.40×    3.05×    5.18×

Iterate    slang_persistent_int/java_mutable                 1.01×    0.89×    0.79×
Iterate    slang_persistent_int/fjava_persistent           256.18×  777.01×  796.19×
Iterate    slang_persistent_int/pcollections_persistent     18.52×   19.60×   27.52×
Iterate    slang_persistent_int/ecollections_persistent      1.52×    3.63×    3.37×
Iterate    slang_persistent_int/clojure_persistent           1.27×    2.33×    2.66×
Iterate    slang_persistent_int/scala_persistent             2.71×    2.64×    2.87×
```