### PR TITLE
CharSeq.repeat >10× speedup

### DIFF
--- a/javaslang-benchmark/src/test/java/javaslang/collection/CharSeqBenchmark.java
+++ b/javaslang-benchmark/src/test/java/javaslang/collection/CharSeqBenchmark.java
@@ -22,6 +22,7 @@ public class CharSeqBenchmark {
             Tail.class,
             Get.class,
             Update.class,
+            Repeat.class,
             Prepend.class,
             Append.class,
             Iterate.class
@@ -33,6 +34,7 @@ public class CharSeqBenchmark {
     }
 
     public static void main(java.lang.String... args) {
+        JmhRunner.runDebugWithAsserts(CLASSES);
         JmhRunner.runNormalNoAsserts(CLASSES);
     }
 
@@ -172,6 +174,15 @@ public class CharSeqBenchmark {
             }
             assert values.forAll(c -> c == replacement);
             return values;
+        }
+    }
+
+    public static class Repeat extends Base {
+        final char value = '❤';
+
+        @Benchmark
+        public Object slang_persistent() {
+            return CharSeq.of(value).repeat(CONTAINER_SIZE);
         }
     }
 

--- a/javaslang/src/main/java/javaslang/collection/CharSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/CharSeq.java
@@ -333,11 +333,20 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * @return A CharSeq representing {@code this * times}
      */
     public CharSeq repeat(int times) {
-        final StringBuilder builder = new StringBuilder();
-        for (int i = 0; i < times; i++) {
-            builder.append(back);
+        if (times <= 0) return empty();
+        else if (times == 1) return this;
+        else {
+            final int finalLength = length() * times;
+            final StringBuilder result = new StringBuilder(2 * finalLength);
+            result.append(back);
+
+            for (int i = 1; i <= times; i *= 2) {
+                result.append(result);
+            }
+            result.setLength(finalLength);
+
+            return of(result);
         }
-        return of(builder);
     }
 
     //

--- a/javaslang/src/main/java/javaslang/collection/CharSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/CharSeq.java
@@ -333,19 +333,20 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
      * @return A CharSeq representing {@code this * times}
      */
     public CharSeq repeat(int times) {
-        if (times <= 0) return empty();
+        if (times <= 0 || isEmpty()) return empty();
         else if (times == 1) return this;
         else {
             final int finalLength = length() * times;
-            final StringBuilder result = new StringBuilder(2 * finalLength);
-            result.append(back);
+            final char[] result = new char[finalLength];
+            back.getChars(0, length(), result, 0);
 
-            for (int i = 1; i <= times; i *= 2) {
-                result.append(result);
+            int i = length();
+            for (; i <= (finalLength >>> 1); i <<= 1) {
+                System.arraycopy(result, 0, result, i, i);
             }
-            result.setLength(finalLength);
+            System.arraycopy(result, 0, result, i, finalLength - i);
 
-            return of(result);
+            return of(new String(result));
         }
     }
 

--- a/javaslang/src/test/java/javaslang/collection/CharSeqTest.java
+++ b/javaslang/src/test/java/javaslang/collection/CharSeqTest.java
@@ -2840,6 +2840,7 @@ public class CharSeqTest {
         assertThat(empty().repeat(0)).isEqualTo(empty());
         assertThat(empty().repeat(5)).isEqualTo(empty());
         assertThat(of("123").repeat(0)).isEqualTo(empty());
+        assertThat(of("123").repeat(4)).isEqualTo(of("123123123123"));
         assertThat(of("123").repeat(5)).isEqualTo(of("123123123123123"));
         assertThat(repeat('1', 0)).isEqualTo(empty());
         assertThat(repeat('!', 5)).isEqualTo(of("!!!!!"));

--- a/javaslang/src/test/java/javaslang/collection/CharSeqTest.java
+++ b/javaslang/src/test/java/javaslang/collection/CharSeqTest.java
@@ -2845,6 +2845,23 @@ public class CharSeqTest {
         assertThat(repeat('!', 5)).isEqualTo(of("!!!!!"));
     }
 
+    @Test
+    public void shouldCompareRepeatAgainstTestImpl() {
+        final String value = ".";
+        for (int i = 0; i < 10; i++) {
+            final String source = testRepeat(value, i);
+            for (int j = 0; j < 100; j++) {
+                final String actual = CharSeq.of(source).repeat(j).mkString();
+                final String expected = testRepeat(source, j);
+                assertThat(actual).isEqualTo(expected);
+            }
+        }
+    }
+
+    private String testRepeat(String source, int times) {
+        return Stream.continually(source).take(times).mkString();
+    }
+
     // -- transform()
 
     @Test


### PR DESCRIPTION
original:
```java
Target            Operation   Impl                  Params  Count            Score  ±     Error    Unit  slang_persistent
CharSeqBenchmark  Repeat      slang_persistent          10      5     4,651,788.68  ±    23.81%   ops/s
CharSeqBenchmark  Repeat      slang_persistent         100      5       639,050.67  ±    20.89%   ops/s
CharSeqBenchmark  Repeat      slang_persistent        1000      5       115,828.61  ±     6.77%   ops/s
```
with doubling:
```java
Target            Operation   Impl                  Params  Count            Score  ±     Error    Unit  slang_persistent
CharSeqBenchmark  Repeat      slang_persistent          10      5    10,155,280.50  ±    12.97%   ops/s
CharSeqBenchmark  Repeat      slang_persistent         100      5     6,494,596.25  ±     4.02%   ops/s
CharSeqBenchmark  Repeat      slang_persistent        1000      5     1,204,059.76  ±     6.58%   ops/s
```
with `char[]` doubling:
```java
Target            Operation   Impl                  Params  Count            Score  ±     Error    Unit  slang_persistent
CharSeqBenchmark  Repeat      slang_persistent          10      5    13,406,385.45  ±     4.30%   ops/s                 
CharSeqBenchmark  Repeat      slang_persistent         100      5     9,117,266.10  ±     3.28%   ops/s                 
CharSeqBenchmark  Repeat      slang_persistent        1000      5     1,606,002.67  ±     4.93%   ops/s   
```