### PR TITLE
General `Vector` speedup

### DIFF
--- a/javaslang/generator/Generator.scala
+++ b/javaslang/generator/Generator.scala
@@ -2397,8 +2397,7 @@ def generateMainClasses(): Unit = {
                   final Collection<? extends T> collection = (Collection<? extends T>) iterable;
                   return collection.toArray();
               } else {
-                  final Tuple2<Iterable<? extends T>, Integer> iterableAndSize = Collections.withSize(iterable);
-                  return asArray(iterableAndSize._1.iterator(), iterableAndSize._2);
+                  return Collections.withSize(iterable).toArray();
               }
           }
 

--- a/javaslang/src-gen/main/java/javaslang/collection/ArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/ArrayType.java
@@ -10,8 +10,6 @@ package javaslang.collection;
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
 import java.io.Serializable;
-
-import javaslang.Tuple2;
 import java.util.Collection;
 
 /**
@@ -127,8 +125,7 @@ interface ArrayType<T> {
             final Collection<? extends T> collection = (Collection<? extends T>) iterable;
             return collection.toArray();
         } else {
-            final Tuple2<Iterable<? extends T>, Integer> iterableAndSize = Collections.withSize(iterable);
-            return asArray(iterableAndSize._1.iterator(), iterableAndSize._2);
+            return Collections.withSize(iterable).toArray();
         }
     }
 

--- a/javaslang/src-gen/main/java/javaslang/collection/ArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/ArrayType.java
@@ -10,6 +10,7 @@ package javaslang.collection;
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
 import java.io.Serializable;
+
 import java.util.Collection;
 
 /**
@@ -31,9 +32,10 @@ interface ArrayType<T> {
     Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size);
 
     @SuppressWarnings("unchecked")
-    static <T> ArrayType<T> of(Object array) { return of((Class<T>) array.getClass().getComponentType()); }
+    static <T> ArrayType<T> of(Object array)  { return of((Class<T>) array.getClass().getComponentType()); }
+    static <T> ArrayType<T> of(Class<T> type) { return !type.isPrimitive() ? obj() : ofPrimitive(type); }
     @SuppressWarnings("unchecked")
-    static <T> ArrayType<T> of(Class<T> type) {
+    static <T> ArrayType<T> ofPrimitive(Class<T> type) {
         if (boolean.class == type) {
             return (ArrayType<T>) BooleanArrayType.INSTANCE;
         } else if (byte.class == type) {
@@ -51,7 +53,7 @@ interface ArrayType<T> {
         } else if (short.class == type) {
             return (ArrayType<T>) ShortArrayType.INSTANCE;
         } else {
-            return (ArrayType<T>) ObjectArrayType.INSTANCE;
+            throw new IllegalArgumentException(String.valueOf(type));
         }
     }
 
@@ -155,29 +157,30 @@ interface ArrayType<T> {
         public boolean[] empty() { return EMPTY; }
 
         @Override
-        public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+        public int lengthOf(Object array) { return (array != null) ? cast(array).length : 0; }
 
         @Override
         public Boolean getAt(Object array, int index) { return cast(array)[index]; }
 
         @Override
         public void setAt(Object array, int index, Boolean value) throws ClassCastException {
-            if (value == null) {
-                throw new ClassCastException();
-            } else {
+            if (value != null) {
                 cast(array)[index] = value;
+            } else {
+                throw new ClassCastException();
             }
         }
 
         @Override
         public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
-            if (size == 0) {
-                return new boolean[arraySize];
-            } else {
-                final boolean[] result = new boolean[arraySize];
-                System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
-                return result;
-            }
+            return (size > 0)
+                    ? copyNonEmpty(array, arraySize, sourceFrom, destinationFrom, size)
+                    : new boolean[arraySize];
+        }
+        private static Object copyNonEmpty(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+            final boolean[] result = new boolean[arraySize];
+            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            return result;
         }
     }
 
@@ -195,29 +198,30 @@ interface ArrayType<T> {
         public byte[] empty() { return EMPTY; }
 
         @Override
-        public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+        public int lengthOf(Object array) { return (array != null) ? cast(array).length : 0; }
 
         @Override
         public Byte getAt(Object array, int index) { return cast(array)[index]; }
 
         @Override
         public void setAt(Object array, int index, Byte value) throws ClassCastException {
-            if (value == null) {
-                throw new ClassCastException();
-            } else {
+            if (value != null) {
                 cast(array)[index] = value;
+            } else {
+                throw new ClassCastException();
             }
         }
 
         @Override
         public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
-            if (size == 0) {
-                return new byte[arraySize];
-            } else {
-                final byte[] result = new byte[arraySize];
-                System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
-                return result;
-            }
+            return (size > 0)
+                    ? copyNonEmpty(array, arraySize, sourceFrom, destinationFrom, size)
+                    : new byte[arraySize];
+        }
+        private static Object copyNonEmpty(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+            final byte[] result = new byte[arraySize];
+            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            return result;
         }
     }
 
@@ -235,29 +239,30 @@ interface ArrayType<T> {
         public char[] empty() { return EMPTY; }
 
         @Override
-        public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+        public int lengthOf(Object array) { return (array != null) ? cast(array).length : 0; }
 
         @Override
         public Character getAt(Object array, int index) { return cast(array)[index]; }
 
         @Override
         public void setAt(Object array, int index, Character value) throws ClassCastException {
-            if (value == null) {
-                throw new ClassCastException();
-            } else {
+            if (value != null) {
                 cast(array)[index] = value;
+            } else {
+                throw new ClassCastException();
             }
         }
 
         @Override
         public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
-            if (size == 0) {
-                return new char[arraySize];
-            } else {
-                final char[] result = new char[arraySize];
-                System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
-                return result;
-            }
+            return (size > 0)
+                    ? copyNonEmpty(array, arraySize, sourceFrom, destinationFrom, size)
+                    : new char[arraySize];
+        }
+        private static Object copyNonEmpty(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+            final char[] result = new char[arraySize];
+            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            return result;
         }
     }
 
@@ -275,29 +280,30 @@ interface ArrayType<T> {
         public double[] empty() { return EMPTY; }
 
         @Override
-        public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+        public int lengthOf(Object array) { return (array != null) ? cast(array).length : 0; }
 
         @Override
         public Double getAt(Object array, int index) { return cast(array)[index]; }
 
         @Override
         public void setAt(Object array, int index, Double value) throws ClassCastException {
-            if (value == null) {
-                throw new ClassCastException();
-            } else {
+            if (value != null) {
                 cast(array)[index] = value;
+            } else {
+                throw new ClassCastException();
             }
         }
 
         @Override
         public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
-            if (size == 0) {
-                return new double[arraySize];
-            } else {
-                final double[] result = new double[arraySize];
-                System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
-                return result;
-            }
+            return (size > 0)
+                    ? copyNonEmpty(array, arraySize, sourceFrom, destinationFrom, size)
+                    : new double[arraySize];
+        }
+        private static Object copyNonEmpty(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+            final double[] result = new double[arraySize];
+            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            return result;
         }
     }
 
@@ -315,29 +321,30 @@ interface ArrayType<T> {
         public float[] empty() { return EMPTY; }
 
         @Override
-        public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+        public int lengthOf(Object array) { return (array != null) ? cast(array).length : 0; }
 
         @Override
         public Float getAt(Object array, int index) { return cast(array)[index]; }
 
         @Override
         public void setAt(Object array, int index, Float value) throws ClassCastException {
-            if (value == null) {
-                throw new ClassCastException();
-            } else {
+            if (value != null) {
                 cast(array)[index] = value;
+            } else {
+                throw new ClassCastException();
             }
         }
 
         @Override
         public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
-            if (size == 0) {
-                return new float[arraySize];
-            } else {
-                final float[] result = new float[arraySize];
-                System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
-                return result;
-            }
+            return (size > 0)
+                    ? copyNonEmpty(array, arraySize, sourceFrom, destinationFrom, size)
+                    : new float[arraySize];
+        }
+        private static Object copyNonEmpty(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+            final float[] result = new float[arraySize];
+            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            return result;
         }
     }
 
@@ -355,29 +362,30 @@ interface ArrayType<T> {
         public int[] empty() { return EMPTY; }
 
         @Override
-        public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+        public int lengthOf(Object array) { return (array != null) ? cast(array).length : 0; }
 
         @Override
         public Integer getAt(Object array, int index) { return cast(array)[index]; }
 
         @Override
         public void setAt(Object array, int index, Integer value) throws ClassCastException {
-            if (value == null) {
-                throw new ClassCastException();
-            } else {
+            if (value != null) {
                 cast(array)[index] = value;
+            } else {
+                throw new ClassCastException();
             }
         }
 
         @Override
         public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
-            if (size == 0) {
-                return new int[arraySize];
-            } else {
-                final int[] result = new int[arraySize];
-                System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
-                return result;
-            }
+            return (size > 0)
+                    ? copyNonEmpty(array, arraySize, sourceFrom, destinationFrom, size)
+                    : new int[arraySize];
+        }
+        private static Object copyNonEmpty(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+            final int[] result = new int[arraySize];
+            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            return result;
         }
     }
 
@@ -395,29 +403,30 @@ interface ArrayType<T> {
         public long[] empty() { return EMPTY; }
 
         @Override
-        public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+        public int lengthOf(Object array) { return (array != null) ? cast(array).length : 0; }
 
         @Override
         public Long getAt(Object array, int index) { return cast(array)[index]; }
 
         @Override
         public void setAt(Object array, int index, Long value) throws ClassCastException {
-            if (value == null) {
-                throw new ClassCastException();
-            } else {
+            if (value != null) {
                 cast(array)[index] = value;
+            } else {
+                throw new ClassCastException();
             }
         }
 
         @Override
         public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
-            if (size == 0) {
-                return new long[arraySize];
-            } else {
-                final long[] result = new long[arraySize];
-                System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
-                return result;
-            }
+            return (size > 0)
+                    ? copyNonEmpty(array, arraySize, sourceFrom, destinationFrom, size)
+                    : new long[arraySize];
+        }
+        private static Object copyNonEmpty(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+            final long[] result = new long[arraySize];
+            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            return result;
         }
     }
 
@@ -435,29 +444,30 @@ interface ArrayType<T> {
         public short[] empty() { return EMPTY; }
 
         @Override
-        public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+        public int lengthOf(Object array) { return (array != null) ? cast(array).length : 0; }
 
         @Override
         public Short getAt(Object array, int index) { return cast(array)[index]; }
 
         @Override
         public void setAt(Object array, int index, Short value) throws ClassCastException {
-            if (value == null) {
-                throw new ClassCastException();
-            } else {
+            if (value != null) {
                 cast(array)[index] = value;
+            } else {
+                throw new ClassCastException();
             }
         }
 
         @Override
         public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
-            if (size == 0) {
-                return new short[arraySize];
-            } else {
-                final short[] result = new short[arraySize];
-                System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
-                return result;
-            }
+            return (size > 0)
+                    ? copyNonEmpty(array, arraySize, sourceFrom, destinationFrom, size)
+                    : new short[arraySize];
+        }
+        private static Object copyNonEmpty(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+            final short[] result = new short[arraySize];
+            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            return result;
         }
     }
 
@@ -475,7 +485,7 @@ interface ArrayType<T> {
         public Object[] empty() { return EMPTY; }
 
         @Override
-        public int lengthOf(Object array) { return (array == null) ? 0 : cast(array).length; }
+        public int lengthOf(Object array) { return (array != null) ? cast(array).length : 0; }
 
         @Override
         public Object getAt(Object array, int index) { return cast(array)[index]; }
@@ -487,13 +497,14 @@ interface ArrayType<T> {
 
         @Override
         public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
-            if (size == 0) {
-                return new Object[arraySize];
-            } else {
-                final Object[] result = new Object[arraySize];
-                System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
-                return result;
-            }
+            return (size > 0)
+                    ? copyNonEmpty(array, arraySize, sourceFrom, destinationFrom, size)
+                    : new Object[arraySize];
+        }
+        private static Object copyNonEmpty(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+            final Object[] result = new Object[arraySize];
+            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            return result;
         }
     }
 }

--- a/javaslang/src/main/java/javaslang/collection/BitMappedTrie.java
+++ b/javaslang/src/main/java/javaslang/collection/BitMappedTrie.java
@@ -267,13 +267,16 @@ final class BitMappedTrie<T> implements Serializable {
         } else if (depthShift == BRANCHING_BASE) {
             return obj().getAt(array, firstDigit(offset + index, depthShift));
         } else {
-            index += offset;
-            Object leaf = obj().getAt(array, firstDigit(index, depthShift));
-            for (int shift = depthShift - BRANCHING_BASE; shift > 0; shift -= BRANCHING_BASE) {
-                leaf = obj().getAt(leaf, digit(index, shift));
-            }
-            return leaf;
+            return getLeafGeneral(index);
         }
+    }
+    private Object getLeafGeneral(int index) {
+        index += offset;
+        Object leaf = obj().getAt(array, firstDigit(index, depthShift));
+        for (int shift = depthShift - BRANCHING_BASE; shift > 0; shift -= BRANCHING_BASE) {
+            leaf = obj().getAt(leaf, digit(index, shift));
+        }
+        return leaf;
     }
 
     Iterator<T> iterator() {

--- a/javaslang/src/main/java/javaslang/collection/BitMappedTrie.java
+++ b/javaslang/src/main/java/javaslang/collection/BitMappedTrie.java
@@ -11,10 +11,8 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static java.util.function.Function.identity;
-import static javaslang.API.Vector;
 import static javaslang.collection.ArrayType.obj;
-import static javaslang.collection.Collections.isTraversableAgain;
-import static javaslang.collection.Collections.reverseIterator;
+import static javaslang.collection.Collections.withSize;
 import static javaslang.collection.NodeModifier.COPY_NODE;
 import static javaslang.collection.NodeModifier.IDENTITY;
 
@@ -86,19 +84,16 @@ final class BitMappedTrie<T> implements Serializable {
     private BitMappedTrie<T> boxed() { return map(identity()); }
 
     BitMappedTrie<T> prependAll(Iterable<? extends T> iterable) {
-        if (!isTraversableAgain(iterable)) {
-            iterable = Vector(iterable);
-        }
-
+        final Collections.IterableWithSize<? extends T> iter = withSize(iterable);
         try {
-            return prepend(reverseIterator(iterable));
+            return prepend(iter.reverseIterator(), iter.size());
         } catch (ClassCastException ignored) {
-            return boxed().prepend(reverseIterator(iterable));
+            return boxed().prepend(iter.reverseIterator(), iter.size());
         }
     }
-    private BitMappedTrie<T> prepend(java.util.Iterator<? extends T> iterator) {
+    private BitMappedTrie<T> prepend(java.util.Iterator<? extends T> iterator, int size) {
         BitMappedTrie<T> result = this;
-        while (iterator.hasNext()) {
+        while (size > 0) {
             Object array = result.array;
             int shift = result.depthShift, offset = result.offset;
             if (result.isFullLeft()) {
@@ -107,38 +102,38 @@ final class BitMappedTrie<T> implements Serializable {
                 offset = treeSize(BRANCHING_FACTOR - 1, shift);
             }
 
-            final MutableInt delta = new MutableInt(0);
-            array = result.modifyLeaf(array, shift, offset - 1, COPY_NODE, prependToLeaf(iterator, delta));
-            result = new BitMappedTrie<>(type, array, offset - delta.val, result.length + delta.val, shift);
+            final int index = offset - 1;
+            final int delta = Math.min(size, lastDigit(index) + 1);
+            size -= delta;
+
+            array = result.modify(array, shift, index, COPY_NODE, prependToLeaf(iterator));
+            result = new BitMappedTrie<>(type, array, offset - delta, result.length + delta, shift);
         }
+        assert !iterator.hasNext();
         return result;
     }
     private boolean isFullLeft() { return offset == 0; }
-    private NodeModifier prependToLeaf(java.util.Iterator<? extends T> iterator, MutableInt delta) {
+    private NodeModifier prependToLeaf(java.util.Iterator<? extends T> iterator) {
         return (array, index) -> {
             final Object copy = type.copy(array, BRANCHING_FACTOR);
-            for (; iterator.hasNext() && index >= 0; index--) {
-                type.setAt(copy, index, iterator.next());
-                delta.val++;
+            while (iterator.hasNext() && index >= 0) {
+                type.setAt(copy, index--, iterator.next());
             }
             return copy;
         };
     }
 
     BitMappedTrie<T> appendAll(Iterable<? extends T> iterable) {
-        if (!isTraversableAgain(iterable)) {
-            iterable = Vector(iterable);
-        }
-
+        final Collections.IterableWithSize<? extends T> iter = withSize(iterable);
         try {
-            return append(iterable.iterator());
+            return append(iter.iterator(), iter.size());
         } catch (ClassCastException ignored) {
-            return boxed().append(iterable.iterator());
+            return boxed().append(iter.iterator(), iter.size());
         }
     }
-    private BitMappedTrie<T> append(java.util.Iterator<? extends T> iterator) {
+    private BitMappedTrie<T> append(java.util.Iterator<? extends T> iterator, int size) {
         BitMappedTrie<T> result = this;
-        while (iterator.hasNext()) {
+        while (size > 0) {
             Object array = result.array;
             int shift = result.depthShift;
             if (result.isFullRight()) {
@@ -146,20 +141,24 @@ final class BitMappedTrie<T> implements Serializable {
                 shift += BRANCHING_BASE;
             }
 
-            final MutableInt delta = new MutableInt(0);
-            array = result.modifyLeaf(array, shift, result.offset + result.length, COPY_NODE, appendToLeaf(iterator, delta));
-            result = new BitMappedTrie<>(type, array, result.offset, result.length + delta.val, shift);
+            final int index = offset + result.length;
+            final int leafSpace = lastDigit(index);
+            final int delta = Math.min(size, BRANCHING_FACTOR - leafSpace);
+            size -= delta;
+
+            array = result.modify(array, shift, index, COPY_NODE, appendToLeaf(iterator, leafSpace + delta));
+            result = new BitMappedTrie<>(type, array, offset, result.length + delta, shift);
         }
+        assert !iterator.hasNext();
         return result;
 
     }
     private boolean isFullRight() { return (offset + length + 1) > treeSize(BRANCHING_FACTOR, depthShift); }
-    private NodeModifier appendToLeaf(java.util.Iterator<? extends T> iterator, MutableInt delta) {
+    private NodeModifier appendToLeaf(java.util.Iterator<? extends T> iterator, int leafSize) {
         return (array, index) -> {
-            final Object copy = type.copy(array, BRANCHING_FACTOR);
-            for (int length = type.lengthOf(copy); iterator.hasNext() && index < length; index++) {
-                type.setAt(copy, index, iterator.next());
-                delta.val++;
+            final Object copy = type.copy(array, leafSize);
+            while (iterator.hasNext() && index < leafSize) {
+                type.setAt(copy, index++, iterator.next());
             }
             return copy;
         };
@@ -167,7 +166,7 @@ final class BitMappedTrie<T> implements Serializable {
 
     BitMappedTrie<T> update(int index, T element) {
         try {
-            final Object root = modifyLeaf(array, depthShift, offset + index, COPY_NODE, updateLeafWith(type, element));
+            final Object root = modify(array, depthShift, offset + index, COPY_NODE, updateLeafWith(type, element));
             return new BitMappedTrie<>(type, root, offset, length, depthShift);
         } catch (ClassCastException ignored) {
             return boxed().update(index, element);
@@ -184,7 +183,7 @@ final class BitMappedTrie<T> implements Serializable {
             final int index = offset + n;
             final Object root = arePointingToSameLeaf(0, n)
                                 ? array
-                                : modifyLeaf(array, depthShift, index, obj()::copyDrop, IDENTITY);
+                                : modify(array, depthShift, index, obj()::copyDrop, IDENTITY);
             return collapsed(type, root, index, length - n, depthShift);
         }
     }
@@ -198,7 +197,7 @@ final class BitMappedTrie<T> implements Serializable {
             final int index = n - 1;
             final Object root = arePointingToSameLeaf(index, length - 1)
                                 ? array
-                                : modifyLeaf(array, depthShift, offset + index, obj()::copyTake, IDENTITY);
+                                : modify(array, depthShift, offset + index, obj()::copyTake, IDENTITY);
             return collapsed(type, root, offset, n, depthShift);
         }
     }
@@ -223,29 +222,31 @@ final class BitMappedTrie<T> implements Serializable {
     }
 
     /* descend the tree from root to leaf, applying the given modifications along the way, returning the new root */
