### PR TITLE
More efficient array creation by not zeroing it out

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/CharSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/CharSeq.java
@@ -3455,7 +3455,7 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
 
     @Override
     public Character[] toJavaArray() {
-        return toJavaList().toArray(new Character[size()]);
+        return toJavaList().toArray(new Character[0]);
     }
 
     // -- functional interfaces


### PR DESCRIPTION
@paplorinc [suggested](https://github.com/javaslang/javaslang/commit/d43944f3674635cac0f9a9b122118293a9856a7e#commitcomment-21225440) to use `new Character[0]` instead of new `Character[size()]`.

See also ["Arrays of Wisdom of the Ancients"](https://shipilev.net/blog/2016/arrays-wisdom-ancients).