### PR TITLE
Adds orElseOf methods to Option

### DIFF
--- a/javaslang/src/main/java/javaslang/control/Option.java
+++ b/javaslang/src/main/java/javaslang/control/Option.java
@@ -255,6 +255,28 @@ public interface Option<T> extends Value<T>, Serializable {
     }
 
     /**
+     * Returns this {@code Option} if it is nonempty, otherwise return option of the value.
+     *
+     * @param value A value
+     * @return this {@code Option} if it is nonempty, otherwise return option of the value.
+     */
+    default Option<T> orElseOf(T value)
+    {
+        return isEmpty() ? Option.of(value) : this;
+    }
+
+    /**
+     * Returns this {@code Option} if it is nonempty, otherwise return option of the result of evaluating supplier.
+     *
+     * @param supplier An alternative supplier
+     * @return this {@code Option} if it is nonempty, otherwise return option of the result of evaluating supplier.
+     */
+    default Option<T> orElseOf(Supplier<? extends T> supplier)
+    {
+        return isEmpty() ? Option.of(supplier.get()) : this;
+    }
+
+    /**
      * Returns the value if this is a {@code Some}, otherwise the {@code other} value is returned,
      * if this is a {@code None}.
      * <p>

--- a/javaslang/src/main/java/javaslang/control/Option.java
+++ b/javaslang/src/main/java/javaslang/control/Option.java
@@ -255,24 +255,22 @@ public interface Option<T> extends Value<T>, Serializable {
     }
 
     /**
-     * Returns this {@code Option} if it is nonempty, otherwise return option of the value.
+     * Returns this {@code Option} if it is nonempty, otherwise return {@code Option} of the value.
      *
      * @param value A value
-     * @return this {@code Option} if it is nonempty, otherwise return option of the value.
+     * @return this {@code Option} if it is nonempty, otherwise return {@code Option} of the value.
      */
-    default Option<T> orElseOf(T value)
-    {
+    default Option<T> orElseOf(T value) {
         return isEmpty() ? Option.of(value) : this;
     }
 
     /**
-     * Returns this {@code Option} if it is nonempty, otherwise return option of the result of evaluating supplier.
+     * Returns this {@code Option} if it is nonempty, otherwise return {@code Option} of the result of evaluating supplier.
      *
      * @param supplier An alternative supplier
-     * @return this {@code Option} if it is nonempty, otherwise return option of the result of evaluating supplier.
+     * @return this {@code Option} if it is nonempty, otherwise return {@code Option} of the result of evaluating supplier.
      */
-    default Option<T> orElseOf(Supplier<? extends T> supplier)
-    {
+    default Option<T> orElseOf(Supplier<? extends T> supplier) {
         return isEmpty() ? Option.of(supplier.get()) : this;
     }
 

--- a/javaslang/src/test/java/javaslang/control/OptionTest.java
+++ b/javaslang/src/test/java/javaslang/control/OptionTest.java
@@ -190,6 +190,30 @@ public class OptionTest extends AbstractValueTest {
         assertThat(Option.none().orElse(() -> opt)).isSameAs(opt);
     }
 
+    @Test
+    public void shouldReturnSelfOnOrElseOfIfValueIsPresent() {
+        final Option<Integer> opt = Option.of(42);
+        assertThat(opt.orElseOf(0)).isSameAs(opt);
+    }
+
+    @Test
+    public void shouldReturnSelfOnOrElseOfSupplierIfValueIsPresent() {
+        final Option<Integer> opt = Option.of(42);
+        assertThat(opt.orElseOf(() -> 0)).isSameAs(opt);
+    }
+
+    @Test
+    public void shouldReturnAlternativeValueOnOrElseOfValueIsNotDefined() {
+        final int value = 42;
+        assertThat(Option.none().orElseOf(value)).isEqualTo(Option.of(value));
+    }
+
+    @Test
+    public void shouldReturnAlternativeValueOnOrElseOfSupplierIfValueIsNotDefined() {
+        final int value = 42;
+        assertThat(Option.none().orElseOf(() -> value)).isEqualTo(Option.of(value));
+    }
+
     // -- getOrElse
 
     @Test


### PR DESCRIPTION
I've proposing to add new methods. They seems to be useful.
Example to use:

```java
Option<Object> someOption = makeSomeOption();
// than you can stack calls if option is missing

Option<Object> result = someOption.orElseOf(() -> getSomeOtherValue()).orElseOf("can't find a value");

// this code would be equivalent to:
Option<Object> result = someOption;
if (result.isEmpty()) 
{
  result = Option.of(getSomeOtherValue());
}
if (result.isEmpty())
{
  result = Option.of("can't find a value");
}
```