### PR TITLE
Make Kind1 and Kind2 extends derive4j-hkt interfaces.

### DIFF
--- a/javaslang/pom.xml
+++ b/javaslang/pom.xml
@@ -29,6 +29,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.derive4j.hkt</groupId>
+            <artifactId>hkt</artifactId>
+            <version>${hkt.version}</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/javaslang/src/main/java/javaslang/Kind1.java
+++ b/javaslang/src/main/java/javaslang/Kind1.java
@@ -5,6 +5,8 @@
  */
 package javaslang;
 
+import org.derive4j.hkt.__;
+
 /**
  * Recursive self type representing {@code TYPE<T>}, which allows similar behavior to higher-kinded types.
  *
@@ -13,5 +15,5 @@ package javaslang;
  * @author Daniel Dietrich
  * @since 2.0.0
  */
-public interface Kind1<TYPE extends Kind1<TYPE, ?>, T> {
+public interface Kind1<TYPE extends Kind1<TYPE, ?>, T> extends __<TYPE, T> {
 }

--- a/javaslang/src/main/java/javaslang/Kind2.java
+++ b/javaslang/src/main/java/javaslang/Kind2.java
@@ -5,6 +5,8 @@
  */
 package javaslang;
 
+import org.derive4j.hkt.__2;
+
 /**
  * Recursive self type representing {@code TYPE<T1, T2>}, which allows similar behavior to higher-kinded types.
  *
@@ -14,5 +16,5 @@ package javaslang;
  * @author Daniel Dietrich, Eric Nelson
  * @since 2.0.0
  */
-public interface Kind2<TYPE extends Kind2<TYPE, ?, ?>, T1, T2> {
+public interface Kind2<TYPE extends Kind2<TYPE, ?, ?>, T1, T2> extends __2<TYPE, T1, T2> {
 }

--- a/javaslang/src/main/java/javaslang/collection/CharSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/CharSeq.java
@@ -25,7 +25,7 @@ import java.util.stream.Collector;
  * @author Ruslan Sennov, Daniel Dietrich
  * @since 2.0.0
  */
-public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, IndexedSeq<Character>, Serializable {
+public final class CharSeq implements CharSequence, IndexedSeq<Character>, Serializable {
 
     private static final long serialVersionUID = 1L;
 

--- a/javaslang/src/main/java/javaslang/collection/PriorityQueue.java
+++ b/javaslang/src/main/java/javaslang/collection/PriorityQueue.java
@@ -25,7 +25,7 @@ import static javaslang.collection.PriorityQueueBase.*;
  * @author Pap Lőrinc
  * @since 2.1.0
  */
-public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> implements Serializable, Kind1<PriorityQueue<T>, T> {
+public final class PriorityQueue<T> extends AbstractsQueue<T, PriorityQueue<T>> implements Serializable, Kind1<PriorityQueue<?>, T> {
 
     private static final long serialVersionUID = 1L;
 

--- a/javaslang/src/main/java/javaslang/collection/Queue.java
+++ b/javaslang/src/main/java/javaslang/collection/Queue.java
@@ -39,7 +39,7 @@ import java.util.stream.Collector;
  * @author Daniel Dietrich
  * @since 2.0.0
  */
-public final class Queue<T> extends AbstractsQueue<T, Queue<T>> implements LinearSeq<T>, Kind1<Queue<T>, T> {
+public final class Queue<T> extends AbstractsQueue<T, Queue<T>> implements LinearSeq<T>, Kind1<Queue<?>, T> {
 
     private static final long serialVersionUID = 1L;
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@ Note: The maven build currently needs to be started from the javaslang root dir
         <jmh.version>1.16</jmh.version>
         <junit.version>4.12</junit.version>
         <gwt.version>2.8.0</gwt.version>
+        <hkt.version>0.9.1</hkt.version>
         <maven.build-helper.version>1.12</maven.build-helper.version>
         <maven.bundle.version>3.2.0</maven.bundle.version>
         <maven.clean.version>3.0.0</maven.clean.version>


### PR DESCRIPTION
so that javaslang can:
- enjoy enhanced compile-time verification (including generated safe cast)
- be compatible at the kind level with a wider ecosystem (highj/cyclops-react).

this commit also fix some errors that have been catched by the hkt processor.

More info (eg. how to customize (or even disable) code generation) at https://github.com/derive4j/hkt.

cc: @johnmcclean-aol