### PR TITLE
Proof of concept for Issue #1519

### DIFF
--- a/javaslang/src/main/java/javaslang/concurrent/Future.java
+++ b/javaslang/src/main/java/javaslang/concurrent/Future.java
@@ -28,6 +28,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.*;
 
+import static javaslang.API.Match;
+
 /**
  * A Future is a computation result that becomes available at some point. All operations provided are non-blocking.
  * <p>
@@ -755,7 +757,9 @@ public interface Future<T> extends Value<T> {
      * @return this Future
      */
     @SuppressWarnings({ "unchecked", "varargs" })
-    Future<T> onCompleteMatch(API.Match.Case<? extends Try<T>, Consumer<? super Try<T>>>... cases);
+    default Future<T> onCompleteMatch(API.Match.Case<? extends Try<T>, Consumer<? super Try<T>>>... cases){
+        return onComplete(result -> Match(result).option(cases).forEach(matchedConsumer -> matchedConsumer.accept(result)));
+    }
 
     /**
      * Performs the action once the Future is complete and the result is a {@link Try.Failure}. Please note that the
@@ -771,6 +775,18 @@ public interface Future<T> extends Value<T> {
     }
 
     /**
+     * Performs the action of matched case once the Future is failed.
+     *
+     * @param cases A cases containing actions, to match against future fail result.
+     * @return this Future
+     */
+    @SuppressWarnings({ "unchecked", "varargs" })
+    default Future<T> onFailureMatch(API.Match.Case<? extends Throwable, Consumer<? super Throwable>>... cases){
+        return onFailure(failure -> Match(failure).option(cases).forEach(matchedConsumer -> matchedConsumer.accept(failure)));
+    }
+
+
+    /**
      * Performs the action once the Future is complete and the result is a {@link Try.Success}.
      *
      * @param action An action to be performed when this future succeeded.
@@ -780,6 +796,17 @@ public interface Future<T> extends Value<T> {
     default Future<T> onSuccess(Consumer<? super T> action) {
         Objects.requireNonNull(action, "action is null");
         return onComplete(result -> result.onSuccess(action));
+    }
+
+    /**
+     * Performs the action of matched case once the Future is successful.
+     *
+     * @param cases A cases containing actions, to match against future success result.
+     * @return this Future
+     */
+    @SuppressWarnings({ "unchecked", "varargs" })
+    default Future<T> onSuccessMatch(API.Match.Case<? extends T, Consumer<? super T>>... cases){
+        return onSuccess(success -> Match(success).option(cases).forEach(matchedConsumer -> matchedConsumer.accept(success)));
     }
 
     /**

--- a/javaslang/src/main/java/javaslang/concurrent/Future.java
+++ b/javaslang/src/main/java/javaslang/concurrent/Future.java
@@ -5,6 +5,7 @@
  */
 package javaslang.concurrent;
 
+import javaslang.API;
 import javaslang.Tuple;
 import javaslang.Tuple2;
 import javaslang.Value;
