### PR TITLE
Simplified function memoization

### DIFF
--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction1.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction1.java
@@ -167,13 +167,9 @@ public interface CheckedFunction1<T1, R> extends λ<R> {
         if (isMemoized()) {
             return this;
         } else {
-            final Object lock = new Object();
-            final Map<T1, R> cache = new HashMap<>();
-            return (CheckedFunction1<T1, R> & Memoized) t1 -> {
-                synchronized (lock) {
-                    return cache.computeIfAbsent(t1, t -> Try.of(() -> this.apply(t)).get());
-                }
-            };
+            final Map<Tuple1<T1>, R> cache = new HashMap<>();
+            return (CheckedFunction1<T1, R> & Memoized) (t1)
+                    -> Memoized.of(cache, Tuple.of(t1), t -> Try.of(() -> apply(t1)).get());
         }
     }
 

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction2.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction2.java
@@ -175,14 +175,9 @@ public interface CheckedFunction2<T1, T2, R> extends λ<R> {
         if (isMemoized()) {
             return this;
         } else {
-            final Object lock = new Object();
             final Map<Tuple2<T1, T2>, R> cache = new HashMap<>();
-            final CheckedFunction1<Tuple2<T1, T2>, R> tupled = tupled();
-            return (CheckedFunction2<T1, T2, R> & Memoized) (t1, t2) -> {
-                synchronized (lock) {
-                    return cache.computeIfAbsent(Tuple.of(t1, t2), t -> Try.of(() -> tupled.apply(t)).get());
-                }
-            };
+            return (CheckedFunction2<T1, T2, R> & Memoized) (t1, t2)
+                    -> Memoized.of(cache, Tuple.of(t1, t2), t -> Try.of(() -> apply(t1, t2)).get());
         }
     }
 

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction3.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction3.java
@@ -192,14 +192,9 @@ public interface CheckedFunction3<T1, T2, T3, R> extends λ<R> {
         if (isMemoized()) {
             return this;
         } else {
-            final Object lock = new Object();
             final Map<Tuple3<T1, T2, T3>, R> cache = new HashMap<>();
-            final CheckedFunction1<Tuple3<T1, T2, T3>, R> tupled = tupled();
-            return (CheckedFunction3<T1, T2, T3, R> & Memoized) (t1, t2, t3) -> {
-                synchronized (lock) {
-                    return cache.computeIfAbsent(Tuple.of(t1, t2, t3), t -> Try.of(() -> tupled.apply(t)).get());
-                }
-            };
+            return (CheckedFunction3<T1, T2, T3, R> & Memoized) (t1, t2, t3)
+                    -> Memoized.of(cache, Tuple.of(t1, t2, t3), t -> Try.of(() -> apply(t1, t2, t3)).get());
         }
     }
 

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction4.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction4.java
@@ -211,14 +211,9 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends λ<R> {
         if (isMemoized()) {
             return this;
         } else {
-            final Object lock = new Object();
             final Map<Tuple4<T1, T2, T3, T4>, R> cache = new HashMap<>();
-            final CheckedFunction1<Tuple4<T1, T2, T3, T4>, R> tupled = tupled();
-            return (CheckedFunction4<T1, T2, T3, T4, R> & Memoized) (t1, t2, t3, t4) -> {
-                synchronized (lock) {
-                    return cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4), t -> Try.of(() -> tupled.apply(t)).get());
-                }
-            };
+            return (CheckedFunction4<T1, T2, T3, T4, R> & Memoized) (t1, t2, t3, t4)
+                    -> Memoized.of(cache, Tuple.of(t1, t2, t3, t4), t -> Try.of(() -> apply(t1, t2, t3, t4)).get());
         }
     }
 

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction5.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction5.java
@@ -231,14 +231,9 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends λ<R> {
         if (isMemoized()) {
             return this;
         } else {
-            final Object lock = new Object();
             final Map<Tuple5<T1, T2, T3, T4, T5>, R> cache = new HashMap<>();
-            final CheckedFunction1<Tuple5<T1, T2, T3, T4, T5>, R> tupled = tupled();
-            return (CheckedFunction5<T1, T2, T3, T4, T5, R> & Memoized) (t1, t2, t3, t4, t5) -> {
-                synchronized (lock) {
-                    return cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5), t -> Try.of(() -> tupled.apply(t)).get());
-                }
-            };
+            return (CheckedFunction5<T1, T2, T3, T4, T5, R> & Memoized) (t1, t2, t3, t4, t5)
+                    -> Memoized.of(cache, Tuple.of(t1, t2, t3, t4, t5), t -> Try.of(() -> apply(t1, t2, t3, t4, t5)).get());
         }
     }
 

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction6.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction6.java
@@ -252,14 +252,9 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
         if (isMemoized()) {
             return this;
         } else {
-            final Object lock = new Object();
             final Map<Tuple6<T1, T2, T3, T4, T5, T6>, R> cache = new HashMap<>();
-            final CheckedFunction1<Tuple6<T1, T2, T3, T4, T5, T6>, R> tupled = tupled();
-            return (CheckedFunction6<T1, T2, T3, T4, T5, T6, R> & Memoized) (t1, t2, t3, t4, t5, t6) -> {
-                synchronized (lock) {
-                    return cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5, t6), t -> Try.of(() -> tupled.apply(t)).get());
-                }
-            };
+            return (CheckedFunction6<T1, T2, T3, T4, T5, T6, R> & Memoized) (t1, t2, t3, t4, t5, t6)
+                    -> Memoized.of(cache, Tuple.of(t1, t2, t3, t4, t5, t6), t -> Try.of(() -> apply(t1, t2, t3, t4, t5, t6)).get());
         }
     }
 

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction7.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction7.java
@@ -274,14 +274,9 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
         if (isMemoized()) {
             return this;
         } else {
-            final Object lock = new Object();
             final Map<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> cache = new HashMap<>();
-            final CheckedFunction1<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> tupled = tupled();
-            return (CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> & Memoized) (t1, t2, t3, t4, t5, t6, t7) -> {
-                synchronized (lock) {
-                    return cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5, t6, t7), t -> Try.of(() -> tupled.apply(t)).get());
-                }
-            };
+            return (CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> & Memoized) (t1, t2, t3, t4, t5, t6, t7)
+                    -> Memoized.of(cache, Tuple.of(t1, t2, t3, t4, t5, t6, t7), t -> Try.of(() -> apply(t1, t2, t3, t4, t5, t6, t7)).get());
         }
     }
 

