### PR TITLE
Speeds up the Travis CI build by skipping the 'install' phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install --only-upgrade -y oracle-java8-installer
   - pip install --user codecov
+install: true
 script: .travis/run-tests.sh
 after_success:
   - codecov


### PR DESCRIPTION
See http://stackoverflow.com/questions/31945809/skip-first-mvn-install-in-travis-ci

Maybe this fixes also the problem of [stalling builds](https://travis-ci.org/javaslang/javaslang/builds/203272423)!?