### PR TITLE
fix a bunch of javadoc warnings and errors

### DIFF
--- a/javaslang/generator/Generator.scala
+++ b/javaslang/generator/Generator.scala
@@ -430,7 +430,7 @@ def generateMainClasses(): Unit = {
           }
 
           /$javadoc
-           * Alias for {@link $FutureType#of($CheckedSupplierType)}
+           * Alias for {@link $FutureType#of($TryType.$CheckedSupplierType)}
            *
            * @param <T>         Type of the computation result.
            * @param computation A computation.
@@ -442,7 +442,7 @@ def generateMainClasses(): Unit = {
           }
 
           /$javadoc
-           * Alias for {@link $FutureType#of($ExecutorServiceType, $CheckedSupplierType)}
+           * Alias for {@link $FutureType#of($ExecutorServiceType, $TryType.$CheckedSupplierType)}
            *
            * @param <T>             Type of the computation result.
            * @param executorService An executor service.

--- a/javaslang/src-gen/main/java/javaslang/API.java
+++ b/javaslang/src-gen/main/java/javaslang/API.java
@@ -781,7 +781,7 @@ public final class API {
     }
 
     /**
-     * Alias for {@link Future#of(CheckedSupplier)}
+     * Alias for {@link Future#of(Try.CheckedSupplier)}
      *
      * @param <T>         Type of the computation result.
      * @param computation A computation.
@@ -793,7 +793,7 @@ public final class API {
     }
 
     /**
-     * Alias for {@link Future#of(ExecutorService, CheckedSupplier)}
+     * Alias for {@link Future#of(ExecutorService, Try.CheckedSupplier)}
      *
      * @param <T>             Type of the computation result.
      * @param executorService An executor service.

--- a/javaslang/src/main/java/javaslang/Value.java
+++ b/javaslang/src/main/java/javaslang/Value.java
@@ -874,6 +874,7 @@ public interface Value<T> extends Iterable<T> {
      * Converts this to an {@link Either}.
      *
      * @param left A left value for the {@link Either}
+     * @param <L> Either left component type
      * @return A new {@link Either}.
      */
     default <L> Either<L, T> toEither(L left) {
@@ -888,6 +889,7 @@ public interface Value<T> extends Iterable<T> {
      * Converts this to an {@link Either}.
      *
      * @param leftSupplier A {@link Supplier} for the left value for the {@link Either}
+     * @param <L> Validation error component type
      * @return A new {@link Either}.
      */
     default <L> Either<L, T> toEither(Supplier<? extends L> leftSupplier) {
@@ -903,6 +905,7 @@ public interface Value<T> extends Iterable<T> {
      * Converts this to an {@link Validation}.
      *
      * @param invalid An invalid value for the {@link Validation}
+     * @param <L> Validation error component type
      * @return A new {@link Validation}.
      */
     default <L> Validation<L, T> toValidation(L invalid) {
@@ -917,6 +920,7 @@ public interface Value<T> extends Iterable<T> {
      * Converts this to an {@link Validation}.
      *
      * @param invalidSupplier A {@link Supplier} for the invalid value for the {@link Validation}
+     * @param <L> Validation error component type
      * @return A new {@link Validation}.
      */
     default <L> Validation<L, T> toValidation(Supplier<? extends L> invalidSupplier) {

--- a/javaslang/src/main/java/javaslang/collection/Foldable.java
+++ b/javaslang/src/main/java/javaslang/collection/Foldable.java
@@ -51,10 +51,10 @@ public interface Foldable<T> {
      *
      * Example:
      *
-     * <pre><code>
+     * <pre> {@code
      * // = 6
      * Set(1, 2, 3).fold(0, (a, b) -> a + b);
-     * </code></pre>
+     * } </pre>
      *
      * @param zero    A zero element to start with.
      * @param combine A function which combines elements.
@@ -71,10 +71,10 @@ public interface Foldable<T> {
      * <p>
      * Example:
      *
-     * <pre><code>
+     * <pre> {@code
      * // = "cba!"
      * List("a", "b", "c").foldLeft("!", (xs, x) -> x + xs)
-     * </code></pre>
+     * } </pre>
      *
      * @param <U>     the type to fold over
      * @param zero    A zero element to start with.
@@ -89,10 +89,10 @@ public interface Foldable<T> {
      * <p>
      * Example:
      *
-     * <pre><code>
+     * <pre> {@code
      * // = "!cba"
      * List("a", "b", "c").foldRight("!", (x, xs) -> xs + x)
-     * </code></pre>
+     * } </pre>
      *
      * @param <U>     the type of the folded value
      * @param zero    A zero element to start with.

--- a/javaslang/src/main/java/javaslang/collection/HashMap.java
+++ b/javaslang/src/main/java/javaslang/collection/HashMap.java
@@ -121,6 +121,10 @@ public final class HashMap<K, V> implements Kind2<HashMap<?, ?>, K, V>, Map<K, V
     /**
      * Creates a HashMap of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -132,6 +136,12 @@ public final class HashMap<K, V> implements Kind2<HashMap<?, ?>, K, V>, Map<K, V
     /**
      * Creates a HashMap of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -145,6 +155,14 @@ public final class HashMap<K, V> implements Kind2<HashMap<?, ?>, K, V>, Map<K, V
      *
      * @param <K> The key type
      * @param <V> The value type
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
      * @return A new Map containing the given entries
      */
     public static <K, V> HashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
@@ -154,6 +172,16 @@ public final class HashMap<K, V> implements Kind2<HashMap<?, ?>, K, V>, Map<K, V
     /**
      * Creates a HashMap of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -165,6 +193,18 @@ public final class HashMap<K, V> implements Kind2<HashMap<?, ?>, K, V>, Map<K, V
     /**
      * Creates a HashMap of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -176,6 +216,20 @@ public final class HashMap<K, V> implements Kind2<HashMap<?, ?>, K, V>, Map<K, V
     /**
      * Creates a HashMap of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
+     * @param k7 a key for the map
+     * @param v7 the value for k7
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -187,6 +241,22 @@ public final class HashMap<K, V> implements Kind2<HashMap<?, ?>, K, V>, Map<K, V
     /**
      * Creates a HashMap of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
+     * @param k7 a key for the map
+     * @param v7 the value for k7
+     * @param k8 a key for the map
+     * @param v8 the value for k8
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -198,6 +268,24 @@ public final class HashMap<K, V> implements Kind2<HashMap<?, ?>, K, V>, Map<K, V
     /**
      * Creates a HashMap of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
+     * @param k7 a key for the map
+     * @param v7 the value for k7
+     * @param k8 a key for the map
+     * @param v8 the value for k8
+     * @param k9 a key for the map
+     * @param v9 the value for k9
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -209,6 +297,26 @@ public final class HashMap<K, V> implements Kind2<HashMap<?, ?>, K, V>, Map<K, V
     /**
      * Creates a HashMap of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
+     * @param k7 a key for the map
+     * @param v7 the value for k7
+     * @param k8 a key for the map
+     * @param v8 the value for k8
+     * @param k9 a key for the map
+     * @param v9 the value for k9
+     * @param k10 a key for the map
+     * @param v10 the value for k10
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries

--- a/javaslang/src/main/java/javaslang/collection/HashMultimap.java
+++ b/javaslang/src/main/java/javaslang/collection/HashMultimap.java
@@ -103,6 +103,8 @@ public final class HashMultimap<K, V> extends AbstractMultimap<K, V, HashMultima
         /**
          * Creates a HashMultimap of the given key-value pair.
          *
+         * @param key a key for the map
+         * @param value the value for key
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -115,6 +117,10 @@ public final class HashMultimap<K, V> extends AbstractMultimap<K, V, HashMultima
         /**
          * Creates a HashMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -126,6 +132,12 @@ public final class HashMultimap<K, V> extends AbstractMultimap<K, V, HashMultima
         /**
          * Creates a HashMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -137,6 +149,14 @@ public final class HashMultimap<K, V> extends AbstractMultimap<K, V, HashMultima
         /**
          * Creates a HashMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -148,6 +168,16 @@ public final class HashMultimap<K, V> extends AbstractMultimap<K, V, HashMultima
         /**
          * Creates a HashMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -159,6 +189,18 @@ public final class HashMultimap<K, V> extends AbstractMultimap<K, V, HashMultima
         /**
          * Creates a HashMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -170,6 +212,20 @@ public final class HashMultimap<K, V> extends AbstractMultimap<K, V, HashMultima
         /**
          * Creates a HashMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
+         * @param k7 a key for the map
+         * @param v7 the value for k7
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -181,6 +237,22 @@ public final class HashMultimap<K, V> extends AbstractMultimap<K, V, HashMultima
         /**
          * Creates a HashMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
+         * @param k7 a key for the map
+         * @param v7 the value for k7
+         * @param k8 a key for the map
+         * @param v8 the value for k8
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -192,6 +264,24 @@ public final class HashMultimap<K, V> extends AbstractMultimap<K, V, HashMultima
         /**
          * Creates a HashMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
+         * @param k7 a key for the map
+         * @param v7 the value for k7
+         * @param k8 a key for the map
+         * @param v8 the value for k8
+         * @param k9 a key for the map
+         * @param v9 the value for k9
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -203,6 +293,26 @@ public final class HashMultimap<K, V> extends AbstractMultimap<K, V, HashMultima
         /**
          * Creates a HashMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
+         * @param k7 a key for the map
+         * @param v7 the value for k7
+         * @param k8 a key for the map
+         * @param v8 the value for k8
+         * @param k9 a key for the map
+         * @param v9 the value for k9
+         * @param k10 a key for the map
+         * @param v10 the value for k10
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries

--- a/javaslang/src/main/java/javaslang/collection/LinkedHashMap.java
+++ b/javaslang/src/main/java/javaslang/collection/LinkedHashMap.java
@@ -126,6 +126,10 @@ public final class LinkedHashMap<K, V> implements Kind2<LinkedHashMap<?, ?>, K, 
     /**
      * Creates a LinkedHashMap of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -139,6 +143,12 @@ public final class LinkedHashMap<K, V> implements Kind2<LinkedHashMap<?, ?>, K, 
     /**
      * Creates a LinkedHashMap of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -152,6 +162,14 @@ public final class LinkedHashMap<K, V> implements Kind2<LinkedHashMap<?, ?>, K, 
     /**
      * Creates a LinkedHashMap of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -165,6 +183,16 @@ public final class LinkedHashMap<K, V> implements Kind2<LinkedHashMap<?, ?>, K, 
     /**
      * Creates a LinkedHashMap of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -178,6 +206,18 @@ public final class LinkedHashMap<K, V> implements Kind2<LinkedHashMap<?, ?>, K, 
     /**
      * Creates a LinkedHashMap of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -191,6 +231,20 @@ public final class LinkedHashMap<K, V> implements Kind2<LinkedHashMap<?, ?>, K, 
     /**
      * Creates a LinkedHashMap of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
+     * @param k7 a key for the map
+     * @param v7 the value for k7
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -204,6 +258,22 @@ public final class LinkedHashMap<K, V> implements Kind2<LinkedHashMap<?, ?>, K, 
     /**
      * Creates a LinkedHashMap of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
+     * @param k7 a key for the map
+     * @param v7 the value for k7
+     * @param k8 a key for the map
+     * @param v8 the value for k8
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -217,6 +287,24 @@ public final class LinkedHashMap<K, V> implements Kind2<LinkedHashMap<?, ?>, K, 
     /**
      * Creates a LinkedHashMap of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
+     * @param k7 a key for the map
+     * @param v7 the value for k7
+     * @param k8 a key for the map
+     * @param v8 the value for k8
+     * @param k9 a key for the map
+     * @param v9 the value for k9
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -230,6 +318,26 @@ public final class LinkedHashMap<K, V> implements Kind2<LinkedHashMap<?, ?>, K, 
     /**
      * Creates a LinkedHashMap of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
+     * @param k7 a key for the map
+     * @param v7 the value for k7
+     * @param k8 a key for the map
+     * @param v8 the value for k8
+     * @param k9 a key for the map
+     * @param v9 the value for k9
+     * @param k10 a key for the map
+     * @param v10 the value for k10
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries

--- a/javaslang/src/main/java/javaslang/collection/LinkedHashMultimap.java
+++ b/javaslang/src/main/java/javaslang/collection/LinkedHashMultimap.java
@@ -103,6 +103,8 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
         /**
          * Creates a LinkedHashMultimap of the given key-value pair.
          *
+         * @param key   A singleton map key.
+         * @param value A singleton map value.
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -115,6 +117,10 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
         /**
          * Creates a LinkedHashMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -126,6 +132,12 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
         /**
          * Creates a LinkedHashMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -137,6 +149,14 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
         /**
          * Creates a LinkedHashMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -148,6 +168,16 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
         /**
          * Creates a LinkedHashMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -159,6 +189,18 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
         /**
          * Creates a LinkedHashMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -170,6 +212,20 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
         /**
          * Creates a LinkedHashMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
+         * @param k7 a key for the map
+         * @param v7 the value for k7
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -181,6 +237,22 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
         /**
          * Creates a LinkedHashMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
+         * @param k7 a key for the map
+         * @param v7 the value for k7
+         * @param k8 a key for the map
+         * @param v8 the value for k8
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -192,6 +264,24 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
         /**
          * Creates a LinkedHashMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
+         * @param k7 a key for the map
+         * @param v7 the value for k7
+         * @param k8 a key for the map
+         * @param v8 the value for k8
+         * @param k9 a key for the map
+         * @param v9 the value for k9
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -203,6 +293,26 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
         /**
          * Creates a LinkedHashMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
+         * @param k7 a key for the map
+         * @param v7 the value for k7
+         * @param k8 a key for the map
+         * @param v8 the value for k8
+         * @param k9 a key for the map
+         * @param v9 the value for k9
+         * @param k10 a key for the map
+         * @param v10 the value for k10
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries

--- a/javaslang/src/main/java/javaslang/collection/TreeMap.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeMap.java
@@ -178,6 +178,10 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
     /**
      * Creates a {@code TreeMap} of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -189,6 +193,12 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
     /**
      * Creates a {@code TreeMap} of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -200,6 +210,14 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
     /**
      * Creates a {@code TreeMap} of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -211,6 +229,16 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
     /**
      * Creates a {@code TreeMap} of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -222,6 +250,18 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
     /**
      * Creates a {@code TreeMap} of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -233,6 +273,20 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
     /**
      * Creates a {@code TreeMap} of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
+     * @param k7 a key for the map
+     * @param v7 the value for k7
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -244,6 +298,22 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
     /**
      * Creates a {@code TreeMap} of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
+     * @param k7 a key for the map
+     * @param v7 the value for k7
+     * @param k8 a key for the map
+     * @param v8 the value for k8
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -255,6 +325,24 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
     /**
      * Creates a {@code TreeMap} of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
+     * @param k7 a key for the map
+     * @param v7 the value for k7
+     * @param k8 a key for the map
+     * @param v8 the value for k8
+     * @param k9 a key for the map
+     * @param v9 the value for k9
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -266,6 +354,26 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
     /**
      * Creates a {@code TreeMap} of the given list of key-value pairs.
      *
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
+     * @param k7 a key for the map
+     * @param v7 the value for k7
+     * @param k8 a key for the map
+     * @param v8 the value for k8
+     * @param k9 a key for the map
+     * @param v9 the value for k9
+     * @param k10 a key for the map
+     * @param v10 the value for k10
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -293,6 +401,10 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
      * Creates a {@code TreeMap} of the given list of key-value pairs.
      *
      * @param keyComparator The comparator used to sort the entries by their key.
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -305,6 +417,12 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
      * Creates a {@code TreeMap} of the given list of key-value pairs.
      *
      * @param keyComparator The comparator used to sort the entries by their key.
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -317,6 +435,14 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
      * Creates a {@code TreeMap} of the given list of key-value pairs.
      *
      * @param keyComparator The comparator used to sort the entries by their key.
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -329,6 +455,16 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
      * Creates a {@code TreeMap} of the given list of key-value pairs.
      *
      * @param keyComparator The comparator used to sort the entries by their key.
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -341,6 +477,18 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
      * Creates a {@code TreeMap} of the given list of key-value pairs.
      *
      * @param keyComparator The comparator used to sort the entries by their key.
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -353,6 +501,20 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
      * Creates a {@code TreeMap} of the given list of key-value pairs.
      *
      * @param keyComparator The comparator used to sort the entries by their key.
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
+     * @param k7 a key for the map
+     * @param v7 the value for k7
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -365,6 +527,22 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
      * Creates a {@code TreeMap} of the given list of key-value pairs.
      *
      * @param keyComparator The comparator used to sort the entries by their key.
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
+     * @param k7 a key for the map
+     * @param v7 the value for k7
+     * @param k8 a key for the map
+     * @param v8 the value for k8
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -377,6 +555,24 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
      * Creates a {@code TreeMap} of the given list of key-value pairs.
      *
      * @param keyComparator The comparator used to sort the entries by their key.
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
+     * @param k7 a key for the map
+     * @param v7 the value for k7
+     * @param k8 a key for the map
+     * @param v8 the value for k8
+     * @param k9 a key for the map
+     * @param v9 the value for k9
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries
@@ -389,6 +585,26 @@ public final class TreeMap<K, V> implements Kind2<TreeMap<?, ?>, K, V>, SortedMa
      * Creates a {@code TreeMap} of the given list of key-value pairs.
      *
      * @param keyComparator The comparator used to sort the entries by their key.
+     * @param k1 a key for the map
+     * @param v1 the value for k1
+     * @param k2 a key for the map
+     * @param v2 the value for k2
+     * @param k3 a key for the map
+     * @param v3 the value for k3
+     * @param k4 a key for the map
+     * @param v4 the value for k4
+     * @param k5 a key for the map
+     * @param v5 the value for k5
+     * @param k6 a key for the map
+     * @param v6 the value for k6
+     * @param k7 a key for the map
+     * @param v7 the value for k7
+     * @param k8 a key for the map
+     * @param v8 the value for k8
+     * @param k9 a key for the map
+     * @param v9 the value for k9
+     * @param k10 a key for the map
+     * @param v10 the value for k10
      * @param <K> The key type
      * @param <V> The value type
      * @return A new Map containing the given entries

--- a/javaslang/src/main/java/javaslang/collection/TreeMultimap.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeMultimap.java
@@ -141,6 +141,8 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given key-value pair.
          *
+         * @param key           A singleton map key.
+         * @param value         A singleton map value.
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -152,6 +154,10 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -163,6 +169,12 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -174,6 +186,14 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -185,6 +205,16 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -196,6 +226,18 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -207,6 +249,20 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
+         * @param k7 a key for the map
+         * @param v7 the value for k7
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -218,6 +274,22 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
+         * @param k7 a key for the map
+         * @param v7 the value for k7
+         * @param k8 a key for the map
+         * @param v8 the value for k8
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -229,6 +301,24 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
+         * @param k7 a key for the map
+         * @param v7 the value for k7
+         * @param k8 a key for the map
+         * @param v8 the value for k8
+         * @param k9 a key for the map
+         * @param v9 the value for k9
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -240,6 +330,26 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
+         * @param k7 a key for the map
+         * @param v7 the value for k7
+         * @param k8 a key for the map
+         * @param v8 the value for k8
+         * @param k9 a key for the map
+         * @param v9 the value for k9
+         * @param k10 a key for the map
+         * @param v10 the value for k10
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries
@@ -262,9 +372,11 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given key-value pair.
          *
+         * @param keyComparator The comparator used to sort the entries by their key.
+         * @param key A singleton map key.
+         * @param value A singleton map value.
          * @param <K> The key type
          * @param <V2> The value type
-         * @param keyComparator The comparator used to sort the entries by their key.
          * @return A new Multimap containing the given entries
          */
         public <K, V2 extends V> TreeMultimap<K, V2> of(Comparator<? super K> keyComparator, K key, V2 value) {
@@ -275,6 +387,10 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
          * @param <K> The key type
          * @param <V2> The value type
          * @param keyComparator The comparator used to sort the entries by their key.
@@ -287,6 +403,12 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
          * @param <K> The key type
          * @param <V2> The value type
          * @param keyComparator The comparator used to sort the entries by their key.
@@ -299,6 +421,14 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
          * @param <K> The key type
          * @param <V2> The value type
          * @param keyComparator The comparator used to sort the entries by their key.
@@ -311,6 +441,16 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
          * @param <K> The key type
          * @param <V2> The value type
          * @param keyComparator The comparator used to sort the entries by their key.
@@ -323,6 +463,18 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
          * @param <K> The key type
          * @param <V2> The value type
          * @param keyComparator The comparator used to sort the entries by their key.
@@ -335,6 +487,20 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
+         * @param k7 a key for the map
+         * @param v7 the value for k7
          * @param <K> The key type
          * @param <V2> The value type
          * @param keyComparator The comparator used to sort the entries by their key.
@@ -347,6 +513,22 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
+         * @param k7 a key for the map
+         * @param v7 the value for k7
+         * @param k8 a key for the map
+         * @param v8 the value for k8
          * @param <K> The key type
          * @param <V2> The value type
          * @param keyComparator The comparator used to sort the entries by their key.
@@ -359,6 +541,24 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
+         * @param k7 a key for the map
+         * @param v7 the value for k7
+         * @param k8 a key for the map
+         * @param v8 the value for k8
+         * @param k9 a key for the map
+         * @param v9 the value for k9
          * @param <K> The key type
          * @param <V2> The value type
          * @param keyComparator The comparator used to sort the entries by their key.
@@ -371,6 +571,26 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given list of key-value pairs.
          *
+         * @param k1 a key for the map
+         * @param v1 the value for k1
+         * @param k2 a key for the map
+         * @param v2 the value for k2
+         * @param k3 a key for the map
+         * @param v3 the value for k3
+         * @param k4 a key for the map
+         * @param v4 the value for k4
+         * @param k5 a key for the map
+         * @param v5 the value for k5
+         * @param k6 a key for the map
+         * @param v6 the value for k6
+         * @param k7 a key for the map
+         * @param v7 the value for k7
+         * @param k8 a key for the map
+         * @param v8 the value for k8
+         * @param k9 a key for the map
+         * @param v9 the value for k9
+         * @param k10 a key for the map
+         * @param v10 the value for k10
          * @param <K> The key type
          * @param <V2> The value type
          * @param keyComparator The comparator used to sort the entries by their key.

--- a/javaslang/src/main/java/javaslang/control/Either.java
+++ b/javaslang/src/main/java/javaslang/control/Either.java
@@ -275,10 +275,10 @@ public interface Either<L, R> extends Value<R> {
     /**
      * Maps the value of this Either if it is a Left, performs no operation if this is a Right.
      *
-     * <pre><code>
+     * <pre>{@code
      * import static javaslang.API.*;
      *
-     * class Example {{
+     * class Example {
      *
      *     // = Left(2)
      *     Left(1).mapLeft(i -> i + 1);
@@ -286,8 +286,8 @@ public interface Either<L, R> extends Value<R> {
      *     // = Right("a")
      *     Right("a").mapLeft(i -> i + 1);
      *
-     * }}
-     * </code></pre>
+     * }
+     * }</pre>
      *
      * @param leftMapper A mapper
      * @param <U>        Component type of the mapped right value

--- a/javaslang/src/main/java/javaslang/control/Validation.java
+++ b/javaslang/src/main/java/javaslang/control/Validation.java
@@ -522,7 +522,7 @@ public interface Validation<E, T> extends Value<T> {
      * Applies a function f to the error of this Validation if this is an Invalid. Otherwise does nothing
      * if this is a Valid.
      *
-     * @deprecated  replaced by {@link #mapError()}
+     * @deprecated  replaced by {@link #mapError(Function)}
      * @param <U> type of the error resulting from the mapping
      * @param f   a function that maps the error in this Invalid
      * @return an instance of Validation&lt;U,T&gt;


### PR DESCRIPTION
some of the errors i'm fixing were from my PRs :-)
listing all of the key-values for the map builders looks a bit ugly even in the generated javadoc actually. But probably it's as it should be...