### PR TITLE
HashArrayMappedTrie.equals() fixed #1815

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/HashArrayMappedTrie.java
+++ b/javaslang/src/main/java/javaslang/collection/HashArrayMappedTrie.java
@@ -236,7 +236,19 @@ interface HashArrayMappedTrieModule {
                 return true;
             } else if (o instanceof HashArrayMappedTrie) {
                 final HashArrayMappedTrie<Object, ?> that = (HashArrayMappedTrie<Object, ?>) o;
-                return (this.size() == that.size()) && Collections.areEqual(this, that);
+                if (this.size() == that.size()) {
+                    final java.util.Iterator<Tuple2<K, V>> it = iterator();
+                    while (it.hasNext()) {
+                        Tuple2<K, V> thisEntry = it.next();
+                        Option<?> thatValue = that.get(thisEntry._1);
+                        if (!thatValue.isDefined() || !thatValue.get().equals(thisEntry._2)) {
+                            return false;
+                        }
+                    }
+                    return true;
+                } else {
+                    return false;
+                }
             } else {
                 return false;
             }

--- a/javaslang/src/test/java/javaslang/collection/HashArrayMappedTrieTest.java
+++ b/javaslang/src/test/java/javaslang/collection/HashArrayMappedTrieTest.java
@@ -142,6 +142,13 @@ public class HashArrayMappedTrieTest {
         assertThat(of(1, 2).equals(of(1, 2, 3))).isFalse();
     }
 
+    @Test
+    public void shouldEqualsIgnoreOrder() {
+        HashArrayMappedTrie<String, Integer> map = HashArrayMappedTrie.<String, Integer> empty().put("Aa", 1).put("BB", 2);
+        HashArrayMappedTrie<String, Integer> map2 = HashArrayMappedTrie.<String, Integer> empty().put("BB", 2).put("Aa", 1);
+        assertThat(map).isEqualTo(map2);
+    }
+
     // -- hashCode
 
     @Test


### PR DESCRIPTION
Different keys with same hashCodes can come in random order, so we can't use `Collections.areEqual(this, that)` here