### PR TITLE
use a Vector as accumulator of map.traverse (#1633)

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/Map.java
+++ b/javaslang/src/main/java/javaslang/collection/Map.java
@@ -543,7 +543,7 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
 
     default <U> Seq<U> traverse(BiFunction<K, V, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return foldLeft(List.empty(), (acc, entry) -> acc.append(mapper.apply(entry._1, entry._2)));
+        return foldLeft(Vector.empty(), (acc, entry) -> acc.append(mapper.apply(entry._1, entry._2)));
     }
 
     default Tuple2<Seq<K>, Seq<V>> unzip() {

--- a/javaslang/src/main/java/javaslang/collection/Multimap.java
+++ b/javaslang/src/main/java/javaslang/collection/Multimap.java
@@ -455,7 +455,7 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
 
     default <U> Seq<U> traverse(BiFunction<K, V, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return foldLeft(List.empty(), (acc, entry) -> acc.append(mapper.apply(entry._1, entry._2)));
+        return foldLeft(Vector.empty(), (acc, entry) -> acc.append(mapper.apply(entry._1, entry._2)));
     }
 
     default <T1, T2> Tuple2<Seq<T1>, Seq<T2>> unzip(BiFunction<? super K, ? super V, Tuple2<? extends T1, ? extends T2>> unzipper) {


### PR DESCRIPTION
fixes #1633 
was it really that easy or did I overlook something?!

The measurement looks a lot better now:
```
Created list with 100 entries in 111 ms
	116	1.16	0.012
Traverse after 129 ms
	129	1.29	0.013
Sum is 333300 after 131 ms
	131	1.31	0.013
Created list with 400 entries in 2 ms
	2	0.005	0
Traverse after 5 ms
	5	0.013	0
Sum is 21333200 after 6 ms
	6	0.015	0
Created list with 1600 entries in 3 ms
	3	0.002	0
Traverse after 10 ms
	10	0.006	0
Sum is 1365332800 after 12 ms
	12	0.007	0
Created list with 6400 entries in 9 ms
	9	0.001	0
Traverse after 19 ms
	19	0.003	0
Sum is 87381331200 after 21 ms
	21	0.003	0
Created list with 25600 entries in 25 ms
	25	0.001	0
Traverse after 47 ms
	47	0.002	0
Sum is 5592405324800 after 52 ms
	53	0.002	0
Created list with 102400 entries in 90 ms
	90	0.001	0
Traverse after 131 ms
	131	0.001	0
Sum is 22073268555776 after 137 ms
	137	0.001	0
Created list with 409600 entries in 314 ms
	314	0.001	0
Traverse after 516 ms
	516	0.001	0
Sum is 16266472669184 after 576 ms
	576	0.001	0
```