### PR TITLE
add more Map.replace methods

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/AbstractMultimap.java
+++ b/javaslang/src/main/java/javaslang/collection/AbstractMultimap.java
@@ -323,7 +323,7 @@ abstract class AbstractMultimap<K, V, M extends Multimap<K, V>> implements Multi
         } else if (that.isEmpty()) {
             return (M) this;
         } else {
-            return that.foldLeft((M) this, (map, entry) -> !map.contains((Tuple2<K, V>) entry) ? (M) map.put(entry) : map);
+            return that.foldLeft((M) this, (map, entry) -> (M) map.put(entry));
         }
     }
 

--- a/javaslang/src/main/java/javaslang/collection/AbstractMultimap.java
+++ b/javaslang/src/main/java/javaslang/collection/AbstractMultimap.java
@@ -15,6 +15,8 @@ import java.util.Comparator;
 import java.util.Objects;
 import java.util.function.*;
 
+import static javaslang.API.Tuple;
+
 /**
  * An {@link Multimap} implementation (not intended to be public).
  *
@@ -375,6 +377,24 @@ abstract class AbstractMultimap<K, V, M extends Multimap<K, V>> implements Multi
     @Override
     public M replaceAll(Tuple2<K, V> currentElement, Tuple2<K, V> newElement) {
         return replace(currentElement, newElement);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public M replaceValue(K key, V value) {
+        return (M) (containsKey(key) ? remove(key).put(key, value) : this);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public M replace(K key, V oldValue, V newValue) {
+        return (M) (contains(Tuple(key, oldValue)) ? remove(key, oldValue).put(key, newValue) : this);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public M replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
+        return (M) map((k, v) -> Tuple(k, function.apply(k, v)));
     }
 
     @SuppressWarnings("unchecked")

--- a/javaslang/src/main/java/javaslang/collection/AbstractMultimap.java
+++ b/javaslang/src/main/java/javaslang/collection/AbstractMultimap.java
@@ -28,9 +28,6 @@ import static javaslang.API.Tuple;
  */
 abstract class AbstractMultimap<K, V, M extends Multimap<K, V>> implements Multimap<K, V> {
 
-    interface SerializableSupplier<T> extends Supplier<T>, Serializable {
-    }
-
     private static final long serialVersionUID = 1L;
 
     protected final Map<K, Traversable<V>> back;
@@ -508,5 +505,8 @@ abstract class AbstractMultimap<K, V, M extends Multimap<K, V>> implements Multi
             javaMap.computeIfAbsent(t._1, k -> javaContainerSupplier.get()).add(t._2);
         }
         return javaMap;
+    }
+
+    interface SerializableSupplier<T> extends Supplier<T>, Serializable {
     }
 }

--- a/javaslang/src/main/java/javaslang/collection/HashMap.java
+++ b/javaslang/src/main/java/javaslang/collection/HashMap.java
@@ -569,6 +569,21 @@ public final class HashMap<K, V> implements Kind2<HashMap<?, ?>, K, V>, Map<K, V
     }
 
     @Override
+    public HashMap<K, V> replaceValue(K key, V value) {
+        return Maps.replaceValue(this, key, value);
+    }
+
+    @Override
+    public HashMap<K, V> replace(K key, V oldValue, V newValue) {
+        return Maps.replace(this, key, oldValue, newValue);
+    }
+
+    @Override
+    public HashMap<K, V> replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
+        return Maps.replaceAll(this, function);
+    }
+
+    @Override
     public HashMap<K, V> retainAll(Iterable<? extends Tuple2<K, V>> elements) {
         Objects.requireNonNull(elements, "elements is null");
         HashArrayMappedTrie<K, V> tree = HashArrayMappedTrie.empty();

--- a/javaslang/src/main/java/javaslang/collection/LinkedHashMap.java
+++ b/javaslang/src/main/java/javaslang/collection/LinkedHashMap.java
@@ -622,6 +622,21 @@ public final class LinkedHashMap<K, V> implements Kind2<LinkedHashMap<?, ?>, K, 
     }
 
     @Override
