### PR TITLE
noticed that the ifPresent test sections duplicates the forEach tests

### DIFF
--- a/javaslang/src/test/java/javaslang/control/OptionTest.java
+++ b/javaslang/src/test/java/javaslang/control/OptionTest.java
@@ -244,22 +244,6 @@ public class OptionTest extends AbstractValueTest {
         assertThat(Option.of(1).isEmpty()).isFalse();
     }
 
-    // -- ifPresent
-
-    @Test
-    public void shouldConsumePresentValueOnWhenValueIsDefined() {
-        final int[] actual = new int[] { -1 };
-        Option.of(1).forEach(i -> actual[0] = i);
-        assertThat(actual[0]).isEqualTo(1);
-    }
-
-    @Test
-    public void shouldNotConsumeAnythingOnIsDefinedWhenValueIsNotDefined() {
-        final int[] actual = new int[] { -1 };
-        Option.<Integer> none().forEach(i -> actual[0] = i);
-        assertThat(actual[0]).isEqualTo(-1);
-    }
-
     // -- filter
 
     @Test


### PR DESCRIPTION
it seems javaslang used to have a `ifPresent` method on `Option` and it was removed or renamed to `forEach`.

Now the test section for `ifPresent` duplicates exactly the one for `forEach` which is a little lower in the same file:
https://github.com/javaslang/javaslang/blob/master/javaslang/src/test/java/javaslang/control/OptionTest.java#L350-L364

so this PR removes the now duplicate tests.