### PR TITLE
Fixes Traversable.containsAll(Iterable).

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/Array.java
+++ b/javaslang/src/main/java/javaslang/collection/Array.java
@@ -593,7 +593,7 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
             return wrap(arr);
         }
     }
-
+    
     @Override
     public boolean hasDefiniteSize() {
         return true;

--- a/javaslang/src/main/java/javaslang/collection/Collections.java
+++ b/javaslang/src/main/java/javaslang/collection/Collections.java
@@ -10,10 +10,7 @@ import javaslang.control.Option;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
+import java.util.function.*;
 
 import static javaslang.collection.ArrayType.asArray;
 
@@ -297,6 +294,7 @@ final class Collections {
     static <T> IterableWithSize<T> withSize(Iterable<? extends T> iterable) {
         return isTraversableAgain(iterable) ? withSizeTraversable(iterable) : withSizeTraversable(List.ofAll(iterable));
     }
+    
     private static <T> IterableWithSize<T> withSizeTraversable(Iterable<? extends T> iterable) {
         if (iterable instanceof Collection) {
             return new IterableWithSize<>(iterable, ((Collection<?>) iterable).size());
@@ -306,6 +304,7 @@ final class Collections {
     }
 
     static <T, U extends Seq<T>, V extends Seq<U>> V transpose(V matrix, Function<Iterable<U>, V> rowFactory, Function<T[], U> columnFactory) {
+        Objects.requireNonNull(matrix, "matrix is null");
         if (matrix.isEmpty() || (matrix.length() == 1 && matrix.head().length() <= 1)) {
             return matrix;
         } else {

--- a/javaslang/src/main/java/javaslang/collection/Iterator.java
+++ b/javaslang/src/main/java/javaslang/collection/Iterator.java
@@ -1234,6 +1234,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
      * @throws NullPointerException if {@code f} is null
      */
     static <T, U> Iterator<U> unfoldLeft(T seed, Function<? super T, Option<Tuple2<? extends T, ? extends U>>> f) {
+        Objects.requireNonNull(f, "f is null");
         return Stream.<U> ofAll(
                 unfoldRight(seed, f.andThen(tupleOpt -> tupleOpt.map(t -> Tuple.of(t._2, t._1)))))
                 .reverse().iterator();

--- a/javaslang/src/main/java/javaslang/collection/List.java
+++ b/javaslang/src/main/java/javaslang/collection/List.java
@@ -573,6 +573,7 @@ public interface List<T> extends Kind1<List<?>, T>, LinearSeq<T>, Stack<T> {
     /**
      * Transposes the rows and columns of a {@link List} matrix.
      *
+     * @param <T> matrix element type
      * @param matrix to be transposed.
      * @return a transposed {@link List} matrix.
      * @throws IllegalArgumentException if the row lengths of {@code matrix} differ.

--- a/javaslang/src/main/java/javaslang/collection/Queue.java
+++ b/javaslang/src/main/java/javaslang/collection/Queue.java
@@ -479,6 +479,7 @@ public final class Queue<T> extends AbstractsQueue<T, Queue<T>> implements Linea
     /**
      * Transposes the rows and columns of a {@link Queue} matrix.
      *
+     * @param <T> matrix element type
      * @param matrix to be transposed.
      * @return a transposed {@link Queue} matrix.
      * @throws IllegalArgumentException if the row lengths of {@code matrix} differ.

--- a/javaslang/src/main/java/javaslang/collection/Stream.java
+++ b/javaslang/src/main/java/javaslang/collection/Stream.java
@@ -666,6 +666,7 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
     /**
      * Transposes the rows and columns of a {@link Stream} matrix.
      *
+     * @param <T> matrix element type
      * @param matrix to be transposed.
      * @return a transposed {@link Stream} matrix.
      * @throws IllegalArgumentException if the row lengths of {@code matrix} differ.
@@ -821,7 +822,7 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
         Objects.requireNonNull(mapper, "mapper is null");
         return isEmpty() ? this : new AppendSelf<>((Cons<T>) this, mapper).stream();
     }
-
+    
     @Override
     default Stream<Stream<T>> combinations() {
         return Stream.rangeClosed(0, length()).map(this::combinations).flatMap(Function.identity());

--- a/javaslang/src/main/java/javaslang/collection/Traversable.java
+++ b/javaslang/src/main/java/javaslang/collection/Traversable.java
@@ -226,8 +226,12 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      * @throws NullPointerException if {@code elements} is null
      */
     default boolean containsAll(Iterable<? extends T> elements) {
-        final HashSet<T> uniqueElements = HashSet.ofAll(elements);
-        return toSet().intersect(uniqueElements).size() == uniqueElements.size();
+        for (T element : elements) {
+            if (!contains(element)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -485,6 +485,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
     /**
      * Transposes the rows and columns of a {@link Vector} matrix.
      *
+     * @param <T> matrix element type
      * @param matrix to be transposed.
      * @return a transposed {@link Vector} matrix.
      * @throws IllegalArgumentException if the row lengths of {@code matrix} differ.
@@ -723,6 +724,7 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public Vector<T> insertAll(int index, Iterable<? extends T> elements) {
+        Objects.requireNonNull(elements, "elements is null");
         if ((index >= 0) && (index <= length())) {
             final Vector<T> begin = take(index).appendAll(elements);
             final Vector<T> end = drop(index);
@@ -1020,6 +1022,8 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
 
     @Override
     public <U> Vector<T> sortBy(Comparator<? super U> comparator, Function<? super T, ? extends U> mapper) {
+        Objects.requireNonNull(comparator, "comparator is null");
+        Objects.requireNonNull(mapper, "mapper is null");
         final Function<? super T, ? extends U> domain = Function1.of(mapper::apply).memoized();
         return toJavaStream()
                 .sorted((e1, e2) -> comparator.compare(domain.apply(e1), domain.apply(e2)))

--- a/javaslang/src/test/java/javaslang/TestComparators.java
+++ b/javaslang/src/test/java/javaslang/TestComparators.java
@@ -16,7 +16,7 @@ public final class TestComparators {
     }
 
     public static Comparator<Object> toStringComparator() {
-        return (Comparator<Object> & Serializable) comparing(String::valueOf);
+        return comparing(String::valueOf);
     }
 
 }


### PR DESCRIPTION
Adds more null-checks.
Fixes javadoc.