### PR TITLE
Simplified a few `Vector` operations

### DIFF
--- a/javaslang/generator/Generator.scala
+++ b/javaslang/generator/Generator.scala
@@ -2297,7 +2297,6 @@ def generateMainClasses(): Unit = {
           /** Repeatedly group an array into equal sized sub-trees */
           default Object grouped(Object array, int groupSize) {
               final int arrayLength = lengthOf(array);
-              assert arrayLength > groupSize;
               final Object results = obj().newInstance(1 + ((arrayLength - 1) / groupSize));
               obj().setAt(results, 0, copyRange(array, 0, groupSize));
 
@@ -2351,19 +2350,8 @@ def generateMainClasses(): Unit = {
           }
 
           @SuppressWarnings("unchecked")
-          static <T> Object[] asArray(Iterable<? extends T> iterable) {
-              if (iterable instanceof Collection<?>) {
-                  final Collection<? extends T> collection = (Collection<? extends T>) iterable;
-                  return collection.toArray();
-              } else {
-                  return Collections.withSize(iterable).toArray();
-              }
-          }
-
-          @SuppressWarnings("unchecked")
           static <T> T asPrimitives(Class<?> primitiveClass, Iterable<?> values) {
               final Object[] array = Array.ofAll(values).toJavaArray();
-              assert (array.length == 0) || !primitiveClass.isArray();
               final ArrayType<T> type = of((Class<T>) primitiveClass);
               final Object results = type.newInstance(array.length);
               for (int i = 0; i < array.length; i++) {

--- a/javaslang/src-gen/main/java/javaslang/collection/ArrayType.java
+++ b/javaslang/src-gen/main/java/javaslang/collection/ArrayType.java
@@ -68,7 +68,6 @@ interface ArrayType<T> {
     /** Repeatedly group an array into equal sized sub-trees */
     default Object grouped(Object array, int groupSize) {
         final int arrayLength = lengthOf(array);
-        assert arrayLength > groupSize;
         final Object results = obj().newInstance(1 + ((arrayLength - 1) / groupSize));
         obj().setAt(results, 0, copyRange(array, 0, groupSize));
 
@@ -122,19 +121,8 @@ interface ArrayType<T> {
     }
 
     @SuppressWarnings("unchecked")
-    static <T> Object[] asArray(Iterable<? extends T> iterable) {
-        if (iterable instanceof Collection<?>) {
-            final Collection<? extends T> collection = (Collection<? extends T>) iterable;
-            return collection.toArray();
-        } else {
-            return Collections.withSize(iterable).toArray();
-        }
-    }
-
-    @SuppressWarnings("unchecked")
     static <T> T asPrimitives(Class<?> primitiveClass, Iterable<?> values) {
         final Object[] array = Array.ofAll(values).toJavaArray();
-        assert (array.length == 0) || !primitiveClass.isArray();
         final ArrayType<T> type = of((Class<T>) primitiveClass);
         final Object results = type.newInstance(array.length);
         for (int i = 0; i < array.length; i++) {

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -14,8 +14,8 @@ import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;
 
-import static javaslang.collection.ArrayType.asArray;
 import static javaslang.collection.Collections.areEqual;
+import static javaslang.collection.Collections.withSize;
 
 /**
  * Vector is the default Seq implementation that provides effectively constant time access to any element.
@@ -33,10 +33,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     private static final Vector<?> EMPTY = new Vector<>(BitMappedTrie.empty());
 
     final BitMappedTrie<T> trie;
-    private Vector(BitMappedTrie<T> trie) {
-        this.trie = trie;
-        assert (EMPTY == null) || (length() > 0);
-    }
+    private Vector(BitMappedTrie<T> trie) { this.trie = trie; }
 
     @SuppressWarnings("ObjectEquality")
     private Vector<T> wrap(BitMappedTrie<T> trie) {
@@ -161,8 +158,8 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
         if (iterable instanceof Vector) {
             return (Vector<T>) iterable;
         } else {
-            final BitMappedTrie<T> trie = BitMappedTrie.ofAll(asArray(iterable));
-            return ofAll(trie);
+            final Object[] values = withSize(iterable).toArray();
+            return ofAll(BitMappedTrie.ofAll(values));
         }
     }
 


### PR DESCRIPTION
This commit was meant to simplify things, not necessarily to optimize them
No real speed advantage was measured, only a minor improvement in `groupBy`.

Others:
* removed assertions
* separated big methods to smaller, inlinable methods (as suggested by JITWatch)