--- a/javaslang/src-gen/main/java/javaslang/CheckedFunction8.java
+++ b/javaslang/src-gen/main/java/javaslang/CheckedFunction8.java
@@ -297,14 +297,9 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<
         if (isMemoized()) {
             return this;
         } else {
-            final Object lock = new Object();
             final Map<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> cache = new HashMap<>();
-            final CheckedFunction1<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> tupled = tupled();
-            return (CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> & Memoized) (t1, t2, t3, t4, t5, t6, t7, t8) -> {
-                synchronized (lock) {
-                    return cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5, t6, t7, t8), t -> Try.of(() -> tupled.apply(t)).get());
-                }
-            };
+            return (CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> & Memoized) (t1, t2, t3, t4, t5, t6, t7, t8)
+                    -> Memoized.of(cache, Tuple.of(t1, t2, t3, t4, t5, t6, t7, t8), t -> Try.of(() -> apply(t1, t2, t3, t4, t5, t6, t7, t8)).get());
         }
     }
 

--- a/javaslang/src-gen/main/java/javaslang/Function1.java
+++ b/javaslang/src-gen/main/java/javaslang/Function1.java
@@ -167,13 +167,9 @@ public interface Function1<T1, R> extends λ<R>, Function<T1, R> {
         if (isMemoized()) {
             return this;
         } else {
-            final Object lock = new Object();
-            final Map<T1, R> cache = new HashMap<>();
-            return (Function1<T1, R> & Memoized) t1 -> {
-                synchronized (lock) {
-                    return cache.computeIfAbsent(t1, this);
-                }
-            };
+            final Map<Tuple1<T1>, R> cache = new HashMap<>();
+            return (Function1<T1, R> & Memoized) (t1)
+                    -> Memoized.of(cache, Tuple.of(t1), tupled());
         }
     }
 