-    private Object modifyLeaf(Object root, int depthShift, int index, NodeModifier node, NodeModifier leaf) {
-        if (depthShift == 0) {
-            return leaf.apply(root, index);
-        } else {
-            int previousIndex = firstDigit(index, depthShift);
-            root = node.apply(root, previousIndex);
+    private Object modify(Object root, int depthShift, int index, NodeModifier node, NodeModifier leaf) {
+        return (depthShift == 0)
+                ? leaf.apply(root, index)
+                : modifyNonLeaf(root, depthShift, index, node, leaf);
+    }
+    private Object modifyNonLeaf(Object root, int depthShift, int index, NodeModifier node, NodeModifier leaf) {
+        int previousIndex = firstDigit(index, depthShift);
+        root = node.apply(root, previousIndex);
 
-            Object array = root;
-            for (int shift = depthShift - BRANCHING_BASE; shift >= BRANCHING_BASE; shift -= BRANCHING_BASE) {
-                final int offset = digit(index, shift);
-
-                final Object previous = obj().getAt(array, previousIndex);
-                final Object newNode = node.apply(previous, offset);
-                obj().setAt(array, previousIndex, newNode);
-
-                previousIndex = offset;
-                array = newNode;
-            }
-
-            final Object newLeaf = leaf.apply(obj().getAt(array, previousIndex), lastDigit(index));
-            obj().setAt(array, previousIndex, newLeaf);
-            return root;
+        Object array = root;
+        for (int shift = depthShift - BRANCHING_BASE; shift >= BRANCHING_BASE; shift -= BRANCHING_BASE) {
+            final int prev = previousIndex;
+            previousIndex = digit(index, shift);
+            array = setNewNode(node, prev, array, previousIndex);
         }
+
+        final Object newLeaf = leaf.apply(obj().getAt(array, previousIndex), lastDigit(index));
+        obj().setAt(array, previousIndex, newLeaf);
+        return root;
+    }
+    private Object setNewNode(NodeModifier node, int previousIndex, Object array, int offset) {
+        final Object previous = obj().getAt(array, previousIndex);
+        final Object newNode = node.apply(previous, offset);
+        obj().setAt(array, previousIndex, newNode);
+        return newNode;
     }
 
     T get(int index) {
@@ -369,9 +370,4 @@ interface NodeModifier {
 @FunctionalInterface
 interface LeafVisitor<T> {
     int visit(int index, T leaf, int start, int end);
-}
-
-class MutableInt {
-    int val;
-    MutableInt(int val) { this.val = val; }
 }

--- a/javaslang/src/main/java/javaslang/collection/Collections.java
+++ b/javaslang/src/main/java/javaslang/collection/Collections.java
@@ -64,7 +64,7 @@ final class Collections {
     static <T, C, R extends Iterable<T>> Map<C, R> groupBy(Traversable<T> source, Function<? super T, ? extends C> classifier, Function<? super Iterable<T>, R> mapper) {
         Objects.requireNonNull(classifier, "classifier is null");
         Objects.requireNonNull(mapper, "mapper is null");
-        final java.util.Map<C, Collection<T>> mutableResults = new java.util.LinkedHashMap<>();
+        final java.util.Map<C, Collection<T>> mutableResults = new java.util.LinkedHashMap<>(source.isTraversableAgain() ? source.size() : 16);
         for (T value : source) {
             final C key = classifier.apply(value);
             mutableResults.computeIfAbsent(key, k -> new ArrayList<>()).add(value);

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -16,7 +16,6 @@ import java.util.stream.Collector;
 
 import static javaslang.collection.ArrayType.asArray;
 import static javaslang.collection.Collections.areEqual;
-import static javaslang.collection.Collections.withSize;
 
 /**
  * Vector is the default Seq implementation that provides effectively constant time access to any element.
@@ -657,19 +656,20 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public T get(int index) {
-        if ((index < 0) || (index >= length())) {
-            throw new IndexOutOfBoundsException("get(" + index + ")");
-        } else {
+        if (isValid(index)) {
             return trie.get(index);
+        } else {
+            throw new IndexOutOfBoundsException("get(" + index + ")");
         }
     }
+    private boolean isValid(int index) { return (index >= 0) && (index < length()); }
 
     @Override
     public T head() {
-        if (isEmpty()) {
-            throw new NoSuchElementException("head of empty Vector");
-        } else {
+        if (nonEmpty()) {
             return get(0);
+        } else {
+            throw new NoSuchElementException("head of empty Vector");
         }
     }
 
@@ -694,10 +694,10 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public Vector<T> init() {
-        if (isEmpty()) {
-            throw new UnsupportedOperationException("init of empty Vector");
-        } else {
+        if (nonEmpty()) {
             return dropRight(1);
+        } else {
+            throw new UnsupportedOperationException("init of empty Vector");
         }
     }
 
@@ -709,14 +709,14 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public Vector<T> insertAll(int index, Iterable<? extends T> elements) {
-        if ((index < 0) || (index > length())) {
-            throw new IndexOutOfBoundsException("insert(" + index + ", e) on Vector of length " + length());
-        } else {
+        if ((index >= 0) && (index <= length())) {
             final Vector<T> begin = take(index).appendAll(elements);
             final Vector<T> end = drop(index);
             return (begin.size() > end.size())
-                   ? begin.appendAll(end)
-                   : end.prependAll(begin);
+                    ? begin.appendAll(end)
+                    : end.prependAll(begin);
+        } else {
+            throw new IndexOutOfBoundsException("insert(" + index + ", e) on Vector of length " + length());
         }
     }
 
@@ -866,12 +866,14 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public Vector<T> removeAt(int index) {
-        if ((index < 0) || (index >= length())) {
-            throw new IndexOutOfBoundsException("removeAt(" + index + ")");
-        } else {
+        if (isValid(index)) {
             final Vector<T> begin = take(index);
             final Vector<T> end = drop(index + 1);
-            return begin.appendAll(end);
+            return (begin.size() > end.size())
+                    ? begin.appendAll(end)
+                    : end.prependAll(begin);
+        } else {
+            throw new IndexOutOfBoundsException("removeAt(" + index + ")");
         }
     }
 
@@ -1018,28 +1020,28 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public Vector<T> subSequence(int beginIndex) {
-        if ((beginIndex < 0) || (beginIndex > length())) {
-            throw new IndexOutOfBoundsException("subSequence(" + beginIndex + ")");
-        } else {
+        if ((beginIndex >= 0) && (beginIndex <= length())) {
             return drop(beginIndex);
+        } else {
+            throw new IndexOutOfBoundsException("subSequence(" + beginIndex + ")");
         }
     }
 
     @Override
     public Vector<T> subSequence(int beginIndex, int endIndex) {
-        if ((beginIndex < 0) || (beginIndex > endIndex) || (endIndex > length())) {
-            throw new IndexOutOfBoundsException("subSequence(" + beginIndex + ", " + endIndex + ") on Vector of size " + length());
-        } else {
+        if ((beginIndex >= 0) && (beginIndex <= endIndex) && (endIndex <= length())) {
             return slice(beginIndex, endIndex);
+        } else {
+            throw new IndexOutOfBoundsException("subSequence(" + beginIndex + ", " + endIndex + ") on Vector of size " + length());
         }
     }
 
     @Override
     public Vector<T> tail() {
-        if (isEmpty()) {
-            throw new UnsupportedOperationException("tail of empty Vector");
-        } else {
+        if (nonEmpty()) {
             return drop(1);
+        } else {
+            throw new UnsupportedOperationException("tail of empty Vector");
         }
     }
 
@@ -1120,10 +1122,10 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public Vector<T> update(int index, T element) {
-        if ((index < 0) || (index >= length())) {
-            throw new IndexOutOfBoundsException("update(" + index + ")");
-        } else {
+        if (isValid(index)) {
             return wrap(trie.update(index, element));
+        } else {
+            throw new IndexOutOfBoundsException("update(" + index + ")");
         }
     }
 

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -644,6 +644,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public Vector<T> filter(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
         return wrap(trie.filter(predicate));
     }
 
@@ -749,6 +750,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public <U> Vector<U> map(Function<? super T, ? extends U> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
         return ofAll(trie.map(mapper));
     }
 

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -563,7 +563,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public Vector<T> append(T element) { return appendAll(Iterator.of(element)); }
+    public Vector<T> append(T element) { return appendAll(List.of(element)); }
 
     @Override
     public Vector<T> appendAll(Iterable<? extends T> iterable) {
@@ -818,7 +818,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public Vector<T> prepend(T element) { return prependAll(Iterator.of(element)); }
+    public Vector<T> prepend(T element) { return prependAll(List.of(element)); }
 
     @Override
     public Vector<T> prependAll(Iterable<? extends T> iterable) {

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -16,6 +16,7 @@ import java.util.stream.Collector;
 
 import static javaslang.collection.ArrayType.asArray;
 import static javaslang.collection.Collections.areEqual;
+import static javaslang.collection.Collections.withSize;
 
 /**
  * Vector is the default Seq implementation that provides effectively constant time access to any element.
@@ -568,8 +569,9 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     @Override
     public Vector<T> appendAll(Iterable<? extends T> iterable) {
         Objects.requireNonNull(iterable, "iterable is null");
-        return isEmpty() ? ofAll(iterable)
-                         : wrap(trie.appendAll(iterable));
+        return isEmpty()
+                ? ofAll(iterable)
+                : new Vector<>(trie.appendAll(iterable));
     }
 
     @Override
@@ -823,8 +825,9 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     @Override
     public Vector<T> prependAll(Iterable<? extends T> iterable) {
         Objects.requireNonNull(iterable, "iterable is null");
-        return isEmpty() ? ofAll(iterable)
-                         : wrap(trie.prependAll(iterable));
+        return isEmpty()
+                ? ofAll(iterable)
+                : new Vector<>(trie.prependAll(iterable));
     }
 
     @Override


### PR DESCRIPTION
Every modification is in a separate commit
```java
Ratios slang / <alternative_impl>
Target           Operation   Ratio                                 10     100    1026
VectorBenchmark  Create      slang_persistent/scala_persistent  7.26×   6.66×   6.39×
VectorBenchmark  Head        slang_persistent/scala_persistent  0.78×   0.62×   0.48×
VectorBenchmark  Tail        slang_persistent/scala_persistent  6.00×   7.30×   8.68×
VectorBenchmark  Get         slang_persistent/scala_persistent  1.08×   1.00×   0.71×
VectorBenchmark  Update      slang_persistent/scala_persistent  2.72×   2.93×   2.01×
VectorBenchmark  Map         slang_persistent/scala_persistent  1.38×   0.93×   1.31×
VectorBenchmark  Filter      slang_persistent/scala_persistent  1.16×   1.47×   1.23×
VectorBenchmark  Prepend     slang_persistent/scala_persistent  0.32×   0.32×   0.31×
VectorBenchmark  Append      slang_persistent/scala_persistent  0.76×   0.41×   0.34×
VectorBenchmark  AppendAll   slang_persistent/scala_persistent  4.21×   1.96×   1.71×
VectorBenchmark  GroupBy     slang_persistent/scala_persistent  1.58×   1.33×   1.14×
VectorBenchmark  Slice       slang_persistent/scala_persistent  4.94×   7.61×  10.43×
VectorBenchmark  Iterate     slang_persistent/scala_persistent  1.81×   1.37×   1.30×
```
i.e.  `append(All)`,`prepend(All)`, `slice`, `update` and `iterate` are faster now.