### PR TITLE
remove redundant type parameters

### DIFF
--- a/javaslang/src/main/java/javaslang/Value.java
+++ b/javaslang/src/main/java/javaslang/Value.java
@@ -525,7 +525,7 @@ public interface Value<T> extends Iterable<T> {
      *
      * @return A new {@link CompletableFuture} containing the value
      */
-     default <U extends T> CompletableFuture<T> toCompletableFuture() {
+     default CompletableFuture<T> toCompletableFuture() {
          final CompletableFuture<T> completableFuture = new CompletableFuture<>();
          try {
              completableFuture.complete(get());

--- a/javaslang/src/main/java/javaslang/concurrent/Future.java
+++ b/javaslang/src/main/java/javaslang/concurrent/Future.java
@@ -499,7 +499,7 @@ public interface Future<T> extends Value<T> {
     }
 
     @Override
-    default <U extends T> CompletableFuture<T> toCompletableFuture() {
+    default CompletableFuture<T> toCompletableFuture() {
         final CompletableFuture<T> future = new CompletableFuture<>();
         onSuccess(future::complete);
         onFailure(future::completeExceptionally);


### PR DESCRIPTION
Follow up on PR #1720 - remove unnecessary type parameters