--- a/javaslang/src-gen/main/java/javaslang/Function2.java
+++ b/javaslang/src-gen/main/java/javaslang/Function2.java
@@ -175,14 +175,9 @@ public interface Function2<T1, T2, R> extends λ<R>, BiFunction<T1, T2, R> {
         if (isMemoized()) {
             return this;
         } else {
-            final Object lock = new Object();
             final Map<Tuple2<T1, T2>, R> cache = new HashMap<>();
-            final Function1<Tuple2<T1, T2>, R> tupled = tupled();
-            return (Function2<T1, T2, R> & Memoized) (t1, t2) -> {
-                synchronized (lock) {
-                    return cache.computeIfAbsent(Tuple.of(t1, t2), tupled);
-                }
-            };
+            return (Function2<T1, T2, R> & Memoized) (t1, t2)
+                    -> Memoized.of(cache, Tuple.of(t1, t2), tupled());
         }
     }
 

--- a/javaslang/src-gen/main/java/javaslang/Function3.java
+++ b/javaslang/src-gen/main/java/javaslang/Function3.java
@@ -192,14 +192,9 @@ public interface Function3<T1, T2, T3, R> extends λ<R> {
         if (isMemoized()) {
             return this;
         } else {
-            final Object lock = new Object();
             final Map<Tuple3<T1, T2, T3>, R> cache = new HashMap<>();
-            final Function1<Tuple3<T1, T2, T3>, R> tupled = tupled();
-            return (Function3<T1, T2, T3, R> & Memoized) (t1, t2, t3) -> {
-                synchronized (lock) {
-                    return cache.computeIfAbsent(Tuple.of(t1, t2, t3), tupled);
-                }
-            };
+            return (Function3<T1, T2, T3, R> & Memoized) (t1, t2, t3)
+                    -> Memoized.of(cache, Tuple.of(t1, t2, t3), tupled());
         }
     }
 

--- a/javaslang/src-gen/main/java/javaslang/Function4.java
+++ b/javaslang/src-gen/main/java/javaslang/Function4.java
@@ -211,14 +211,9 @@ public interface Function4<T1, T2, T3, T4, R> extends λ<R> {
         if (isMemoized()) {
             return this;
         } else {
-            final Object lock = new Object();
             final Map<Tuple4<T1, T2, T3, T4>, R> cache = new HashMap<>();
-            final Function1<Tuple4<T1, T2, T3, T4>, R> tupled = tupled();
-            return (Function4<T1, T2, T3, T4, R> & Memoized) (t1, t2, t3, t4) -> {
-                synchronized (lock) {
-                    return cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4), tupled);
-                }
-            };
+            return (Function4<T1, T2, T3, T4, R> & Memoized) (t1, t2, t3, t4)
+                    -> Memoized.of(cache, Tuple.of(t1, t2, t3, t4), tupled());
         }
     }
 

--- a/javaslang/src-gen/main/java/javaslang/Function5.java
+++ b/javaslang/src-gen/main/java/javaslang/Function5.java
@@ -231,14 +231,9 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends λ<R> {
         if (isMemoized()) {
             return this;
         } else {
-            final Object lock = new Object();
             final Map<Tuple5<T1, T2, T3, T4, T5>, R> cache = new HashMap<>();
-            final Function1<Tuple5<T1, T2, T3, T4, T5>, R> tupled = tupled();
-            return (Function5<T1, T2, T3, T4, T5, R> & Memoized) (t1, t2, t3, t4, t5) -> {
-                synchronized (lock) {
-                    return cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5), tupled);
-                }
-            };
+            return (Function5<T1, T2, T3, T4, T5, R> & Memoized) (t1, t2, t3, t4, t5)
+                    -> Memoized.of(cache, Tuple.of(t1, t2, t3, t4, t5), tupled());
         }
     }
 

