### PR TITLE
Implemented `transpose` in `Seq`

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/Array.java
+++ b/javaslang/src/main/java/javaslang/collection/Array.java
@@ -554,6 +554,21 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
         return Iterator.unfold(seed, f).toArray();
     }
 
+    /**
+     * Transposes the rows and columns of an {@link Array}.
+     *
+     * @param rows to be transposed.
+     * @return a transposed {@link Array}.
+     * <p>
+     * ex: {@code
+     * Array.transpose(Array(Array(1,2,3), Array(4,5,6))) → Array(Array(1,4), Array(2,5), Array(3,6))
+     * Array.transpose(Array(Array(1,2), Array(3))) → Array(Array(1,3), Array(2))
+     * }
+     */
+    static <T> Array<Array<T>> transpose(Array<Array<T>> rows) {
+        return Collections.transpose(rows, Array::ofAll);
+    }
+
     @Override
     public Array<T> append(T element) {
         final Object[] copy = copyOf(delegate, delegate.length + 1);
@@ -1048,11 +1063,15 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
 
     @Override
     public Array<T> reverse() {
-        final Object[] arr = new Object[delegate.length];
-        for (int i = 0; i < delegate.length; i++) {
-            arr[delegate.length - 1 - i] = delegate[i];
+        if (size() <= 1) {
+            return this;
+        } else {
+            final Object[] arr = new Object[delegate.length];
+            for (int i = 0; i < delegate.length; i++) {
+                arr[delegate.length - 1 - i] = delegate[i];
+            }
+            return wrap(arr);
         }
-        return wrap(arr);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/Array.java
+++ b/javaslang/src/main/java/javaslang/collection/Array.java
@@ -1066,9 +1066,10 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
         if (size() <= 1) {
             return this;
         } else {
-            final Object[] arr = new Object[delegate.length];
-            for (int i = 0; i < delegate.length; i++) {
-                arr[delegate.length - 1 - i] = delegate[i];
+            final int length = delegate.length;
+            final Object[] arr = new Object[length];
+            for (int i = 0, j = length - 1; i < length; i++, j--) {
+                arr[j] = delegate[i];
             }
             return wrap(arr);
         }

--- a/javaslang/src/main/java/javaslang/collection/Collections.java
+++ b/javaslang/src/main/java/javaslang/collection/Collections.java
@@ -91,6 +91,7 @@ final class Collections {
         return results;
 
     }
+
     private static <T, C> java.util.Set<java.util.Map.Entry<C, Collection<T>>> groupBy(Traversable<T> source, Function<? super T, ? extends C> classifier) {
         final java.util.Map<C, Collection<T>> results = new java.util.LinkedHashMap<>(source.isTraversableAgain() ? source.size() : 16);
         for (T value : source) {
@@ -286,5 +287,31 @@ final class Collections {
         } else {
             return new IterableWithSize<>(iterable, ((Traversable<?>) iterable).size());
         }
+    }
+
+    static <T, U extends Iterable<? extends Iterable<T>>> U transpose(U source, Function<Iterable<?>, Iterable<?>> mapper) {
+        if (source.iterator().hasNext()) {
+            return transposeIterables(source, mapper);
+        } else {
+            return source;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T, U extends Iterable<? extends Iterable<T>>> U transposeIterables(U source, Function<Iterable<?>, Iterable<?>> mapper) {
+        final ArrayList<ArrayList<T>> results = new ArrayList<>();
+
+        for (Iterable<T> row : source) {
+            int c = 0;
+            for (T element : row) {
+                if (results.size() == c) {
+                    results.add(new ArrayList<T>());
+                }
+                results.get(c).add(element);
+                c++;
+            }
+        }
+
+        return (U) mapper.apply(Iterator.ofAll(results).map(mapper::apply));
     }
 }

--- a/javaslang/src/main/java/javaslang/collection/List.java
+++ b/javaslang/src/main/java/javaslang/collection/List.java
@@ -656,6 +656,21 @@ public interface List<T> extends Kind1<List<?>, T>, LinearSeq<T>, Stack<T> {
         return Iterator.unfold(seed, f).toList();
     }
 
+    /**
+     * Transposes the rows and columns of a {@link List}.
+     *
+     * @param rows to be transposed.
+     * @return a transposed {@link List}.
+     * <p>
+     * ex: {@code
+     * List.transpose(List(List(1,2,3), List(4,5,6))) → List(List(1,4), List(2,5), List(3,6))
+     * List.transpose(List(List(1,2), List(3))) → List(List(1,3), List(2))
+     * }
+     */
+    static <T> List<List<T>> transpose(List<List<T>> rows) {
+        return Collections.transpose(rows, List::ofAll);
+    }
+
     @Override
     default List<T> append(T element) {
         return foldRight(of(element), (x, xs) -> xs.prepend(x));

--- a/javaslang/src/main/java/javaslang/collection/Queue.java
+++ b/javaslang/src/main/java/javaslang/collection/Queue.java
@@ -503,6 +503,21 @@ public final class Queue<T> extends AbstractsQueue<T, Queue<T>> implements Linea
     }
 
     /**
+     * Transposes the rows and columns of a {@link Queue}.
+     *
+     * @param rows to be transposed.
+     * @return a transposed {@link Queue}.
+     * <p>
+     * ex: {@code
+     * Queue.transpose(Queue(Queue(1,2,3), Queue(4,5,6))) → Queue(Queue(1,4), Queue(2,5), Queue(3,6))
+     * Queue.transpose(Queue(Queue(1,2), Queue(3))) → Queue(Queue(1,3), Queue(2))
+     * }
+     */
+    public static <T> Queue<Queue<T>> transpose(Queue<Queue<T>> rows) {
+        return Collections.transpose(rows, Queue::ofAll);
+    }
+
+    /**
      * Creates a Queue from a seed value and a function.
      * The function takes the seed at first.
      * The function should return {@code None} when it's

--- a/javaslang/src/main/java/javaslang/collection/Stream.java
+++ b/javaslang/src/main/java/javaslang/collection/Stream.java
@@ -750,6 +750,21 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
     }
 
     /**
+     * Transposes the rows and columns of a {@link Stream}.
+     *
+     * @param rows to be transposed.
+     * @return a transposed {@link Stream}.
+     * <p>
+     * ex: {@code
+     * Stream.transpose(Stream(Stream(1,2,3), Stream(4,5,6))) → Stream(Stream(1,4), Stream(2,5), Stream(3,6))
+     * Stream.transpose(Stream(Stream(1,2), Stream(3))) → Stream(Stream(1,3), Stream(2))
+     * }
+     */
+    static <T> Stream<Stream<T>> transpose(Stream<Stream<T>> rows) {
+        return Collections.transpose(rows, Stream::ofAll);
+    }
+
+    /**
      * Repeats an element infinitely often.
      *
      * @param t   An element

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -567,6 +567,21 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
         return Iterator.unfold(seed, f).toVector();
     }
 
+    /**
+     * Transposes the rows and columns of a {@link Vector}.
+     *
+     * @param rows to be transposed.
+     * @return a transposed {@link Vector}.
+     * <p>
+     * ex: {@code
+     * Vector.transpose(Vector(Vector(1,2,3), Vector(4,5,6))) → Vector(Vector(1,4), Vector(2,5), Vector(3,6))
+     * Vector.transpose(Vector(Vector(1,2), Vector(3))) → Vector(Vector(1,3), Vector(2))
+     * }
+     */
+    public static <T> Vector<Vector<T>> transpose(Vector<Vector<T>> rows) {
+        return Collections.transpose(rows, Vector::ofAll);
+    }
+
     @Override
     public Vector<T> append(T element) { return appendAll(List.of(element)); }
 

--- a/javaslang/src/test/java/javaslang/collection/AbstractSeqTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractSeqTest.java
@@ -106,6 +106,8 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Override
     abstract protected Seq<Long> rangeClosedBy(long from, long toInclusive, long step);
 
+    abstract protected <T> Seq<? extends Seq<T>> transpose(Seq<? extends Seq<T>> rows);
+
     // -- static narrow
 
     @Test
@@ -1799,5 +1801,132 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
         assertThat(withDef.apply(2)).isEqualTo("c");
         assertThat(withDef.apply(-1)).isEqualTo("-1");
         assertThat(withDef.apply(3)).isEqualTo("3");
+    }
+
+    // -- transpose()
+
+    @Test
+    public void shouldTransposeIfEmpty() {
+        final Seq<Seq<Integer>> actual = empty();
+        assertThat(transpose(actual)).isSameAs(actual);
+    }
+
+    @Test
+    public void shouldTransposeIfSingleValued() {
+        final Seq<Seq<Integer>> actual = of(of(0));
+        final Seq<Seq<Integer>> expected = of(of(0));
+        assertThat(transpose(actual)).isEqualTo(expected);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldTransposeIfMultiValuedColumn() {
+        final Seq<Seq<Integer>> actual = of(of(0, 1, 2));
+        final Seq<Seq<Integer>> expected = of(of(0), of(1), of(2));
+        assertThat(transpose(actual)).isEqualTo(expected);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldTransposeIfMultiValuedRow() {
+        final Seq<Seq<Integer>> actual = of(of(0), of(1), of(2));
+        final Seq<Seq<Integer>> expected = of(of(0, 1, 2));
+        assertThat(transpose(actual)).isEqualTo(expected);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldTransposeIfMultiValuedIfSymmetric() {
+        Seq<Seq<Integer>> actual = of(
+                of(1, 2, 3),
+                of(4, 5, 6),
+                of(7, 8, 9));
+        Seq<Seq<Integer>> expected = of(
+                of(1, 4, 7),
+                of(2, 5, 8),
+                of(3, 6, 9));
+        assertThat(transpose(actual)).isEqualTo(expected);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldTransposeIfMultiValuedWithMoreColumnsThanRows() {
+        Seq<Seq<Integer>> actual = of(
+                of(1, 2, 3),
+                of(4, 5, 6));
+        Seq<Seq<Integer>> expected = of(
+                of(1, 4),
+                of(2, 5),
+                of(3, 6));
+        assertThat(transpose(actual)).isEqualTo(expected);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldTransposeIfMultiValuedWithMoreRowsThanColumns() {
+        Seq<Seq<Integer>> actual = of(
+                of(1, 2),
+                of(3, 4),
+                of(5, 6));
+        Seq<Seq<Integer>> expected = of(
+                of(1, 3, 5),
+                of(2, 4, 6));
+        assertThat(transpose(actual)).isEqualTo(expected);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldBeEqualIfTransposedTwiceWithNoMissingValues() {
+        Seq<Seq<Integer>> actual = of(
+                of(1, 2, 3),
+                of(4, 5, 6));
+        Seq<Seq<Integer>> transposedOnce = of(
+                of(1, 4),
+                of(2, 5),
+                of(3, 6));
+        assertThat(transpose(transposedOnce)).isEqualTo(actual);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldNotBeEqualIfTransposedTwiceWithMissingValues() {
+        Seq<Seq<Integer>> actual = of(
+                of(1, 2),
+                of(3, 4, 5));
+        Seq<Seq<Integer>> transposedOnce = of(
+                of(1, 3),
+                of(2, 4),
+                of(5));
+        assertThat(transpose(transposedOnce)).isNotEqualTo(actual);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldTransposeIfMissingValues() {
+        Seq<Seq<Integer>> actual = of(
+                of(1),
+                of(2, 3),
+                of(4));
+        Seq<Seq<Integer>> expected = of(
+                of(1, 2, 4),
+                of(3));
+        assertThat(transpose(actual)).isEqualTo(expected);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldTransposeIfMissingAndEmptyValues() {
+        Seq<Seq<Integer>> actual = of(
+                of(),
+                of(0, 1),
+                of(2, 3, 4, 5),
+                of(),
+                of(6, 7, 8));
+        Seq<Seq<Integer>> expected = of(
+                of(0, 2, 6),
+                of(1, 3, 7),
+                of(4, 8),
+                of(5));
+        assertThat(transpose(actual)).isEqualTo(expected);
     }
 }

--- a/javaslang/src/test/java/javaslang/collection/ArrayTest.java
+++ b/javaslang/src/test/java/javaslang/collection/ArrayTest.java
@@ -177,6 +177,12 @@ public class ArrayTest extends AbstractIndexedSeqTest {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
+    protected <T> Array<Array<T>> transpose(Seq<? extends Seq<T>> rows) {
+        return Array.transpose((Array<Array<T>>) rows);
+    }
+
+    @Override
     protected int getPeekNonNilPerformingAnAction() {
         return 1;
     }

--- a/javaslang/src/test/java/javaslang/collection/ListTest.java
+++ b/javaslang/src/test/java/javaslang/collection/ListTest.java
@@ -183,6 +183,12 @@ public class ListTest extends AbstractLinearSeqTest {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
+    protected <T> List<List<T>> transpose(Seq<? extends Seq<T>> rows) {
+        return List.transpose((List<List<T>>) rows);
+    }
+
+    @Override
     protected int getPeekNonNilPerformingAnAction() {
         return 1;
     }

--- a/javaslang/src/test/java/javaslang/collection/QueueTest.java
+++ b/javaslang/src/test/java/javaslang/collection/QueueTest.java
@@ -181,6 +181,12 @@ public class QueueTest extends AbstractLinearSeqTest {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
+    protected <T> Queue<Queue<T>> transpose(Seq<? extends Seq<T>> rows) {
+        return Queue.transpose((Queue<Queue<T>>) rows);
+    }
+
+    @Override
     protected int getPeekNonNilPerformingAnAction() {
         return 1;
     }

--- a/javaslang/src/test/java/javaslang/collection/StreamTest.java
+++ b/javaslang/src/test/java/javaslang/collection/StreamTest.java
@@ -183,6 +183,12 @@ public class StreamTest extends AbstractLinearSeqTest {
         return Stream.rangeClosedBy(from, toInclusive, step);
     }
 
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <T> Stream<Stream<T>> transpose(Seq<? extends Seq<T>> rows) {
+        return Stream.transpose((Stream<Stream<T>>) rows);
+    }
+
     // -- static concat()
 
     @Test

--- a/javaslang/src/test/java/javaslang/collection/VectorTest.java
+++ b/javaslang/src/test/java/javaslang/collection/VectorTest.java
@@ -187,6 +187,12 @@ public class VectorTest extends AbstractIndexedSeqTest {
         return Vector.rangeClosedBy(from, toInclusive, step);
     }
 
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <T> Vector<Vector<T>> transpose(Seq<? extends Seq<T>> rows) {
+        return Vector.transpose((Vector<Vector<T>>) rows);
+    }
+
     // -- static narrow
 
     @Test


### PR DESCRIPTION
Fixes: https://github.com/javaslang/javaslang/issues/1659
Note: ~I only implemented it in `Array`, `List` and `Vector`. It made no sense for all Traversables to have it, but if you want, I can implement it in others too. Since I found no common interface for these three, I had to implement it in each one separately.~
I implemented it in `Seq` except `CharSeq` because this would need a different implementation.