+    public LinkedHashMap<K, V> replaceValue(K key, V value) {
+        return Maps.replaceValue(this, key, value);
+    }
+
+    @Override
+    public LinkedHashMap<K, V> replace(K key, V oldValue, V newValue) {
+        return Maps.replace(this, key, oldValue, newValue);
+    }
+
+    @Override
+    public LinkedHashMap<K, V> replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
+        return Maps.replaceAll(this, function);
+    }
+
+    @Override
     public LinkedHashMap<K, V> retainAll(Iterable<? extends Tuple2<K, V>> elements) {
         Objects.requireNonNull(elements, "elements is null");
         LinkedHashMap<K, V> result = empty();

--- a/javaslang/src/main/java/javaslang/collection/Map.java
+++ b/javaslang/src/main/java/javaslang/collection/Map.java
@@ -674,6 +674,33 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
     @Override
     Map<K, V> replace(Tuple2<K, V> currentElement, Tuple2<K, V> newElement);
 
+    /**
+     * Replaces the entry for the specified key only if it is currently mapped to some value.
+     *
+     * @param key the key of the element to be substituted.
+     * @param value the new value to be associated with the key
+     * @return a new map containing key mapped to value if key was contained before. The old map otherwise.
+     */
+    Map<K, V> replaceValue(K key, V value);
+
+    /**
+     * Replaces the entry for the specified key only if currently mapped to the specified value.
+     *
+     * @param key the key of the element to be substituted.
+     * @param oldValue the expected current value that the key is currently mapped to
+     * @param newValue the new value to be associated with the key
+     * @return a new map containing key mapped to newValue if key was contained before and oldValue matched. The old map otherwise.
+     */
+    Map<K, V> replace(K key, V oldValue, V newValue);
+
+    /**
+     * Replaces each entry's value with the result of invoking the given function on that entry until all entries have been processed or the function throws an exception.
+     *
+     * @param function function transforming key and current value to a new value
+     * @return a new map with the same keySet but transformed values.
+     */
+    Map<K, V> replaceAll(BiFunction<? super K, ? super V, ? extends V> function);
+
     @Override
     Map<K, V> replaceAll(Tuple2<K, V> currentElement, Tuple2<K, V> newElement);
 

--- a/javaslang/src/main/java/javaslang/collection/Maps.java
+++ b/javaslang/src/main/java/javaslang/collection/Maps.java
@@ -13,6 +13,8 @@ import java.util.Comparator;
 import java.util.Objects;
 import java.util.function.*;
 
+import static javaslang.API.Tuple;
+
 /**
  * Implementations of common {@code Map} functions (not intended to be public).
  *
@@ -236,6 +238,20 @@ final class Maps {
 
     static <K, V, M extends Map<K, V>> M replaceAll(M map, Tuple2<K, V> currentElement, Tuple2<K, V> newElement) {
         return replace(map, currentElement, newElement);
+    }
+
+    static <K, V, M extends Map<K, V>> M replaceValue(M map, K key, V value) {
+        return map.containsKey(key) ? put(map, Tuple(key, value)) :  map;
+    }
+
+
+    static <K, V, M extends Map<K, V>> M replace(M map, K key, V oldValue, V newValue) {
+        return map.contains(Tuple(key, oldValue)) ? put(map, Tuple(key, newValue)) : map;
+    }
+
+    @SuppressWarnings("unchecked")
+    static <K, V, M extends Map<K, V>> M replaceAll(M map, BiFunction<? super K, ? super V, ? extends V> function) {
+        return (M) map.map((k, v) -> Tuple(k, function.apply(k, v)));
     }
 
     static <K, V, M extends Map<K, V>> M scan(

--- a/javaslang/src/main/java/javaslang/collection/Maps.java
+++ b/javaslang/src/main/java/javaslang/collection/Maps.java
@@ -240,13 +240,14 @@ final class Maps {
         return replace(map, currentElement, newElement);
     }
 
+    @SuppressWarnings("unchecked")
     static <K, V, M extends Map<K, V>> M replaceValue(M map, K key, V value) {
-        return map.containsKey(key) ? put(map, Tuple(key, value)) :  map;
+        return map.containsKey(key) ? (M) map.put(key, value) :  map;
     }
 
-
+    @SuppressWarnings("unchecked")
     static <K, V, M extends Map<K, V>> M replace(M map, K key, V oldValue, V newValue) {
-        return map.contains(Tuple(key, oldValue)) ? put(map, Tuple(key, newValue)) : map;
+        return map.contains(Tuple(key, oldValue)) ? (M) map.put(key, newValue) : map;
     }
 
     @SuppressWarnings("unchecked")

--- a/javaslang/src/main/java/javaslang/collection/Multimap.java
+++ b/javaslang/src/main/java/javaslang/collection/Multimap.java
@@ -147,7 +147,7 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
 
     @Override
     default boolean contains(Tuple2<K, V> element) {
-        return get(element._1).map(v -> Objects.equals(v, element._2)).getOrElse(false);
+        return get(element._1).map(v -> v.contains(element._2)).getOrElse(false);
     }
 
     /**

--- a/javaslang/src/main/java/javaslang/collection/Multimap.java
+++ b/javaslang/src/main/java/javaslang/collection/Multimap.java
@@ -585,6 +585,33 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, 
     @Override
     Multimap<K, V> replaceAll(Tuple2<K, V> currentElement, Tuple2<K, V> newElement);
 
+    /**
+     * Replaces the entry for the specified key only if it is currently mapped to some value.
+     *
+     * @param key the key of the element to be substituted
+     * @param value the new value to be associated with the key
+     * @return a new map containing key mapped to value if key was contained before. The old map otherwise
+     */
+    Multimap<K, V> replaceValue(K key, V value);
+
+    /**
+     * Replaces the entry with the specified key and oldValue.
+     *
+     * @param key the key of the element to be substituted
+     * @param oldValue the expected current value associated with the key
+     * @param newValue the new value to be associated with the key
+     * @return a new map containing key mapped to newValue if key was contained before and oldValue was associated with the key. The old map otherwise.
+     */
+    Multimap<K, V> replace(K key, V oldValue, V newValue);
+
+    /**
+     * Replaces each entry's values with the result of invoking the given function on that each tuple until all entries have been processed or the function throws an exception.
+     *
+     * @param function function transforming key and current value to a new value
+     * @return a new map with the same keySet but transformed values
+     */
+    Multimap<K, V> replaceAll(BiFunction<? super K, ? super V, ? extends V> function);
+
     @Override
     Multimap<K, V> retainAll(Iterable<? extends Tuple2<K, V>> elements);
 

--- a/javaslang/src/main/java/javaslang/collection/Traversable.java
+++ b/javaslang/src/main/java/javaslang/collection/Traversable.java
@@ -945,7 +945,7 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      *
      * @param currentElement An element to be substituted.
      * @param newElement     A replacement for currentElement.
-     * @return a Traversable containing all elements of this where the first occurrence of currentElement is replaced with newELement.
+     * @return a Traversable containing all elements of this where the first occurrence of currentElement is replaced with newElement.
      */
     Traversable<T> replace(T currentElement, T newElement);
 
@@ -954,7 +954,7 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      *
      * @param currentElement An element to be substituted.
      * @param newElement     A replacement for currentElement.
-     * @return a Traversable containing all elements of this where all occurrences of currentElement are replaced with newELement.
+     * @return a Traversable containing all elements of this where all occurrences of currentElement are replaced with newElement.
      */
     Traversable<T> replaceAll(T currentElement, T newElement);
 

--- a/javaslang/src/main/java/javaslang/collection/TreeMap.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeMap.java
@@ -863,6 +863,21 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
     }
 
     @Override
