### PR TITLE
make javadoc alignment at least locally coherent

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/Map.java
+++ b/javaslang/src/main/java/javaslang/collection/Map.java
@@ -280,7 +280,7 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V> {
     /**
      * Returns the value associated with a key, or a default value if the key is not contained in the map.
      *
-     * @param key          the key
+     * @param key the key
      * @param defaultValue a default value
      * @return the value associated with key if it exists, otherwise the default value.
      */

--- a/javaslang/src/main/java/javaslang/collection/TreeMultimap.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeMultimap.java
@@ -141,8 +141,8 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         /**
          * Creates a TreeMultimap of the given key-value pair.
          *
-         * @param key           A singleton map key.
-         * @param value         A singleton map value.
+         * @param key A singleton map key.
+         * @param value A singleton map value.
          * @param <K> The key type
          * @param <V2> The value type
          * @return A new Multimap containing the given entries


### PR DESCRIPTION
@paplorinc was commenting about the javadoc alignment being inconsistent.
actually sometimes we have the descriptions aligned between themselves, sometimes they are only one space character away from the keys. Maybe we could harmonize that through the project, maybe not, but yes, at least we should be coherent in a single javadoc comment, that's what this commit does.

see https://github.com/javaslang/javaslang/commit/b97080b199adc2abe51b8ebb05d646acecfac8fe#commitcomment-19891096