### PR TITLE
Optimized `Vector` sorting

### DIFF
--- a/javaslang-benchmark/pom.xml
+++ b/javaslang-benchmark/pom.xml
@@ -30,8 +30,8 @@
         <dependency>
             <groupId>org.scalaz</groupId>
             <artifactId>scalaz-core_2.12</artifactId>
-            <version>7.3.0-M6</version>
-            <!--contains scala-library 2.12.0-->
+            <version>7.3.0-M8</version>
+            <!--contains scala-library 2.12.1-->
         </dependency>
         <dependency>
             <groupId>org.clojure</groupId>
@@ -45,7 +45,7 @@
         </dependency>
         <dependency>
             <groupId>org.functionaljava</groupId>
-            <artifactId>functionaljava</artifactId>
+            <artifactId>functionaljava-java8</artifactId>
             <version>4.6</version>
         </dependency>
         <dependency>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
-            <version>0.6</version>
+            <version>0.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>

--- a/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java
@@ -675,6 +675,23 @@ public class VectorBenchmark {
     }
 
     public static class PrependAll extends Base {
+        final CanBuildFrom canBuildFrom = scala.collection.immutable.Vector.canBuildFrom();
+
+        @Benchmark
+        public void scala_persistent(Blackhole bh) {
+            for (int i = 0; i < CONTAINER_SIZE; i++) {
+                final java.util.List<Integer> front = javaMutable.subList(0, i);
+                final scala.collection.immutable.Vector<Integer> back = scalaPersistent.slice(i, CONTAINER_SIZE);
+
+                scala.collection.immutable.Vector<Integer> values = back;
+                for (int j = front.size() - 1; j >= 0; j--) {
+                    values = values.appendFront(front.get(j));
+                }
+                assert areEqual(asJavaCollection(values), javaMutable);
+                bh.consume(values);
+            }
+        }
+
         @Benchmark
         public void slang_persistent(Blackhole bh) {
             for (int i = 0; i < CONTAINER_SIZE; i++) {

--- a/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/collection/VectorBenchmark.java
@@ -11,7 +11,10 @@ import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 import scala.collection.generic.CanBuildFrom;
+import scala.math.Ordering;
+import scala.math.Ordering$;
 
+import java.util.Comparator;
 import java.util.Objects;
 import java.util.Random;
 
@@ -21,6 +24,7 @@ import static java.util.stream.Collectors.toList;
 import static javaslang.JmhRunner.Includes.*;
 import static javaslang.JmhRunner.*;
 import static javaslang.collection.Collections.areEqual;
+import static javaslang.collection.Vector.collector;
 import static scala.collection.JavaConversions.asJavaCollection;
 import static scala.collection.JavaConversions.asScalaBuffer;
 
@@ -41,6 +45,7 @@ public class VectorBenchmark {
             Insert.class,
             GroupBy.class,
             Slice.class,
+            Sort.class,
             Iterate.class
     );
 
@@ -875,6 +880,45 @@ public class VectorBenchmark {
                 values = values.slice(0, values.size() - 1);
                 bh.consume(values);
             }
+        }
+    }
+
+    public static class Sort extends Base {
+        static final Ordering<Integer> SCALA_ORDERING = Ordering$.MODULE$.comparatorToOrdering(Integer::compareTo);
+
+        @State(Scope.Thread)
+        public static class Initialized {
+            final java.util.ArrayList<Integer> javaMutable = new java.util.ArrayList<>();
+
+            @Setup(Level.Invocation)
+            public void initializeMutable(Base state) {
+                java.util.Collections.addAll(javaMutable, state.ELEMENTS);
+                assert areEqual(javaMutable, asList(state.ELEMENTS));
+            }
+
+            @TearDown(Level.Invocation)
+            public void tearDown() { javaMutable.clear(); }
+        }
+
+        @Benchmark
+        public Object java_mutable(Initialized state) {
+            state.javaMutable.sort(Comparator.naturalOrder());
+            assert areEqual(state.javaMutable, slangPersistent.sorted());
+            return state.javaMutable;
+        }
+
+        @Benchmark
+        public Object scala_persistent() {
+            final scala.collection.Seq<Integer> results = (scala.collection.Seq<Integer>) scalaPersistent.sorted(SCALA_ORDERING);
+            assert areEqual(asJavaCollection(results), slangPersistent.sorted());
+            return results;
+        }
+
+        @Benchmark
+        public Object slang_persistent() {
+            final Vector<Integer> results = slangPersistent.sorted();
+            assert areEqual(results, slangPersistent.toJavaStream().sorted().collect(collector()));
+            return results;
         }
     }
 

--- a/javaslang/src/main/java/javaslang/Value.java
+++ b/javaslang/src/main/java/javaslang/Value.java
@@ -1234,8 +1234,8 @@ public interface Value<T> extends Iterable<T> {
 }
 
 interface ValueModule {
-    static <T extends Traversable<V>, V>
-    T toTraversable(Value<V> value, T empty, Function<V, T> ofElement, Function<Iterable<V>, T> ofAll) {
+    static <T extends Traversable<V>, V> T toTraversable(
+            Value<V> value, T empty, Function<V, T> ofElement, Function<Iterable<V>, T> ofAll) {
         if (value.isEmpty()) {
             return empty;
         } else if (value.isSingleValued()) {
@@ -1245,8 +1245,8 @@ interface ValueModule {
         }
     }
 
-    static <T, K, V, M extends Map<K, V>, TT extends Tuple2<? extends K, ? extends V>>
-    M toMap(Value<T> value, M empty, Function<TT, M> ofElement, Function<Iterable<TT>, M> ofAll, Function<? super T, ? extends TT> f) {
+    static <T, K, V, M extends Map<K, V>, TT extends Tuple2<? extends K, ? extends V>> M toMap(
+            Value<T> value, M empty, Function<TT, M> ofElement, Function<Iterable<TT>, M> ofAll, Function<? super T, ? extends TT> f) {
         if (value.isEmpty()) {
             return empty;
         } else if (value.isSingleValued()) {
@@ -1256,8 +1256,8 @@ interface ValueModule {
         }
     }
 
-    static <T extends java.util.Collection<V>, V>
-    T toJavaCollection(Value<V> value, Function<Integer, T> containerSupplier) {
+    static <T extends java.util.Collection<V>, V> T toJavaCollection(
+            Value<V> value, Function<Integer, T> containerSupplier) {
         final int size = (value instanceof Traversable) && ((Traversable) value).isTraversableAgain()
                 ? ((Traversable<V>) value).size()
                 : 16;

--- a/javaslang/src/main/java/javaslang/Value.java
+++ b/javaslang/src/main/java/javaslang/Value.java
@@ -24,7 +24,6 @@ import javaslang.control.Validation;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Objects;
@@ -584,7 +583,17 @@ public interface Value<T> extends Iterable<T> {
      * @return A new Java array.
      */
     default Object[] toJavaArray() {
-        return toJavaList().toArray();
+        if ((this instanceof Traversable<?>) && ((Traversable<?>) this).isTraversableAgain()) {
+            final Object[] results = new Object[((Traversable<T>) this).size()];
+            final Iterator<T> iter = iterator();
+            for (int i = 0; i < results.length; i++) {
+                results[i] = iter.next();
+            }
+            return results;
+
+        } else {
+            return toJavaList().toArray();
+        }
     }
 
     /**
@@ -1225,11 +1234,8 @@ public interface Value<T> extends Iterable<T> {
 }
 
 interface ValueModule {
-
-    @SuppressWarnings("unchecked")
-    static <T extends Traversable<V>, V> T toTraversable(Value<V> value, T empty,
-            Function<V, T> ofElement,
-            Function<Iterable<V>, T> ofAll) {
+    static <T extends Traversable<V>, V>
+    T toTraversable(Value<V> value, T empty, Function<V, T> ofElement, Function<Iterable<V>, T> ofAll) {
         if (value.isEmpty()) {
             return empty;
         } else if (value.isSingleValued()) {
@@ -1239,12 +1245,8 @@ interface ValueModule {
         }
     }
 
-    static <T, K, V, M extends Map<K, V>, TT extends Tuple2<? extends K, ? extends V>> M toMap(
-            Value<T> value, M empty,
-            Function<TT, M> ofElement,
-            Function<Iterable<TT>, M> ofAll,
-            Function<? super T, ? extends TT> f
-    ) {
+    static <T, K, V, M extends Map<K, V>, TT extends Tuple2<? extends K, ? extends V>>
+    M toMap(Value<T> value, M empty, Function<TT, M> ofElement, Function<Iterable<TT>, M> ofAll, Function<? super T, ? extends TT> f) {
         if (value.isEmpty()) {
             return empty;
         } else if (value.isSingleValued()) {
@@ -1254,22 +1256,13 @@ interface ValueModule {
         }
     }
 
-    static <T extends java.util.Collection<V>, V> T toJavaCollection(Value<V> value, Function<Integer, T> containerSupplier) {
-        final T container;
-        if (value.isEmpty()) {
-            container = containerSupplier.apply(0);
-        } else {
-            if (value.isSingleValued()) {
-                container = containerSupplier.apply(1);
-                container.add(value.get());
-            } else {
-                final int size = value instanceof Traversable && ((Traversable) value).isTraversableAgain()
-                                 ? ((Traversable<V>) value).size()
-                                 : 0;
-                container = containerSupplier.apply(size);
-                value.forEach(container::add);
-            }
-        }
+    static <T extends java.util.Collection<V>, V>
+    T toJavaCollection(Value<V> value, Function<Integer, T> containerSupplier) {
+        final int size = (value instanceof Traversable) && ((Traversable) value).isTraversableAgain()
+                ? ((Traversable<V>) value).size()
+                : 16;
+        final T container = containerSupplier.apply(size);
+        value.forEach(container::add);
         return container;
     }
 }

--- a/javaslang/src/main/java/javaslang/collection/BitMappedTrie.java
+++ b/javaslang/src/main/java/javaslang/collection/BitMappedTrie.java
@@ -345,18 +345,6 @@ final class BitMappedTrie<T> implements Serializable {
         return index;
     }
 
-    Object[] toArray() {
-        final Object[] results = new Object[length];
-        visit((index, leaf, start, end) -> {
-            final int copied = end - start;
-            for (int i = start; i < end; i++) {
-                results[index + i] = type.getAt(leaf, i);
-            }
-            return index + copied;
-        });
-        return results;
-    }
-
     int length() { return length; }
 }
 

--- a/javaslang/src/main/java/javaslang/collection/BitMappedTrie.java
+++ b/javaslang/src/main/java/javaslang/collection/BitMappedTrie.java
@@ -345,6 +345,18 @@ final class BitMappedTrie<T> implements Serializable {
         return index;
     }
 
+    Object[] toArray() {
+        final Object[] results = new Object[length];
+        visit((index, leaf, start, end) -> {
+            final int copied = end - start;
+            for (int i = start; i < end; i++) {
+                results[index + i] = type.getAt(leaf, i);
+            }
+            return index + copied;
+        });
+        return results;
+    }
+
     int length() { return length; }
 }
 

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -109,7 +109,8 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     @SafeVarargs
     @SuppressWarnings("varargs")
     public static <T> Vector<T> of(T... elements) {
-        return ofAll(Iterator.of(elements));
+        Objects.requireNonNull(elements, "elements is null");
+        return ofAll(BitMappedTrie.ofAll(elements));
     }
 
     /**
@@ -979,8 +980,18 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
+    public Object[] toJavaArray() { return trie.toArray(); }
+
+    @Override
     public Vector<T> sorted() {
-        return isEmpty() ? this : toJavaStream().sorted().collect(collector());
+        if (isEmpty()) {
+            return this;
+        } else {
+            @SuppressWarnings("unchecked")
+            final T[] list = (T[]) toJavaArray();
+            Arrays.sort(list);
+            return Vector.of(list);
+        }
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -980,7 +980,9 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public Object[] toJavaArray() { return trie.toArray(); }
+    public Object[] toJavaArray() {
+        return trie.toArray();
+    }
 
     @Override
     public Vector<T> sorted() {

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -980,11 +980,6 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     }
 
     @Override
-    public Object[] toJavaArray() {
-        return trie.toArray();
-    }
-
-    @Override
     public Vector<T> sorted() {
         if (isEmpty()) {
             return this;

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@ Note: The maven build currently needs to be started from the javaslang root dir
         <assertj.core.version>3.6.1</assertj.core.version>
         <eclipse.lifecycle.mapping.version>1.0.0</eclipse.lifecycle.mapping.version>
         <java.version>1.8</java.version>
-        <jmh.version>1.17.3</jmh.version>
+        <jmh.version>1.17.4</jmh.version>
         <junit.version>4.12</junit.version>
         <gwt.version>2.8.0</gwt.version>
         <maven.build-helper.version>1.12</maven.build-helper.version>


### PR DESCRIPTION
```java
Operation Ratio                                      10      100     1026 
Sort      slang_persistent/java_mutable           0.86×    0.94×    1.16×
Sort      slang_persistent/scala_persistent       1.16×    1.09×    1.09×
Sort      slang_persistent/slang_persistent_old   1.53×    1.22×    1.11×
```
(not sure how it's faster than a mutable `ArrayList`, but it might be because of the extra comparator)

---

Updated the comparands, therefore I reran all `Vector` benchmarks:
Boxed `Integer`:
```java
Operation   Ratio                                                 10      100     1026 
Create      slang_persistent/java_mutable                      1.10×    0.83×    0.90×
Create      slang_persistent/java_mutable_boxed                4.60×    6.31×    8.56×
Create      slang_persistent/java_mutable_boxed_stream         8.93×    8.46×   11.11×
Create      slang_persistent/fjava_persistent                 68.28×  167.93×  206.75×
Create      slang_persistent/pcollections_persistent          29.70×  114.82×  243.27×
Create      slang_persistent/ecollections_persistent           2.74×    0.90×    0.91×
Create      slang_persistent/clojure_persistent                0.79×   13.23×   16.09×
Create      slang_persistent/scala_persistent                  6.75×    5.74×    5.43×

Head        slang_persistent/java_mutable                      0.77×    0.53×    0.41×
Head        slang_persistent/fjava_persistent                  0.75×    0.61×    0.47×
Head        slang_persistent/pcollections_persistent           1.75×    2.43×    2.81×
Head        slang_persistent/ecollections_persistent           0.63×    0.58×    0.44×
Head        slang_persistent/clojure_persistent                0.66×    0.87×    0.66×
Head        slang_persistent/scala_persistent                  0.77×    0.64×    0.48×

Tail        slang_persistent/java_mutable                      0.87×    0.49×    0.47×
Tail        slang_persistent/fjava_persistent                 32.54×   46.24×   39.62×
Tail        slang_persistent/pcollections_persistent           4.38×    6.00×    7.59×
Tail        slang_persistent/ecollections_persistent          19.75×   21.25×  137.34×
Tail        slang_persistent/clojure_persistent                0.90×    0.71×    0.58×
Tail        slang_persistent/scala_persistent                  2.62×    3.57×    4.26×

Get         slang_persistent/java_mutable                      0.78×    0.41×    0.26×
Get         slang_persistent/fjava_persistent                 28.04×   51.08×   62.64×
Get         slang_persistent/pcollections_persistent           4.86×    6.08×    8.99×
Get         slang_persistent/ecollections_persistent           1.31×    0.40×    0.21×
Get         slang_persistent/clojure_persistent                0.88×    1.51×    0.76×
Get         slang_persistent/scala_persistent                  1.10×    1.05×    0.72×

Update      slang_persistent/java_mutable                      0.20×    0.07×    0.04×
Update      slang_persistent/fjava_persistent                 67.14×  153.02×  189.66×
Update      slang_persistent/pcollections_persistent           1.73×    2.34×    3.07×
Update      slang_persistent/ecollections_persistent           4.98×   23.18×  120.24×
Update      slang_persistent/clojure_persistent                0.74×    1.41×    0.95×
Update      slang_persistent/scala_persistent                  1.16×    1.10×    0.78×

Map         slang_persistent/java_mutable                      2.17×    1.84×    2.26×
Map         slang_persistent/java_mutable_loop                 0.52×    0.41×    0.63×
Map         slang_persistent/ecollections_persistent           1.39×    0.73×    1.09×
Map         slang_persistent/scala_persistent                  1.35×    1.30×    1.43×

Filter      slang_persistent/java_mutable                      1.92×    1.59×    1.54×
Filter      slang_persistent/ecollections_persistent           0.98×    1.13×    1.06×
Filter      slang_persistent/scala_persistent                  1.22×    1.30×    1.46×

Prepend     slang_persistent/java_mutable                      0.17×    0.19×    0.38×
Prepend     slang_persistent/fjava_persistent                  0.58×    0.81×    0.82×
Prepend     slang_persistent/pcollections_persistent           0.32×    0.74×    1.31×
Prepend     slang_persistent/ecollections_persistent           0.61×    2.24×   14.25×
Prepend     slang_persistent/clojure_persistent                1.33×    7.05×   77.42×
Prepend     slang_persistent/scala_persistent                  0.13×    0.12×    0.12×

PrependAll  slang_persistent/scala_persistent                  1.77×    2.37×    2.94×

Append      slang_persistent/java_mutable                      0.08×    0.04×    0.03×
Append      slang_persistent/fjava_persistent                  1.16×    1.10×    0.98×
Append      slang_persistent/pcollections_persistent           0.51×    0.74×    1.09×
Append      slang_persistent/ecollections_persistent           0.94×    2.66×   15.25×
Append      slang_persistent/clojure_persistent                0.29×    0.17×    0.14×
Append      slang_persistent/scala_persistent                  0.25×    0.15×    0.13×

AppendAll   slang_persistent/scala_persistent                  4.04×    1.31×    1.78×

GroupBy     slang_persistent/java_mutable                      0.34×    0.52×    1.10×
GroupBy     slang_persistent/scala_persistent                  1.33×    0.98×    0.93×

Slice       slang_persistent/java_mutable                      0.62×    0.43×    0.46×
Slice       slang_persistent/pcollections_persistent           0.53×    0.38×    0.40×
Slice       slang_persistent/clojure_persistent                0.55×    0.40×    0.41×
Slice       slang_persistent/scala_persistent                  2.46×    2.96×    5.21×

Sort        slang_persistent/java_mutable                      0.91×    0.93×    1.16×
Sort        slang_persistent/scala_persistent                  1.21×    1.09×    1.09×

Iterate     slang_persistent/java_mutable                      0.78×    0.39×    0.26×
Iterate     slang_persistent/fjava_persistent                185.13×  315.68×  238.78×
Iterate     slang_persistent/pcollections_persistent          13.31×   10.68×    8.02×
Iterate     slang_persistent/ecollections_persistent           1.13×    1.53×    1.06×
Iterate     slang_persistent/clojure_persistent                0.94×    1.01×    0.63×
Iterate     slang_persistent/scala_persistent                  1.92×    1.16×    0.90×
```

Primitive `int`:
```java
Operation   Ratio                                                 10      100     1026 
Create      slang_persistent_int/java_mutable                  2.11×    1.29×    0.85×
Create      slang_persistent_int/java_mutable_boxed            8.78×    9.78×    8.12×
Create      slang_persistent_int/java_mutable_boxed_stream    17.05×   13.12×   10.55×
Create      slang_persistent_int/fjava_persistent            130.37×  260.38×  196.30×
Create      slang_persistent_int/pcollections_persistent      56.70×  178.03×  230.97×
Create      slang_persistent_int/ecollections_persistent       5.22×    1.39×    0.86×
Create      slang_persistent_int/clojure_persistent            1.51×   20.51×   15.28×
Create      slang_persistent_int/scala_persistent             12.90×    8.90×    5.15×

Tail        slang_persistent_int/java_mutable                  0.85×    0.43×    0.48×
Tail        slang_persistent_int/fjava_persistent             31.84×   40.53×   39.97×
Tail        slang_persistent_int/pcollections_persistent       4.28×    5.25×    7.66×
Tail        slang_persistent_int/ecollections_persistent      19.32×   18.63×  138.54×
Tail        slang_persistent_int/clojure_persistent            0.88×    0.62×    0.59×
Tail        slang_persistent_int/scala_persistent              2.57×    3.13×    4.30×

Update      slang_persistent_int/java_mutable                  0.21×    0.07×    0.04×
Update      slang_persistent_int/fjava_persistent             69.63×  157.22×  189.31×
Update      slang_persistent_int/pcollections_persistent       1.79×    2.41×    3.07×
Update      slang_persistent_int/ecollections_persistent       5.16×   23.81×  120.02×
Update      slang_persistent_int/clojure_persistent            0.77×    1.44×    0.95×
Update      slang_persistent_int/scala_persistent              1.20×    1.13×    0.78×

Map         slang_persistent_int/java_mutable                  1.83×    1.74×    1.84×
Map         slang_persistent_int/java_mutable_loop             0.44×    0.38×    0.51×
Map         slang_persistent_int/ecollections_persistent       1.17×    0.69×    0.89×
Map         slang_persistent_int/scala_persistent              1.13×    1.23×    1.16×

Filter      slang_persistent_int/java_mutable                  1.99×    2.30×    1.70×
Filter      slang_persistent_int/ecollections_persistent       1.02×    1.63×    1.17×
Filter      slang_persistent_int/scala_persistent              1.27×    1.88×    1.62×

Prepend     slang_persistent_int/java_mutable                  0.26×    0.27×    0.42×
Prepend     slang_persistent_int/fjava_persistent              0.85×    1.18×    0.90×
Prepend     slang_persistent_int/pcollections_persistent       0.47×    1.07×    1.45×
Prepend     slang_persistent_int/ecollections_persistent       0.90×    3.25×   15.70×
Prepend     slang_persistent_int/clojure_persistent            1.97×   10.25×   85.28×
Prepend     slang_persistent_int/scala_persistent              0.19×    0.18×    0.13×

Append      slang_persistent_int/java_mutable                  0.09×    0.06×    0.04×
Append      slang_persistent_int/fjava_persistent              1.32×    1.54×    1.07×
Append      slang_persistent_int/pcollections_persistent       0.59×    1.03×    1.19×
Append      slang_persistent_int/ecollections_persistent       1.07×    3.73×   16.54×
Append      slang_persistent_int/clojure_persistent            0.33×    0.24×    0.15×
Append      slang_persistent_int/scala_persistent              0.29×    0.21×    0.14×

Slice       slang_persistent_int/java_mutable                  0.60×    0.43×    0.47×
Slice       slang_persistent_int/pcollections_persistent       0.51×    0.38×    0.41×
Slice       slang_persistent_int/clojure_persistent            0.53×    0.40×    0.42×
Slice       slang_persistent_int/scala_persistent              2.38×    3.00×    5.26×

Iterate     slang_persistent_int/java_mutable                  1.01×    0.90×    0.78×
Iterate     slang_persistent_int/fjava_persistent            240.10×  726.62×  734.90×
Iterate     slang_persistent_int/pcollections_persistent      17.26×   24.59×   24.68×
Iterate     slang_persistent_int/ecollections_persistent       1.47×    3.53×    3.27×
Iterate     slang_persistent_int/clojure_persistent            1.22×    2.32×    1.95×
Iterate     slang_persistent_int/scala_persistent              2.49×    2.67×    2.77×
```