### PR TITLE
Updated JMH, Scalaz, Clojure, and ECollections benchmark versions

### DIFF
--- a/javaslang-benchmark/pom.xml
+++ b/javaslang-benchmark/pom.xml
@@ -29,14 +29,14 @@
         </dependency>
         <dependency>
             <groupId>org.scalaz</groupId>
-            <artifactId>scalaz-core_2.11</artifactId>
-            <version>7.3.0-M4</version>
-            <!--contains scala-library 2.11.8-->
+            <artifactId>scalaz-core_2.12.0-RC2</artifactId>
+            <version>7.3.0-M6</version>
+            <!--contains scala-library 2.12.0-RC2-->
         </dependency>
         <dependency>
             <groupId>org.clojure</groupId>
             <artifactId>clojure</artifactId>
-            <version>1.9.0-alpha12</version>
+            <version>1.9.0-alpha14</version>
         </dependency>
         <dependency>
             <groupId>org.pcollections</groupId>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
-            <version>8.0.0-M1</version>
+            <version>8.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jol</groupId>

--- a/javaslang-benchmark/src/test/java/javaslang/collection/ListBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/collection/ListBenchmark.java
@@ -3,15 +3,17 @@ package javaslang.collection;
 import javaslang.JmhRunner;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
-import scala.compat.java8.JFunction;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
-import static javaslang.JmhRunner.*;
+import static javaslang.JmhRunner.create;
+import static javaslang.JmhRunner.getRandomValues;
 import static javaslang.collection.Collections.areEqual;
-import static scala.collection.JavaConversions.*;
+import static scala.collection.JavaConverters.asJavaCollection;
+import static scala.collection.JavaConverters.asScalaBuffer;
 
 public class ListBenchmark {
     static final Array<Class<?>> CLASSES = Array.of(
@@ -539,7 +541,7 @@ public class ListBenchmark {
 
         @Benchmark
         public Object scala_persistent() {
-            return scalaPersistent.groupBy(JFunction.func(Integer::bitCount));
+            return scalaPersistent.groupBy(Integer::bitCount);
         }
 
         @Benchmark

--- a/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java
@@ -6,8 +6,6 @@ import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 import scala.collection.generic.CanBuildFrom;
-import scala.compat.java8.functionConverterImpls.FromJavaFunction;
-import scala.compat.java8.functionConverterImpls.FromJavaPredicate;
 
 import java.util.Objects;
 import java.util.Random;
@@ -20,7 +18,6 @@ import static javaslang.JmhRunner.*;
 import static javaslang.collection.Collections.areEqual;
 import static scala.collection.JavaConversions.asJavaCollection;
 import static scala.collection.JavaConversions.asScalaBuffer;
-import static scala.compat.java8.JFunction.func;
 
 @SuppressWarnings({ "ALL", "unchecked", "rawtypes" })
 public class VectorBenchmark {
@@ -520,7 +517,7 @@ public class VectorBenchmark {
 
         @Benchmark
         public Object scala_persistent() {
-            final scala.collection.immutable.Vector<Integer> values = (scala.collection.immutable.Vector<Integer>) scalaPersistent.map(new FromJavaFunction<>(Map::mapper), canBuildFrom);
+            final scala.collection.immutable.Vector<Integer> values = (scala.collection.immutable.Vector<Integer>) scalaPersistent.map(Map::mapper, canBuildFrom);
             assert areEqual(asJavaCollection(values), Array.of(ELEMENTS).map(Map::mapper));
             return values;
         }
@@ -559,7 +556,7 @@ public class VectorBenchmark {
 
         @Benchmark
         public Object scala_persistent() {
-            final scala.collection.immutable.Vector<Integer> someValues = (scala.collection.immutable.Vector<Integer>) scalaPersistent.filter(new FromJavaPredicate<>(Filter::isOdd));
+            final scala.collection.immutable.Vector<Integer> someValues = (scala.collection.immutable.Vector<Integer>) scalaPersistent.filter(Filter::isOdd);
             assert areEqual(asJavaCollection(someValues), Array.of(ELEMENTS).filter(Filter::isOdd));
             return someValues;
         }
@@ -807,7 +804,7 @@ public class VectorBenchmark {
         public Object java_mutable() { return javaMutable.stream().collect(groupingBy(Integer::bitCount)); }
 
         @Benchmark
-        public Object scala_persistent() { return scalaPersistent.groupBy(func(Integer::bitCount)); }
+        public Object scala_persistent() { return scalaPersistent.groupBy(Integer::bitCount); }
 
         @Benchmark
         public Object slang_persistent() { return slangPersistent.groupBy(Integer::bitCount); }

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@ Note: The maven build currently needs to be started from the javaslang root dir
         <assertj.core.version>3.5.2</assertj.core.version>
         <eclipse.lifecycle.mapping.version>1.0.0</eclipse.lifecycle.mapping.version>
         <java.version>1.8</java.version>
-        <jmh.version>1.14</jmh.version>
+        <jmh.version>1.15</jmh.version>
         <junit.version>4.12</junit.version>
         <gwt.version>2.8.0</gwt.version>
         <maven.build-helper.version>1.12</maven.build-helper.version>


### PR DESCRIPTION
Aligned Java 8 compatibility to Scala 2.12 benchmarks