### PR TITLE
Added overloaded forEach to Value - accepts ifEmptyAction param.

### DIFF
--- a/javaslang/src/main/java/javaslang/Value.java
+++ b/javaslang/src/main/java/javaslang/Value.java
@@ -148,6 +148,7 @@ import static javaslang.API.*;
  *
  * @param <T> The type of the wrapped value.
  * @author Daniel Dietrich
+ * @author Maciej Opala
  * @since 2.0.0
  */
 public interface Value<T> extends Iterable<T> {
@@ -314,6 +315,26 @@ public interface Value<T> extends Iterable<T> {
         Objects.requireNonNull(action, "action is null");
         for (T t : this) {
             action.accept(t);
+        }
+    }
+
+    /**
+     * Performs an action on each element if this element is defined, otherwise invokes ifEmptyAction
+     *
+     * @param action action {@code Consumer}
+     * @param action ifEmptyAction {@code java.lang.Runnable}
+     * @throws NullPointerException if {@code action} is null
+     * @throws NullPointerException if {@code ifEmptyAction} is null
+     */
+    default void forEach(Consumer<? super T> action, Runnable ifEmptyAction) {
+        Objects.requireNonNull(action, "action is null");
+        Objects.requireNonNull(ifEmptyAction, "ifEmptyAction is null");
+        if (isEmpty()) {
+            ifEmptyAction.run();
+        } else {
+            for (T t : this) {
+                action.accept(t);
+            }
         }
     }
 

--- a/javaslang/src/test/java/javaslang/AbstractValueTest.java
+++ b/javaslang/src/test/java/javaslang/AbstractValueTest.java
@@ -39,6 +39,7 @@ import java.util.function.Supplier;
 import static javaslang.API.*;
 import static javaslang.Serializables.deserialize;
 import static javaslang.Serializables.serialize;
+import static org.junit.Assert.fail;
 
 public abstract class AbstractValueTest {
 
@@ -188,6 +189,34 @@ public abstract class AbstractValueTest {
         final Value<Integer> value = of(1, 2, 3);
         value.forEach(i -> consumer[0] += i);
         assertThat(consumer[0]).isEqualTo(value.isSingleValued() ? 1 : 6);
+    }
+
+    @Test
+    public void shouldNotCallIfEmptyActionIfValueIsNotEmpty() {
+        try {
+            final int[] consumer = new int[1];
+            final Value<Integer> value = of(1, 2, 3);
+            value.forEach(i -> consumer[0] += i, () -> {
+                throw new RuntimeException("should not be thrown");
+            });
+            assertThat(consumer[0]).isEqualTo(value.isSingleValued() ? 1 : 6);
+        } catch (RuntimeException e) {
+            fail("No exception should be thrown!");
+        }
+    }
+
+    @Test
+    public void shouldCallIfEmptyActionIfValueIsEmpty() {
+        try {
+            final Value<Integer> value = Option.none();
+            value.forEach(val -> {
+            }, () -> {
+                throw new RuntimeException("Empty value!");
+            });
+            fail("Should not get here!!");
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage()).isEqualTo("Empty value!");
+        }
     }
 
     // -- isEmpty


### PR DESCRIPTION
Hi,

I've provided an overloaded version of `Value`'s `forEach`. It accepts two arguments:
- an action to be run if `Value` is not empty
- another action to be run if `Value` is empty