### PR TITLE
Try extended with function recoverOption

### DIFF
--- a/javaslang/src/main/java/javaslang/control/Try.java
+++ b/javaslang/src/main/java/javaslang/control/Try.java
@@ -578,6 +578,7 @@ public interface Try<T> extends Value<T> {
         return this;
     }
 
+    @GwtIncompatible
     default <X extends Throwable> Try<T> recoverWith(Class<X> exception,  Try<? extends T> recovered){
         return (isFailure() && exception.isAssignableFrom(getCause().getClass()))
                 ? narrow(recovered)

--- a/javaslang/src/test/java/javaslang/control/TryTest.java
+++ b/javaslang/src/test/java/javaslang/control/TryTest.java
@@ -947,23 +947,33 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldNotTryToRecoverWhenItIsNotNeeded(){
-        assertThat(Try.of(() -> OK).recoverOption(RuntimeException.class, (ex) -> Option.of(FAILURE)).get()).isEqualTo(OK);
+        assertThat(Try.of(() -> OK).recoverWith(RuntimeException.class, (ex) -> failure()).get()).isEqualTo(OK);
     }
 
     @Test(expected = NonFatalException.class)
     public void shouldReturnExceptionWhenRecoveryWasNotSuccess(){
-        Try.of(() -> {throw error();}).recoverOption(IOException.class, (ex) -> Option.none()).get();
+        Try.of(() -> {throw error();}).recoverWith(IOException.class, (ex) -> failure()).get();
     }
 
     @Test
     public void shouldReturnRecoveredValue(){
-        assertThat(Try.of(() -> {throw error();}).recoverOption(RuntimeException.class, (ex) -> Option.of(OK)).get()).isEqualTo(OK);
+        assertThat(Try.of(() -> {throw error();}).recoverWith(RuntimeException.class, (ex) -> success()).get()).isEqualTo(OK);
     }
 
     @Test
     public void shouldHandleErrorDuringRecovering(){
-        Try<?> t = Try.of(() -> {throw new IllegalArgumentException(OK);}).recoverOption(IOException.class, (ex) -> { throw new IllegalStateException(FAILURE);});
+        Try<?> t = Try.of(() -> {throw new IllegalArgumentException(OK);}).recoverWith(IOException.class, (ex) -> { throw new IllegalStateException(FAILURE);});
          assertThatThrownBy(t::get).hasRootCauseExactlyInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void shouldNotReturnRecoveredValueOnSuccess(){
+        assertThat(Try.of(() -> OK).recoverWith(IOException.class, failure()).get()).isEqualTo(OK);
+    }
+
+    @Test
+    public void shouldReturnRecoveredValueOnFailure(){
+        assertThat(Try.of(() -> {throw new IllegalStateException(FAILURE);}).recoverWith(IllegalStateException.class, success()).get()).isEqualTo(OK);
     }
 
     // -- helpers


### PR DESCRIPTION
I extended the Try class with the recoverOption method. The method has two parameters: exception class and function which accepts exception object and returns Option. The new method is very similar to the javaslang.control.Try#recover(java.lang.Class<X>, java.util.function.Function<? super X,? extends T>) but the new function is more convenient for me because it returns Option<T>. 

The new method solves my problems which occurs when I work with Try and Spring RestTemplate. RestTemplate throws HttpClientErrorException with HTTP response status code. If the status code is equal to 401 I am able to recover it and my recovery function can return not empty Option. But if the response code is equal to e.g. 403 the recovery function is not able to do its job and in this case it returns empty Option.