### PR TITLE
fixes #1680 rename leftMap to mapError & deprecate leftMap

### DIFF
--- a/javaslang/src/main/java/javaslang/Value.java
+++ b/javaslang/src/main/java/javaslang/Value.java
@@ -907,7 +907,7 @@ public interface Value<T> extends Iterable<T> {
      */
     default <L> Validation<L, T> toValidation(L invalid) {
         if (this instanceof Validation) {
-            return ((Validation<?, T>) this).leftMap(ignored -> invalid);
+            return ((Validation<?, T>) this).mapError(ignored -> invalid);
         } else {
             return isEmpty() ? Invalid(invalid) : Valid(get());
         }
@@ -922,7 +922,7 @@ public interface Value<T> extends Iterable<T> {
     default <L> Validation<L, T> toValidation(Supplier<? extends L> invalidSupplier) {
         Objects.requireNonNull(invalidSupplier, "invalidSupplier is null");
         if (this instanceof Validation) {
-            return ((Validation<?, T>) this).leftMap(ignored -> invalidSupplier.get());
+            return ((Validation<?, T>) this).mapError(ignored -> invalidSupplier.get());
         } else {
             return isEmpty() ? Invalid(invalidSupplier.get()) : Valid(get());
         }

--- a/javaslang/src/main/java/javaslang/control/Validation.java
+++ b/javaslang/src/main/java/javaslang/control/Validation.java
@@ -493,11 +493,11 @@ public interface Validation<E, T> extends Value<T> {
     }
 
     /**
-     * Whereas map only performs a mapping on a valid Validation, and leftMap performs a mapping on an invalid
+     * Whereas map only performs a mapping on a valid Validation, and mapError performs a mapping on an invalid
      * Validation, bimap allows you to provide mapping actions for both, and will give you the result based
      * on what type of Validation this is. Without this, you would have to do something like:
      *
-     * validation.map(...).leftMap(...);
+     * validation.map(...).mapError(...);
      *
      * @param <E2>        type of the mapping result if this is an invalid
      * @param <T2>        type of the mapping result if this is a valid
@@ -522,12 +522,27 @@ public interface Validation<E, T> extends Value<T> {
      * Applies a function f to the error of this Validation if this is an Invalid. Otherwise does nothing
      * if this is a Valid.
      *
+     * @deprecated  replaced by {@link #mapError()}
      * @param <U> type of the error resulting from the mapping
      * @param f   a function that maps the error in this Invalid
      * @return an instance of Validation&lt;U,T&gt;
      * @throws NullPointerException if mapping operation f is null
      */
+    @Deprecated
     default <U> Validation<U, T> leftMap(Function<? super E, ? extends U> f) {
+        return mapError(f);
+    }
+
+    /**
+     * Applies a function f to the error of this Validation if this is an Invalid. Otherwise does nothing
+     * if this is a Valid.
+     *
+     * @param <U> type of the error resulting from the mapping
+     * @param f   a function that maps the error in this Invalid
+     * @return an instance of Validation&lt;U,T&gt;
+     * @throws NullPointerException if mapping operation f is null
+     */
+    default <U> Validation<U, T> mapError(Function<? super E, ? extends U> f) {
         Objects.requireNonNull(f, "f is null");
         if (isInvalid()) {
             E error = this.getError();

--- a/javaslang/src/test/java/javaslang/control/ValidationTest.java
+++ b/javaslang/src/test/java/javaslang/control/ValidationTest.java
@@ -272,16 +272,30 @@ public class ValidationTest extends AbstractValueTest {
         assertThat(invalidMapping.getError()).isEqualTo(3);
     }
 
-    // -- leftMap
+    // -- leftMap (deprecated)
 
     @Test
-    public void shouldNotMapSuccess() {
+    @SuppressWarnings("deprecation")
+    public void shouldNotLeftMapSuccess() {
         assertThat(valid().leftMap(x -> 2).get()).isEqualTo(OK);
     }
 
     @Test
-    public void shouldMapFailure() {
+    @SuppressWarnings("deprecation")
+    public void shouldLeftMapFailure() {
         assertThat(invalid().leftMap(x -> 5).getError()).isEqualTo(5);
+    }
+
+    // -- mapError
+
+    @Test
+    public void shouldNotMapSuccess() {
+        assertThat(valid().mapError(x -> 2).get()).isEqualTo(OK);
+    }
+
+    @Test
+    public void shouldMapFailure() {
+        assertThat(invalid().mapError(x -> 5).getError()).isEqualTo(5);
     }
 
     // -- forEach


### PR DESCRIPTION
i can also make a second commit to remove leftMap meant for 3.0+ and that you would not cherry-pick in 2.x, let me know if you'd like that.