### PR TITLE
add Traversable.arrangeBy

### DIFF
--- a/javaslang/src/main/java/javaslang/collection/Traversable.java
+++ b/javaslang/src/main/java/javaslang/collection/Traversable.java
@@ -447,6 +447,21 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
     <C> Map<C, ? extends Traversable<T>> groupBy(Function<? super T, ? extends C> classifier);
 
     /**
+     * Matches each element with a unique key that you extract from it.
+     * If the same key is present twice, the function will return {@code None}.
+     *
+     * @param classifier A function which extracts a key from elements
+     * @param <K>        key class type
+     * @return A Map containing the elements arranged by their keys.
+     * @throws NullPointerException if {@code getKey} is null.
+     */
+    default <K> Option<Map<K, T>> arrangeBy(Function<? super T, K> getKey) {
+        return Option.of(groupBy(getKey).mapValues(Traversable<T>::singleOption))
+            .filter(map -> !map.exists(kv -> kv._2.isEmpty()))
+            .map(map -> map.mapValues(Option::get));
+    }
+
+    /**
      * Groups this {@code Traversable} into fixed size blocks.
      * <p>
      * Let length be the length of this Iterable. Then grouped is defined as follows:

--- a/javaslang/src/main/java/javaslang/collection/Traversable.java
+++ b/javaslang/src/main/java/javaslang/collection/Traversable.java
@@ -443,6 +443,7 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      * @param <C>        classified class type
      * @return A Map containing the grouped elements
      * @throws NullPointerException if {@code classifier} is null.
+     * @see #arrangeBy(Function)
      */
     <C> Map<C, ? extends Traversable<T>> groupBy(Function<? super T, ? extends C> classifier);
 
@@ -454,11 +455,12 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      * @param <K>        key class type
      * @return A Map containing the elements arranged by their keys.
      * @throws NullPointerException if {@code getKey} is null.
+     * @see #groupBy(Function)
      */
-    default <K> Option<Map<K, T>> arrangeBy(Function<? super T, K> getKey) {
+    default <K> Option<Map<K, T>> arrangeBy(Function<? super T, ? extends K> getKey) {
         return Option.of(groupBy(getKey).mapValues(Traversable<T>::singleOption))
             .filter(map -> !map.exists(kv -> kv._2.isEmpty()))
-            .map(map -> map.mapValues(Option::get));
+            .map(map -> Map.narrow(map.mapValues(Option::get)));
     }
 
     /**

--- a/javaslang/src/test/java/javaslang/collection/AbstractTraversableTest.java
+++ b/javaslang/src/test/java/javaslang/collection/AbstractTraversableTest.java
@@ -474,7 +474,7 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         final Traversable<?> empty = empty();
         assertThat(empty.dropRight(1)).isSameAs(empty);
     }
-    
+
     // -- dropUntil
 
     @Test
@@ -731,6 +731,27 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    // -- arrangeBy
+
+    @Test
+    public void shouldNilArrangeBy() {
+        assertThat(empty().arrangeBy(Function.identity())).isEqualTo(Option.of(LinkedHashMap.empty()));
+    }
+
+    @Test
+    public void shouldNonNilArrangeByIdentity() {
+        final Option<Map<Character,Character>> actual = of('a', 'b', 'c').arrangeBy(Function.identity());
+        final Option<Map<?, ?>> expected = Option.of(LinkedHashMap.empty().put('a', 'a').put('b', 'b').put('c', 'c'));
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNonNilArrangeByEqual() {
+        final Option<Map<Integer, Character>> actual = of('a', 'b', 'c').arrangeBy(c -> 1);
+        final Option<Map<?, ?>> expected = Option.none();
+        assertThat(actual).isEqualTo(expected);
+    }
+
     // -- grouped
 
     @Test
@@ -768,7 +789,7 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         final List<Traversable<Integer>> expected = List.of(Vector.of(1, 2, 3, 4));
         assertThat(actual).isEqualTo(expected);
     }
-    
+
     // -- hasDefiniteSize
 
     @Test


### PR DESCRIPTION
i have a version of this arrangeBy function in my helpers for quite some time, and each time I think to myself that it's probably not generally useful enough to be PR-worthy, but today I used it once too many times.

I find it useful for instance if you have a list of customers and a list of products, and each customer has a productId, and you want to associate the customers with the products...

you could loop over the customers and for each customer loop over the products to find the right one, but that's exponential complexity. Better go through the products once, build a Map<ProductKey,Product> with something like arrangeBy... Then go through the customers and do a fast Map.get over your map.

The function returns Option because you may have several items in the traversable with the same key. If the programmer is sure that's not the case, he can use get().

The implementation is functional-style, I guess it could be optimized... Also, maybe we need to add some wildcard operators like `super` and `extends`... I did not master these yet.