+    public TreeMap<K, V> replaceValue(K key, V value) {
+        return Maps.replaceValue(this, key, value);
+    }
+
+    @Override
+    public TreeMap<K, V> replace(K key, V oldValue, V newValue) {
+        return Maps.replace(this, key, oldValue, newValue);
+    }
+
+    @Override
+    public TreeMap<K, V> replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
+        return Maps.replaceAll(this, function);
+    }
+
+    @Override
     public TreeMap<K, V> retainAll(Iterable<? extends Tuple2<K, V>> elements) {
         Objects.requireNonNull(elements, "elements is null");
         RedBlackTree<Tuple2<K, V>> tree = RedBlackTree.empty(entries.comparator());

--- a/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
@@ -1011,6 +1011,51 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
         assertThat(map.get("3")).isEqualTo(Option.none());
     }
 
+    @Test
+    public void shouldReturnSameInstanceIfReplacingCurrentValueWithNonExistingKey() {
+        final Map<Integer, String> map = mapOf(1, "a", 2, "b");
+        final Map<Integer, String> actual = map.replaceValue(3, "?");
+        assertThat(actual).isSameAs(map);
+    }
+
+    @Test
+    public void shouldReplaceCurrentValueForExistingKey() {
+        final Map<Integer, String> map = mapOf(1, "a", 2, "b");
+        final Map<Integer, String> actual = map.replaceValue(2, "c");
+        final Map<Integer, String> expected = mapOf(1, "a", 2, "c");
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldReplaceCurrentValueForExistingKeyAndEqualOldValue() {
+        final Map<Integer, String> map = mapOf(1, "a", 2, "b");
+        final Map<Integer, String> actual = map.replace(2, "b", "c");
+        final Map<Integer, String> expected = mapOf(1, "a", 2, "c");
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldReturnSameInstanceForExistingKeyAndNonEqualOldValue() {
+        final Map<Integer, String> map = mapOf(1, "a", 2, "b");
+        final Map<Integer, String> actual = map.replace(2, "d", "c");
+        assertThat(actual).isSameAs(map);
+    }
+
+    @Test
+    public void shouldReturnSameInstanceIfReplacingCurrentValueWithOldValueWithNonExistingKey() {
+        final Map<Integer, String> map = mapOf(1, "a", 2, "b");
+        final Map<Integer, String> actual = map.replace(3, "?", "!");
+        assertThat(actual).isSameAs(map);
+    }
+
+    @Test
+    public void shouldReplaceAllValuesWithFunctionResult() {
+        final Map<Integer, String> map = mapOf(1, "a", 2, "b");
+        final Map<Integer, String> actual = map.replaceAll((integer, s) -> s + integer);
+        final Map<Integer, String> expected = mapOf(1, "a1", 2, "b2");
+        assertThat(actual).isEqualTo(expected);
+    }
+
     // -- getOrElse
 
     public void shouldReturnDefaultValue() {

--- a/javaslang/src/test/java/javaslang/collection/AbstractMultimapTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractMultimapTest.java
@@ -354,13 +354,13 @@ public abstract class AbstractMultimapTest extends AbstractTraversableTest {
 
     @Test
     public void shouldRecognizeNotContainedKeyValuePair() {
-        final TreeMap<String, Integer> testee = TreeMap.of(Tuple.of("one", 1));
+        final Multimap<String, Integer> testee = mapOf("one", 1);
         assertThat(testee.contains(Tuple.of("one", 0))).isFalse();
     }
 
     @Test
     public void shouldRecognizeContainedKeyValuePair() {
-        final TreeMap<String, Integer> testee = TreeMap.of(Tuple.of("one", 1));
+        final Multimap<String, Integer> testee = mapOf("one", 1);
         assertThat(testee.contains(Tuple.of("one", 1))).isTrue();
     }
 

--- a/javaslang/src/test/java/javaslang/collection/AbstractMultimapTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractMultimapTest.java
@@ -509,6 +509,73 @@ public abstract class AbstractMultimapTest extends AbstractTraversableTest {
         assertThat(src.removeAll(List.empty())).isSameAs(src);
     }
 
+    // -- replaceValue
+
+    @Test
+    public void shouldReturnSameInstanceIfReplacingCurrentValueWithNonExistingKey() {
+        final Multimap<Integer, String> map = mapOf(1, "a").put(2, "b");
+        final Multimap<Integer, String> actual = map.replaceValue(3, "?");
+        assertThat(actual).isSameAs(map);
+    }
+
+    @Test
+    public void shouldReplaceCurrentValueForExistingKey() {
+        final Multimap<Integer, String> map = mapOf(1, "a").put(2, "b");
+        final Multimap<Integer, String> actual = map.replaceValue(2, "c");
+        final Multimap<Integer, String> expected = mapOf(1, "a").put(2, "c");
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldReplaceValuesWithNewValueForExistingKey() {
+        final Multimap<Integer, String> map = mapOf(1, "a").put(2, "b").put(2, "c");
+        final Multimap<Integer, String> actual = map.replaceValue(2, "c");
+        final Multimap<Integer, String> expected = mapOf(1, "a").put(2, "c");
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    // - replace
+
+    @Test
+    public void shouldReplaceCurrentValueForExistingKeyAndEqualOldValue() {
+        final Multimap<Integer, String> map = mapOf(1, "a").put(2, "b");
+        final Multimap<Integer, String> actual = map.replace(2, "b", "c");
+        final Multimap<Integer, String> expected = mapOf(1, "a").put(2, "c");
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldReplaceCurrentValueForKeyWithMultipleValuesAndEqualOldValue() {
+        final Multimap<Integer, String> map = mapOf(1, "a").put(2, "b").put(2, "d");
+        final Multimap<Integer, String> actual = map.replace(2, "b", "c");
+        final Multimap<Integer, String> expected = mapOf(1, "a").put(2, "c").put(2, "d");
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldReturnSameInstanceForExistingKeyAndNonEqualOldValue() {
+        final Multimap<Integer, String> map = mapOf(1, "a").put(2, "b");
+        final Multimap<Integer, String> actual = map.replace(2, "d", "c");
+        assertThat(actual).isSameAs(map);
+    }
+
+    @Test
+    public void shouldReturnSameInstanceIfReplacingCurrentValueWithOldValueWithNonExistingKey() {
+        final Multimap<Integer, String> map = mapOf(1, "a").put(2, "b");
+        final Multimap<Integer, String> actual = map.replace(3, "?", "!");
+        assertThat(actual).isSameAs(map);
+    }
+
+    // - replaceAll
+
+    @Test
+    public void shouldReplaceAllValuesWithFunctionResult() {
+        final Multimap<Integer, String> map = mapOf(1, "a").put(2, "b").put(2, "c");
+        final Multimap<Integer, String> actual = map.replaceAll((integer, s) -> s + integer);
+        final Multimap<Integer, String> expected = mapOf(1, "a1").put(2, "b2").put(2, "c2");
+        assertThat(actual).isEqualTo(expected);
+    }
+
     // -- transform
 
     @Test


### PR DESCRIPTION
Addresses #1600 

This PR is work in progress and currently contains just the Map part. I just wanted to make sure that I am on the right path. 

`Map<K, V> replace(K key, V value)` had to be named `replaceCurrentValue` to not collide with `Map<K, V> replace(Tuple2<K, V> currentElement, Tuple2<K, V> newElement)`

@danieldietrich Is this the way to go? Or do you have any suggestions before I apply a similar solution to the MultiMap part.