### PR TITLE
Fix Gen choose

### DIFF
--- a/javaslang-test/src/main/java/javaslang/test/Gen.java
+++ b/javaslang-test/src/main/java/javaslang/test/Gen.java
@@ -212,12 +212,12 @@ public interface Gen<T> {
      */
     static <T> Gen<T> choose(Iterable<T> values) {
         Objects.requireNonNull(values, "values is null");
-        final Stream<T> stream = Stream.ofAll(values);
-        if (stream.isEmpty()) {
+        final Iterator<T> iterator = Iterator.ofAll(values);
+        if (!iterator.hasNext()) {
             throw new IllegalArgumentException("Empty iterable");
         }
         @SuppressWarnings("unchecked")
-        final T[] array = stream.toJavaArray((Class<T>) stream.head().getClass());
+        final T[] array = (T[]) iterator.toJavaArray();
         return choose(array);
     }
 

--- a/javaslang-test/src/test/java/javaslang/test/GenTest.java
+++ b/javaslang-test/src/test/java/javaslang/test/GenTest.java
@@ -179,6 +179,14 @@ public class GenTest {
         assertForAll(() -> Gen.choose(i).apply(RANDOM), c -> c == 1);
     }
 
+    @Test
+    public void shouldChooseFromIterableWithInstancesOfGenericInterface(){
+        List<Supplier<String>> i = List.of(() -> "test", () -> "test");
+
+        Supplier<String> supplier = Gen.choose(i).apply(RANDOM);
+
+        assertThat(supplier.get()).isEqualTo("test");
+    }
 
     @Test(expected = RuntimeException.class)
     public void shouldFailOnEmptyIterable() throws Exception {

--- a/javaslang-test/src/test/java/javaslang/test/GenTest.java
+++ b/javaslang-test/src/test/java/javaslang/test/GenTest.java
@@ -180,7 +180,7 @@ public class GenTest {
     }
 
     @Test
-    public void shouldChooseFromIterableWithInstancesOfGenericInterface(){
+    public void shouldChooseFromIterableWithInstancesOfGenericInterface() {
         List<Supplier<String>> i = List.of(() -> "test", () -> "test");
 
         Supplier<String> supplier = Gen.choose(i).apply(RANDOM);


### PR DESCRIPTION
For instances of generic interfaces, choose was throwing an ArrayStoreException because of different runtime types of the elements within the iterable. As suggested by Daniel this commit uses Iterator instead of Stream. This resolves the issue #1699.