### PR TITLE
Set.add(existing) does nothing, Map.put(existing, any) overwrites

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/HashSet.java
+++ b/javaslang/src/main/java/javaslang/collection/HashSet.java
@@ -473,7 +473,7 @@ public final class HashSet<T> implements Kind1<HashSet<?>, T>, Set<T>, Serializa
 
     @Override
     public HashSet<T> add(T element) {
-        return new HashSet<>(tree.put(element, element));
+        return contains(element) ? this : new HashSet<>(tree.put(element, element));
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/LinkedHashSet.java
+++ b/javaslang/src/main/java/javaslang/collection/LinkedHashSet.java
@@ -477,7 +477,7 @@ public final class LinkedHashSet<T> implements Kind1<LinkedHashSet<?>, T>, Set<T
 
     @Override
     public LinkedHashSet<T> add(T element) {
-        return new LinkedHashSet<>(map.put(element, element));
+        return contains(element) ? this : new LinkedHashSet<>(map.put(element, element));
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/TreeSet.java
+++ b/javaslang/src/main/java/javaslang/collection/TreeSet.java
@@ -526,7 +526,7 @@ public final class TreeSet<T> implements Kind1<TreeSet<?>, T>, SortedSet<T>, Ser
 
     @Override
     public TreeSet<T> add(T element) {
-        return new TreeSet<>(tree.insert(element));
+        return contains(element) ? this : new TreeSet<>(tree.insert(element));
     }
 
     @Override

--- a/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractMapTest.java
@@ -661,6 +661,28 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
         assertThat(map.put(null, "!")).isEqualTo(mapOfNullKey(1, "a", null, "!", 2, "c"));
     }
 
+    @Test
+    public void shouldPutExistingKeyAndNonEqualValue() {
+        final Map<IntMod2, String> map = mapOf(new IntMod2(1), "a");
+
+        // we need to compare Strings because equals (intentionally) does not work for IntMod2
+        final String actual = map.put(new IntMod2(3), "b").toString();
+        final String expected = map.stringPrefix() + "((3, b))";
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldPutExistingKeyAndEqualValue() {
+        final Map<IntMod2, String> map = mapOf(new IntMod2(1), "a");
+
+        // we need to compare Strings because equals (intentionally) does not work for IntMod2
+        final String actual = map.put(new IntMod2(3), "a").toString();
+        final String expected = map.stringPrefix() + "((3, a))";
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
     // -- remove
 
     @Test

--- a/javaslang/src/test/java/javaslang/collection/AbstractSetTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractSetTest.java
@@ -91,6 +91,12 @@ public abstract class AbstractSetTest extends AbstractTraversableRangeTest {
         assertThat(emptyWithNull().add(1).add(null)).contains(null, 1);
     }
 
+    @Test
+    public void shouldNotAddAnExistingElementTwice() {
+        final Set<IntMod2> set = of(new IntMod2(2));
+        assertThat(set.add(new IntMod2(4))).isSameAs(set);
+    }
+
     // -- map
 
     @Test

--- a/javaslang/src/test/java/javaslang/collection/IntMod2.java
+++ b/javaslang/src/test/java/javaslang/collection/IntMod2.java
@@ -1,0 +1,47 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2017 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+/**
+ * An Int wrapper that implements equality by comparing int values modulo 2.
+ * <br>
+ * Examples:
+ * <ul>
+ * <li>IntMod2(0) equals IntMod2(2) equals IntMod2(4) ...</li>
+ * <li>IntMod2(1) equals IntMod2(3) equals IntMod2(5) ...</li>
+ * <li>IntMod2(0) &lt; IntMod2(1)</li>
+ * <li>IntMod2(_even_int_) &lt; IntMod2(_odd_int_)</li>
+ * </ul>
+ */
+final class IntMod2 implements Comparable<IntMod2> {
+
+    private final int val;
+
+    IntMod2(int val) {
+        this.val = val;
+    }
+
+    @Override
+    public int compareTo(IntMod2 that) {
+        return this.hashCode() - that.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        return that == this || (that instanceof IntMod2 && this.hashCode() == that.hashCode());
+    }
+
+    @Override
+    public int hashCode() {
+        return val % 2;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(val);
+    }
+
+}

--- a/javaslang/src/test/java/javaslang/collection/IntMod2Test.java
+++ b/javaslang/src/test/java/javaslang/collection/IntMod2Test.java
@@ -1,0 +1,38 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2017 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IntMod2Test {
+
+    private static final IntMod2 _1 = new IntMod2(1);
+    private static final IntMod2 _2 = new IntMod2(2);
+    private static final IntMod2 _3 = new IntMod2(3);
+    private static final IntMod2 _4 = new IntMod2(4);
+
+    @Test
+    public void shouldBeEqualIfEven() {
+        assertThat(_2.equals(_4)).isTrue();
+        assertThat(_2.compareTo(_4)).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldBeEqualIfOdd() {
+        assertThat(_1.equals(_3)).isTrue();
+        assertThat(_1.compareTo(_3)).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldNotBeEqualIfEvenAndOdd() {
+        assertThat(_1.equals(_2)).isFalse();
+        assertThat(_1.compareTo(_2)).isEqualTo(1);
+        assertThat(_2.compareTo(_3)).isEqualTo(-1);
+    }
+
+}

--- a/javaslang/src/test/java/javaslang/collection/LinkedHashMapTest.java
+++ b/javaslang/src/test/java/javaslang/collection/LinkedHashMapTest.java
@@ -172,6 +172,34 @@ public class LinkedHashMapTest extends AbstractMapTest {
         assertThat(keySet.mkString()).isEqualTo("412");
     }
 
+    // -- map
+
+    @Test
+    public void shouldReturnModifiedKeysMapWithNonUniqueMapperAndPredictableOrder() {
+        final Map<Integer, String> actual = LinkedHashMap.of(3, "3").put(1, "1").put(2, "2")
+                .mapKeys(Integer::toHexString).mapKeys(String::length);
+        final Map<Integer, String> expected = LinkedHashMap.of(1, "2");
+        assertThat(actual).isEqualTo(expected);
+    }
+    
+    // -- put
+
+    @Test
+    public void shouldAppendToTheEndWhenPuttingAnExistingKeyAndNonExistingValue() {
+        final Map<Integer, String> map = mapOf(1, "a", 2, "b", 3, "c");
+        final Map<Integer, String> actual = map.put(1, "d");
+        final Map<Integer, String> expected = mapOf(2, "b", 3, "c", 1, "d");
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldAppendToTheEndWhenPuttingAnExistingKeyAndExistingValue() {
+        final Map<Integer, String> map = mapOf(1, "a", 2, "b", 3, "c");
+        final Map<Integer, String> actual = map.put(1, "a");
+        final Map<Integer, String> expected = mapOf(2, "b", 3, "c", 1, "a");
+        assertThat(actual).isEqualTo(expected);
+    }
+
     // -- replace
 
     @Test
@@ -270,16 +298,6 @@ public class LinkedHashMapTest extends AbstractMapTest {
                 Tuple.of(7, "cdx"),
                 Tuple.of(4, "dx"),
                 Tuple.of(0, "x")));
-    }
-
-    // -- map
-
-    @Test
-    public void shouldReturnModifiedKeysMapWithNonUniqueMapperAndPredictableOrder() {
-        final Map<Integer, String> actual = LinkedHashMap.of(3, "3").put(1, "1").put(2, "2")
-                .mapKeys(Integer::toHexString).mapKeys(String::length);
-        final Map<Integer, String> expected = LinkedHashMap.of(1, "2");
-        assertThat(actual).isEqualTo(expected);
     }
 
 }


### PR DESCRIPTION
Ensures proper Set.add and Map.put behaviour. Fixes #1827 