--- a/javaslang/src-gen/main/java/javaslang/Function6.java
+++ b/javaslang/src-gen/main/java/javaslang/Function6.java
@@ -252,14 +252,9 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
         if (isMemoized()) {
             return this;
         } else {
-            final Object lock = new Object();
             final Map<Tuple6<T1, T2, T3, T4, T5, T6>, R> cache = new HashMap<>();
-            final Function1<Tuple6<T1, T2, T3, T4, T5, T6>, R> tupled = tupled();
-            return (Function6<T1, T2, T3, T4, T5, T6, R> & Memoized) (t1, t2, t3, t4, t5, t6) -> {
-                synchronized (lock) {
-                    return cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5, t6), tupled);
-                }
-            };
+            return (Function6<T1, T2, T3, T4, T5, T6, R> & Memoized) (t1, t2, t3, t4, t5, t6)
+                    -> Memoized.of(cache, Tuple.of(t1, t2, t3, t4, t5, t6), tupled());
         }
     }
 

--- a/javaslang/src-gen/main/java/javaslang/Function7.java
+++ b/javaslang/src-gen/main/java/javaslang/Function7.java
@@ -274,14 +274,9 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
         if (isMemoized()) {
             return this;
         } else {
-            final Object lock = new Object();
             final Map<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> cache = new HashMap<>();
-            final Function1<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> tupled = tupled();
-            return (Function7<T1, T2, T3, T4, T5, T6, T7, R> & Memoized) (t1, t2, t3, t4, t5, t6, t7) -> {
-                synchronized (lock) {
-                    return cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5, t6, t7), tupled);
-                }
-            };
+            return (Function7<T1, T2, T3, T4, T5, T6, T7, R> & Memoized) (t1, t2, t3, t4, t5, t6, t7)
+                    -> Memoized.of(cache, Tuple.of(t1, t2, t3, t4, t5, t6, t7), tupled());
         }
     }
 

--- a/javaslang/src-gen/main/java/javaslang/Function8.java
+++ b/javaslang/src-gen/main/java/javaslang/Function8.java
@@ -297,14 +297,9 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<R> {
         if (isMemoized()) {
             return this;
         } else {
-            final Object lock = new Object();
             final Map<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> cache = new HashMap<>();
-            final Function1<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> tupled = tupled();
-            return (Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> & Memoized) (t1, t2, t3, t4, t5, t6, t7, t8) -> {
-                synchronized (lock) {
-                    return cache.computeIfAbsent(Tuple.of(t1, t2, t3, t4, t5, t6, t7, t8), tupled);
-                }
-            };
+            return (Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> & Memoized) (t1, t2, t3, t4, t5, t6, t7, t8)
+                    -> Memoized.of(cache, Tuple.of(t1, t2, t3, t4, t5, t6, t7, t8), tupled());
         }
     }
 

--- a/javaslang/src/main/java/javaslang/λ.java
+++ b/javaslang/src/main/java/javaslang/λ.java
@@ -6,6 +6,7 @@
 package javaslang;
 
 import java.io.Serializable;
+import java.util.Map;
 
 /**
  * This is a general definition of a (checked/unchecked) function of unknown parameters and a return type R.
@@ -74,5 +75,17 @@ public interface λ<R> extends Serializable {
      * Zero Abstract Method (ZAM) interface for marking functions as memoized using intersection types.
      */
     interface Memoized {
+        static <T extends Tuple, R> R of(Map<T, R> cache, T key, Function1<T, R> tupled) {
+            synchronized (cache) {
+                if (cache.containsKey(key)) {
+                    return cache.get(key);
+                } else {
+                    final R value = tupled.apply(key);
+                    cache.put(key, value);
+                    return value;
+                }
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Addresses https://github.com/javaslang/javaslang/issues/1762

* `null`s are avoided by always using a `Tuple` wrapper
* concurrent modifications are allowed now, work on Java 9 also.