@@ -746,6 +747,15 @@ public interface Future<T> extends Value<T> {
      * @throws NullPointerException if {@code action} is null.
      */
     Future<T> onComplete(Consumer<? super Try<T>> action);
+
+    /**
+     * Performs the action of matched case once the Future is complete.
+     *
+     * @param cases A cases containing actions, to match against future completion result.
+     * @return this Future
+     */
+    @SuppressWarnings({ "unchecked", "varargs" })
+    Future<T> onCompleteMatch(API.Match.Case<? extends Try<T>, Consumer<? super Try<T>>>... cases);
 
     /**
      * Performs the action once the Future is complete and the result is a {@link Try.Failure}. Please note that the

--- a/javaslang/src/main/java/javaslang/concurrent/FutureImpl.java
+++ b/javaslang/src/main/java/javaslang/concurrent/FutureImpl.java
@@ -15,8 +15,6 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
-import static javaslang.API.Match;
-
 /**
  * <strong>INTERNAL API - This class is subject to change.</strong>
  * <p>
@@ -165,12 +163,6 @@ final class FutureImpl<T> implements Future<T> {
             }
         }
         return this;
-    }
-
-    @SuppressWarnings({ "unchecked", "varargs" })
-    @SafeVarargs
-    public final Future<T> onCompleteMatch(Match.Case<? extends Try<T>, Consumer<? super Try<T>>>... cases) {
-        return onComplete(result -> Match(result).option(cases).forEach(matchedConsumer -> matchedConsumer.accept(result)));
     }
 
     // This class is MUTABLE and therefore CANNOT CHANGE DEFAULT equals() and hashCode() behavior.

--- a/javaslang/src/main/java/javaslang/concurrent/FutureImpl.java
+++ b/javaslang/src/main/java/javaslang/concurrent/FutureImpl.java
@@ -15,6 +15,8 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
+import static javaslang.API.Match;
+
 /**
  * <strong>INTERNAL API - This class is subject to change.</strong>
  * <p>
@@ -163,6 +165,12 @@ final class FutureImpl<T> implements Future<T> {
             }
         }
         return this;
+    }
+
+    @SuppressWarnings({ "unchecked", "varargs" })
+    @SafeVarargs
+    public final Future<T> onCompleteMatch(Match.Case<? extends Try<T>, Consumer<? super Try<T>>>... cases) {
+        return onComplete(result -> Match(result).option(cases).forEach(matchedConsumer -> matchedConsumer.accept(result)));
     }
 
     // This class is MUTABLE and therefore CANNOT CHANGE DEFAULT equals() and hashCode() behavior.

--- a/javaslang/src/test/java/javaslang/concurrent/FutureTest.java
+++ b/javaslang/src/test/java/javaslang/concurrent/FutureTest.java
@@ -21,9 +21,11 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.NoSuchElementException;
 import java.util.concurrent.*;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static javaslang.API.Case;
 import static javaslang.concurrent.Concurrent.waitUntil;
 import static javaslang.concurrent.Concurrent.zZz;
 import static javaslang.concurrent.ExecutorServices.rejectingExecutorService;
@@ -671,6 +673,53 @@ public class FutureTest extends AbstractValueTest {
         assertThat(actual[0]).isEqualTo(-1);
         future.onComplete(result -> actual[0] = result.get());
         assertThat(actual[0]).isEqualTo(1);
+    }
+
+    @Test
+    @SuppressWarnings({ "unchecked" })
+    public void shouldMatchCaseAfterFutureCompleted() {
+        final int[] actual = new int[] { -1 };
+        final Throwable[] holder = new Throwable[] { null };
+        final Consumer<Try<Integer>> successConsumer = success -> actual[0] = success.get();
+        final Consumer<Try<Integer>> failureConsumer = failed -> holder[0] = failed.getCause();
+
+        final Future<Integer> future = Future.of(trivialExecutorService(), () -> 1)
+                                             .onCompleteMatch(
+                                                     Case(Try::isSuccess, successConsumer),
+                                                     Case(Try::isFailure, failureConsumer)
+                                             );
+        waitUntil(future::isCompleted);
+        assertThat(actual[0]).isEqualTo(1);
+        assertThat(holder[0]).isNull();
+    }
+
+    @Test
+    @SuppressWarnings({ "unchecked" })
+    public void shouldMatchCaseAfterFutureCompletedWithFailure() {
+        final int[] actual = new int[] { -1 };
+        final Throwable[] holder = new Throwable[] { null };
+        final Consumer<Try<Integer>> successConsumer = x -> actual[0] = x.get();
+        final Consumer<Try<Integer>> failureConsumer = failed -> holder[0] = failed.getCause();
+
+        Try.CheckedSupplier<Integer> zZz = zZz(new Error());
+        final Future<Integer> future = Future.of(zZz)
+                                             .onCompleteMatch(
+                                                     Case(Try::isSuccess, successConsumer),
+                                                     Case(Try::isFailure, failureConsumer)
+                                             );
+        waitUntil(future::isCompleted);
+        assertThat(actual[0]).isEqualTo(-1);
+        assertThat(holder[0]).isNotNull();
+        assertThat(holder[0].getClass()).isEqualTo(Error.class);
+    }
+
+    @Test
+    @SuppressWarnings({ "unchecked" })
+    public void shouldNotThrowMatchErrorAfterFutureCompletedWithoutMatchedCase() {
+        final Future<Integer> future = Future.of(trivialExecutorService(), () -> 1)
+                                             .onCompleteMatch();
+        waitUntil(future::isCompleted);
+        assertCompleted(future, 1);
     }
 
     // -- onFailure()

--- a/javaslang/src/test/java/javaslang/concurrent/FutureTest.java
+++ b/javaslang/src/test/java/javaslang/concurrent/FutureTest.java
@@ -701,7 +701,7 @@ public class FutureTest extends AbstractValueTest {
         final Consumer<Try<Integer>> successConsumer = x -> actual[0] = x.get();
         final Consumer<Try<Integer>> failureConsumer = failed -> holder[0] = failed.getCause();
 
-        Try.CheckedSupplier<Integer> zZz = zZz(new Error());
+        final Try.CheckedSupplier<Integer> zZz = zZz(new Error());
         final Future<Integer> future = Future.of(zZz)
                                              .onCompleteMatch(
                                                      Case(Try::isSuccess, successConsumer),
@@ -733,6 +733,49 @@ public class FutureTest extends AbstractValueTest {
         assertThat(holder[0].getClass()).isEqualTo(Error.class);
     }
 
+    // -- onFailureMatch()
+
+    @Test
+    @SuppressWarnings({ "unchecked" })
+    public void shouldMatchFailCaseAfterFutureFails() {
+        final Throwable[] holder = new Throwable[] { null };
+        final Consumer<Throwable> errorConsumer = failed -> holder[0] = failed;
+
+        final Try.CheckedSupplier<Integer> zZz = zZz(new Error());
+        final Future<Integer> future = Future.of(zZz)
+                                             .onFailureMatch(
+                                                     Case(f -> f.getClass().equals(Exception.class), m -> {}),
+                                                     Case(f -> f.getClass().equals(Error.class), errorConsumer)
+                                             );
+        waitUntil(future::isCompleted);
+        assertThat(holder[0]).isNotNull();
+        assertThat(holder[0].getClass()).isEqualTo(Error.class);
+    }
+
+    @Test
+    @SuppressWarnings({ "unchecked" })
+    public void shouldNotMatchFailCaseAfterFutureFails() {
+        final Throwable[] holder = new Throwable[] { null };
+        final Consumer<Throwable> errorConsumer = failed -> holder[0] = failed;
+
+        final Try.CheckedSupplier<Integer> zZz = zZz(new Error());
+        final Future<Integer> future = Future.of(trivialExecutorService(), () -> 1)
+                                             .onFailureMatch(
+                                                     Case(f -> f.getClass().equals(Error.class), errorConsumer)
+                                             );
+        waitUntil(future::isCompleted);
+        assertThat(holder[0]).isNull();
+    }
+
+    @Test
+    @SuppressWarnings({ "unchecked" })
+    public void shouldNotThrowMatchErrorAfterFutureFailsWithoutMatchedCase() {
+        final Try.CheckedSupplier<Integer> zZz = zZz(new Error());
+        final Future<Integer> future = Future.of(zZz);
+        waitUntil(future::isCompleted);
+        assertFailed(future, Error.class);
+    }
+
     // -- onSuccess()
 
     @Test
@@ -742,6 +785,46 @@ public class FutureTest extends AbstractValueTest {
         future.onSuccess(i -> holder[0] = i);
         waitUntil(() -> holder[0] > 0);
         assertThat(holder[0]).isEqualTo(42);
+    }
+
+    @Test
+    @SuppressWarnings({ "unchecked" })
+    public void shouldMatchSuccessCaseAfterFutureSucceeds() {
+        final int[] actual = new int[] { -1 };
+        final Consumer<Integer> valueConsumer = value -> actual[0] = value;
+
+        final Future<Integer> future = Future.of(trivialExecutorService(), () -> 1)
+                                             .onSuccessMatch(
+                                                     Case(v -> v == 5, m -> {}),
+                                                     Case(v -> v == 1, valueConsumer)
+                                             );
+        waitUntil(future::isCompleted);
+        assertThat(actual[0]).isEqualTo(1);
+    }
+
+    @Test
+    @SuppressWarnings({ "unchecked" })
+    public void shouldNotMatchSuccessCaseAfterFutureFails() {
+        final int[] actual = new int[] { -1 };
+        final Consumer<Integer> valueConsumer = value -> actual[0] = value;
+
+        final Try.CheckedSupplier<Integer> zZz = zZz(new Error());
+        final Future<Integer> future = Future.of(zZz)
+                                             .onSuccessMatch(
+                                                     Case(v -> v == 1, valueConsumer)
+                                             );
+        waitUntil(future::isCompleted);
+        assertFailed(future, Error.class);
+        assertThat(actual[0]).isEqualTo(-1);
+    }
+
+    @Test
+    @SuppressWarnings({ "unchecked" })
+    public void shouldNotThrowMatchErrorAfterFutureSucceedsWithoutMatchedCase() {
+        final Future<Integer> future = Future.of(trivialExecutorService(), () -> 1)
+                                             .onSuccessMatch();
+        waitUntil(future::isCompleted);
+        assertCompleted(future, 1);
     }
 
     // -- recover()


### PR DESCRIPTION
I was not able to get the same types as in examples provided in issue #1519, due to fact that I was not able to get `Case(Failure($()), thrown -> {...});` compiling in FutureTest.

I needed to name methods differently (`onCompleteMatch`, `onFailureMatch`, onSuccessMatch`) to avoid ambiguity warning during compilation.